### PR TITLE
Add a Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,31 @@
+FROM node:alpine AS build
+RUN apk add --no-cache g++ gcc bash make unbound-dev python2
+RUN mkdir /hsd
+WORKDIR /hsd
+COPY package.json .
+ARG NODE_ENV=production
+RUN npm install
+
+
+
+FROM node:alpine
+WORKDIR /home/hsd
+
+#Set up non-root user to run as
+RUN adduser -S hsd
+USER hsd
+RUN mkdir -p /home/hsd/.hsd
+
+#Install the required binaries and libs 
+COPY bin/ /home/hsd/bin
+COPY lib/ /home/hsd/lib
+
+#Copy the installed version from build image
+COPY --from=build /hsd /home/hsd
+
+ENV PATH="${PATH}:/home/hsd/bin:/home/hsd/node_modules/.bin"
+
+EXPOSE 13037 13038 13039 15349 15350 5300
+VOLUME /home/hsd/.hsd
+CMD ["hsd"]
+HEALTHCHECK --interval=30s --timeout=30s --start-period=5s --retries=3 CMD [ "hsd info >/dev/null" ]

--- a/bin/hsd
+++ b/bin/hsd
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 rl=0
 daemon=0

--- a/bin/hsw
+++ b/bin/hsw
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 rl=0
 daemon=0


### PR DESCRIPTION
I noticed there are several other Dockerfile pull requests, but they seem to be missing some things.

Most noticably, this one includes EXPOSE so users know which ports we use by default, VOLUME to make it easier to persist the blockchain, and HEALTHCHECK to leverage the existing CLI tool you wrote to ensure hsd is running and responding.

Additionally, I replaced the bash shebang on the cmd/ scripts with sh, since there were no bashisms used and sh works fine. Minimal distros often ship without bash, so this helps run there.  If you plan to expand these scripts to use bash specific features I could modify the Dockerfile to include bash instead, but they seem fine.
