### PR TITLE
node/rpc: minor syntax error fix

### DIFF
--- a/lib/node/rpc.js
+++ b/lib/node/rpc.js
@@ -2284,7 +2284,7 @@ class RPC extends RPCBase {
     const txn = this.chain.db.txn;
     const items = [];
 
-    for await (const [key, value] of txn) {
+    for (const [key, value] of txn) {
       const ns = NameState.decode(value);
       ns.nameHash = key;
 


### PR DESCRIPTION
I've dug around a bit and came to a realization that the reason for this Syntax Error is simply due to the fact that the for await iterable isn't considered valid syntax in versions of nodejs under 9.2.

Disregard this PR.

The ideal thing to do is bump the nodejs package versions to 9.2+


