### PR TITLE
pkg: upgraded node version

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "wallet"
   ],
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "dependencies": {
     "bcfg": "~0.1.2",


### PR DESCRIPTION
Prior, I had been running nodev9.1.1 the standard package version for Pacman in arch-linux.

I ran into the same issue as #36 

I've dug around a bit and came to a realization that the reason for this Syntax Error is simply due to the fact that the for await iterable isn't considered valid syntax in versions of nodejs under 9.2.

Therefore I upgraded node to v10.0.0. In reality v9.2.0 should do but it's pretty trivial to keep it at that version and decided to update to v10.0.0 so that the issue doesn't occur to anyone else. 

