### PR TITLE
rpc: fix breaking node.js v8 compatibity

### DIFF
--- a/lib/node/rpc.js
+++ b/lib/node/rpc.js
@@ -2284,11 +2284,11 @@ class RPC extends RPCBase {
     const txn = this.chain.db.txn;
     const items = [];
 
-    for await (const [key, value] of txn) {
+    for (const [key, value] of txn) {
       const ns = NameState.decode(value);
       ns.nameHash = key;
 
-      const info = ns.getJSON(height, network);
+      const info = await ns.getJSON(height, network);
       items.push(info);
     }
 


### PR DESCRIPTION
Fix the only instance of an invalid syntax
while maintaining the required functionality
and compatibility with at least node.js runtime
version 8.x as mentioned by the package.json's
node engine requirements