### PR TITLE
lib/node: use an address object in the coin address endpoint [bugfix]

### DIFF
--- a/lib/node/http.js
+++ b/lib/node/http.js
@@ -18,6 +18,7 @@ const ccmp = require('bcrypto/lib/ccmp');
 const util = require('../utils/util');
 const TX = require('../primitives/tx');
 const Claim = require('../primitives/claim');
+const Address = require('../primitives/address')
 const Network = require('../protocol/network');
 const pkg = require('../pkg');
 
@@ -150,11 +151,12 @@ class HTTP extends Server {
     // UTXO by address
     this.get('/coin/address/:address', async (req, res) => {
       const valid = Validator.fromRequest(req);
-      const address = valid.str('address');
+      const addressString = valid.str('address');
 
-      enforce(address, 'Address is required.');
+      enforce(addressString, 'Address is required.');
       enforce(!this.chain.options.spv, 'Cannot get coins in SPV mode.');
 
+      const address = new Address(addressString);
       const coins = await this.node.getCoinsByAddress(address);
       const result = [];
 


### PR DESCRIPTION
The coin address endpoint at `./lib/node/http.js` passes an address string to `this.node.getCoinsByAddress(*)`, which eventually passes that same address to the mempool's `getCoinsByAddress(*)`. Attempting to query an address from the CLI or from CURL via `hsd-cli coin $ADDRESS` results in the error message `object is not an address`.

This PR creates an `Address` object after receiving the address string to fix this issue.