### PR TITLE
fix: address type in http api /coin/address and /tx/address

### DIFF
--- a/lib/node/http.js
+++ b/lib/node/http.js
@@ -18,6 +18,7 @@ const ccmp = require('bcrypto/lib/ccmp');
 const util = require('../utils/util');
 const TX = require('../primitives/tx');
 const Claim = require('../primitives/claim');
+const Address = require('../primitives/address');
 const Network = require('../protocol/network');
 const pkg = require('../pkg');
 
@@ -150,11 +151,12 @@ class HTTP extends Server {
     // UTXO by address
     this.get('/coin/address/:address', async (req, res) => {
       const valid = Validator.fromRequest(req);
-      const address = valid.str('address');
+      const addressString = valid.str('address');
 
-      enforce(address, 'Address is required.');
+      enforce(addressString, 'Address is required.');
       enforce(!this.chain.options.spv, 'Cannot get coins in SPV mode.');
 
+      const address = Address.fromString(addressString);
       const coins = await this.node.getCoinsByAddress(address);
       const result = [];
 
@@ -187,12 +189,16 @@ class HTTP extends Server {
     // Bulk read UTXOs
     this.post('/coin/address', async (req, res) => {
       const valid = Validator.fromRequest(req);
-      const address = valid.array('addresses');
+      const addressStrings = valid.array('addresses');
 
-      enforce(address, 'Address is required.');
+      enforce(addressStrings, 'Addresses is required.');
+      addressStrings.forEach(addrString => {
+        enforce(typeof addrString === 'string', 'Address should be string.');
+      });
       enforce(!this.chain.options.spv, 'Cannot get coins in SPV mode.');
 
-      const coins = await this.node.getCoinsByAddress(address);
+      const addresses = addressStrings.map(addrString => Address.fromString(addrString));
+      const coins = await this.node.getCoinsByAddress(addresses);
       const result = [];
 
       for (const coin of coins)
@@ -224,11 +230,12 @@ class HTTP extends Server {
     // TX by address
     this.get('/tx/address/:address', async (req, res) => {
       const valid = Validator.fromRequest(req);
-      const address = valid.str('address');
+      const addressString = valid.str('address');
 
-      enforce(address, 'Address is required.');
+      enforce(addressString, 'Address is required.');
       enforce(!this.chain.options.spv, 'Cannot get TX in SPV mode.');
 
+      const address = Address.fromString(addressString);
       const metas = await this.node.getMetaByAddress(address);
       const result = [];
 
@@ -243,12 +250,16 @@ class HTTP extends Server {
     // Bulk read TXs
     this.post('/tx/address', async (req, res) => {
       const valid = Validator.fromRequest(req);
-      const address = valid.array('addresses');
+      const addressStrings = valid.array('addresses');
 
-      enforce(address, 'Address is required.');
+      enforce(addressStrings, 'Addresses is required.');
+      addressStrings.forEach(addrString => {
+        enforce(typeof addrString === 'string', 'Address should be string.');
+      });
       enforce(!this.chain.options.spv, 'Cannot get TX in SPV mode.');
 
-      const metas = await this.node.getMetaByAddress(address);
+      const addresses = addressStrings.map(addrString => Address.fromString(addrString));
+      const metas = await this.node.getMetaByAddress(addresses);
       const result = [];
 
       for (const meta of metas) {


### PR DESCRIPTION
For /coin/address and /tx/address, they receive address strings, but doesn't convert those address strings to address object, so when we request these apis, it will return errors with message 'Object is not address'. This PR is try to fix this.