### PR TITLE
txdb: account for REGISTER in locked balances

### DIFF
--- a/lib/wallet/txdb.js
+++ b/lib/wallet/txdb.js
@@ -1664,6 +1664,26 @@ class TXDB {
           state.clocked(path, -output.value);
         break;
       }
+
+      case types.REGISTER: {
+        assert(i < tx.inputs.length);
+
+        const nameHash = covenant.getHash(0);
+        const prevout = tx.inputs[i].prevout;
+
+        const brv = await this.getReveal(nameHash, prevout);
+        assert(brv);
+
+        if (height === -1) {
+          state.ulocked(path, -brv.value);
+          state.ulocked(path, output.value);
+        } else {
+          state.clocked(path, -brv.value);
+          state.clocked(path, output.value);
+        }
+
+        break;
+      }
     }
   }
 
@@ -1716,6 +1736,26 @@ class TXDB {
           state.ulocked(path, output.value);
         else
           state.clocked(path, output.value);
+        break;
+      }
+
+      case types.REGISTER: {
+        assert(i < tx.inputs.length);
+
+        const nameHash = covenant.getHash(0);
+        const prevout = tx.inputs[i].prevout;
+
+        const brv = await this.getReveal(nameHash, prevout);
+        assert(brv);
+
+        if (height === -1) {
+          state.ulocked(path, brv.value);
+          state.ulocked(path, -output.value);
+        } else {
+          state.clocked(path, brv.value);
+          state.clocked(path, -output.value);
+        }
+
         break;
       }
     }


### PR DESCRIPTION
Previously, locked balances did not update once a name was registered.
This commit decrements the locked balance by the winner's bid, then
increments the locked balance by the value of the second highest bid.

Fixes #62. 