### PR TITLE
http: include warning of deprecation for bulk reads

### DIFF
--- a/lib/node/http.js
+++ b/lib/node/http.js
@@ -187,12 +187,20 @@ class HTTP extends Server {
     });
 
     // Bulk read UTXOs
+    // TODO(boymanjor): Deprecate this endpoint
+    // once the equivalent functionality is included
+    // in the wallet API.
     this.post('/coin/address', async (req, res) => {
       const valid = Validator.fromRequest(req);
       const addresses = valid.array('addresses');
 
       enforce(addresses, 'Addresses is required.');
       enforce(!this.chain.options.spv, 'Cannot get coins in SPV mode.');
+
+      this.logger.warning('%s %s %s',
+        'Warning: endpoint being considered for deprecation.',
+        'Known to cause CPU exhaustion if too many addresses',
+        'are queried or too many results are found.');
 
       const addrs = [];
       for (const address of addresses) {
@@ -249,12 +257,20 @@ class HTTP extends Server {
     });
 
     // Bulk read TXs
+    // TODO(boymanjor): Deprecate this endpoint
+    // once the equivalent functionality is included
+    // in the wallet API.
     this.post('/tx/address', async (req, res) => {
       const valid = Validator.fromRequest(req);
       const addresses = valid.array('addresses');
 
       enforce(addresses, 'Addresses is required.');
       enforce(!this.chain.options.spv, 'Cannot get TX in SPV mode.');
+
+      this.logger.warning('%s %s %s',
+        'Warning: endpoint being considered for deprecation.',
+        'Known to cause CPU exhaustion if too many addresses',
+        'are queried or too many results are found.');
 
       const addrs = [];
       for (const address of addresses) {


### PR DESCRIPTION
Across all implementations, we have decided to explore deprecating
the bulk read endpoints for coins/txs by address. See the discussion
here: https://github.com/bcoin-org/bcoin/pull/612 and here: https://github.com/bcoin-org/bcoin/issues/589.