### PR TITLE
remove names and tld from npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -7,5 +7,3 @@ node_modules/
 browser/hsd*
 package-lock.json
 npm-debug.log
-lib/covenants/names.json
-lib/dns/tld.json


### PR DESCRIPTION
fix from @boymanjor 's bundle branch based off use with bpanel. Fixes error where bundling would fail when hsd is installed as a module because it can't find the ignored jsons.