### PR TITLE
update toMilli exponent to 3

### DIFF
--- a/lib/ui/amount.js
+++ b/lib/ui/amount.js
@@ -90,7 +90,7 @@ class Amount {
    */
 
   toMilli(num) {
-    return Amount.encode(this.value, 5, num);
+    return Amount.encode(this.value, 3, num);
   }
 
   /**
@@ -180,7 +180,7 @@ class Amount {
    */
 
   fromMilli(value) {
-    this.value = Amount.decode(value, 5);
+    this.value = Amount.decode(value, 3);
     return this;
   }
 

--- a/lib/ui/amount.js
+++ b/lib/ui/amount.js
@@ -90,7 +90,7 @@ class Amount {
    */
 
   toMilli(num) {
-    return Amount.encode(this.value, 4, num);
+    return Amount.encode(this.value, 5, num);
   }
 
   /**


### PR DESCRIPTION
The exponents for `toMilli` and `fromMilli` didn't match. Following bcoin's `Amount.toMBTC` ([here](https://github.com/bcoin-org/bcoin/blob/85ed59c842f2aa4c1a8154d74a9cad7696cdfee3/lib/btc/amount.js#L90)), `toMilli` should encode the amount with exponent `5` instead of `4`.