### PR TITLE
add missing bw

### DIFF
--- a/lib/dns/records.js
+++ b/lib/dns/records.js
@@ -1044,7 +1044,7 @@ class Addr extends Struct {
     }
 
     bw.writeU8(0);
-    writeNameBW(this.currency, c.labels);
+    writeNameBW(bw, this.currency, c.labels);
     bw.writeU8(this.address.length);
     bw.writeString(this.address, 'ascii');
 


### PR DESCRIPTION
Right now if an Addr record is added without a whitelisted name (handshake, bitcoin, ethereum) then we get an assertion error as bw is not passed into writeNameBW. This just adds it back in.