### PR TITLE
Fix type assertion in PGP.fromJSON

### DIFF
--- a/lib/dns/records.js
+++ b/lib/dns/records.js
@@ -960,7 +960,7 @@ class PGP extends Struct {
   }
 
   fromJSON(json) {
-    assert(typeof json === 'string');
+    assert(typeof json === 'object');
     assert(typeof json.hash === 'string');
     assert((json.hash.length >>> 1) === 28);
     this.hash = util.parseHex(json.hash);


### PR DESCRIPTION
`PGP.fromJSON` should expect a json object. Since the following line is looking for a `json.hash` value, the only other way for this to work with the current code is to change the prototype of `String`