### PR TITLE
Add mirror RPC methods to generate transactions

### DIFF
--- a/lib/mempool/mempool.js
+++ b/lib/mempool/mempool.js
@@ -273,7 +273,7 @@ class Mempool extends EventEmitter {
       if (!entry)
         continue;
 
-      this.evictEntry(hash);
+      this.evictEntry(entry);
     }
 
     // Invalidate expired claims.

--- a/lib/net/pool.js
+++ b/lib/net/pool.js
@@ -1638,7 +1638,7 @@ class Pool extends EventEmitter {
         case invTypes.CLAIM:
           claims.push(item.hash);
           break;
-        case invTypes.PROOF:
+        case invTypes.AIRDROP:
           proofs.push(item.hash);
           break;
         default:

--- a/lib/net/pool.js
+++ b/lib/net/pool.js
@@ -1668,7 +1668,7 @@ class Pool extends EventEmitter {
       await this.handleClaimInv(peer, claims);
 
     if (proofs.length > 0)
-      await this.handleProofInv(peer, proofs);
+      await this.handleAirdropInv(peer, proofs);
   }
 
   /**

--- a/lib/primitives/mtx.js
+++ b/lib/primitives/mtx.js
@@ -1361,6 +1361,7 @@ class MTX extends TX {
       coin.index = prevout.index;
 
       this.view.addCoin(coin);
+      this.inputs[i].coin = coin;
     }
 
     return this;

--- a/lib/primitives/mtx.js
+++ b/lib/primitives/mtx.js
@@ -1300,7 +1300,12 @@ class MTX extends TX {
    */
 
   format() {
-    return super.format(this.view);
+    const mtx = super.format(this.view);
+
+    if (this.paths)
+      mtx.paths = this.paths;
+
+    return mtx;
   }
 
   /**
@@ -1309,7 +1314,12 @@ class MTX extends TX {
    */
 
   toJSON() {
-    return super.getJSON(null, this.view);
+    const json = super.getJSON(null, this.view);
+
+    if (this.paths)
+      json.paths = this.paths;
+
+    return json;
   }
 
   /**
@@ -1319,7 +1329,12 @@ class MTX extends TX {
    */
 
   getJSON(network) {
-    return super.getJSON(network, this.view);
+    const json = super.getJSON(network, this.view);
+
+    if (this.paths)
+      json.paths = this.paths;
+
+    return json;
   }
 
   /**
@@ -1329,6 +1344,9 @@ class MTX extends TX {
 
   fromJSON(json) {
     super.fromJSON(json);
+
+    if (json.paths)
+      this.paths = json.paths;
 
     for (let i = 0; i < json.inputs.length; i++) {
       const input = json.inputs[i];

--- a/lib/primitives/outpoint.js
+++ b/lib/primitives/outpoint.js
@@ -9,6 +9,7 @@
 const assert = require('bsert');
 const bio = require('bufio');
 const consensus = require('../protocol/consensus');
+const util = require('../utils/util');
 
 /**
  * Outpoint
@@ -189,9 +190,9 @@ class Outpoint extends bio.Struct {
 
   fromJSON(json) {
     assert(json, 'Outpoint data is required.');
-    assert(Buffer.isBuffer(json.hash));
+    assert(json.hash, 'Hash is required.');
     assert((json.index >>> 0) === json.index, 'Index must be a uint32.');
-    this.hash = json.hash;
+    this.hash = util.parseHex(json.hash, 32);
     this.index = json.index;
     return this;
   }

--- a/lib/wallet/layout.js
+++ b/lib/wallet/layout.js
@@ -16,7 +16,7 @@ const bdb = require('bdb');
  *  D -> wallet id depth
  *  p[addr-hash] -> wallet ids
  *  P[wid][addr-hash] -> path data
- *  r[wid][index][hash] -> path account index
+ *  r[wid][index][hash] -> dummy
  *  w[wid] -> wallet
  *  W[wid] -> wallet id
  *  l[id] -> wid

--- a/lib/wallet/rpc.js
+++ b/lib/wallet/rpc.js
@@ -1447,7 +1447,7 @@ class RPC extends RPCBase {
     return mtx.getJSON(this.network);
   }
 
-  async _validateSendToAddress(args, help, method) {
+  _validateSendToAddress(args, help, method) {
     if (help || args.length < 2 || args.length > 5) {
       throw new RPCError(errs.MISC_ERROR,
         `${method} "address" amount`

--- a/lib/wallet/rpc.js
+++ b/lib/wallet/rpc.js
@@ -1413,14 +1413,14 @@ class RPC extends RPCBase {
   }
 
   async sendToAddress(args, help) {
-    const {addr, value, subtract} = this._validateSendToAddress(args, help, 'sendtoaddress');
+    const opts = this._validateSendToAddress(args, help, 'sendtoaddress');
     const wallet = this.wallet;
 
     const options = {
-      subtractFee: subtract,
+      subtractFee: opts.subtract,
       outputs: [{
-        address: addr,
-        value: value
+        address: opts.addr,
+        value: opts.value
       }]
     };
 
@@ -1919,55 +1919,71 @@ class RPC extends RPCBase {
   }
 
   async sendOpen(args, help) {
-    const { name, force } = this._validateOpen(args, help, 'sendopen');
+    const opts = this._validateOpen(args, help, 'sendopen');
     const wallet = this.wallet;
-    const tx = await wallet.sendOpen(name, force);
+    const tx = await wallet.sendOpen(opts.name, opts.force, {
+      account: opts.account
+    });
+
     return tx.getJSON(this.network);
   }
 
   async createOpen(args, help) {
-    const { name, force } = this._validateOpen(args, help, 'createopen');
+    const opts = this._validateOpen(args, help, 'createopen');
     const wallet = this.wallet;
-    const mtx = await wallet.createOpen(name, force, { paths: true });
+    const mtx = await wallet.createOpen(opts.name, opts.force, {
+      paths: true,
+      account: opts.account
+    });
+
     return mtx.getJSON(this.network);
   }
 
   _validateOpen(args, help, method) {
     if (help || args.length < 1 || args.length > 2)
-      throw new RPCError(errs.MISC_ERROR, `${method} "name" ( force )`);
+      throw new RPCError(errs.MISC_ERROR, `${method} "name" ( force "account" )`);
 
     const valid = new Validator(args);
     const name = valid.str(0);
     const force = valid.bool(1, false);
+    const account = valid.str(2);
 
     if (!name || !rules.verifyName(name))
       throw new RPCError(errs.TYPE_ERROR, 'Invalid name.');
 
-    return {name, force};
+    return {name, force, account};
   }
 
   async sendBid(args, help) {
-    const {name, bid, value} = this._validateBid(args, help, 'sendbid');
+    const opts = this._validateBid(args, help, 'sendbid');
     const wallet = this.wallet;
-    const tx = await wallet.sendBid(name, bid, value);
+    const tx = await wallet.sendBid(opts.name, opts.bid, opts.value, {
+      account: opts.account
+    });
+
     return tx.getJSON(this.network);
   }
 
   async createBid(args, help) {
-    const {name, bid, value} = this._validateBid(args, help, 'createbid');
+    const opts = this._validateBid(args, help, 'createbid');
     const wallet = this.wallet;
-    const mtx = await wallet.createBid(name, bid, value, { paths: true });
+    const mtx = await wallet.createBid(opts.name, opts.bid, opts.value, {
+      paths: true,
+      account: opts.account
+    });
+
     return mtx.getJSON(this.network);
   }
 
   _validateBid(args, help, method) {
     if (help || args.length !== 3)
-      throw new RPCError(errs.MISC_ERROR, `${method} "name" bid value`);
+      throw new RPCError(errs.MISC_ERROR, `${method} "name" bid value ( "account" )`);
 
     const valid = new Validator(args);
     const name = valid.str(0);
     const bid = valid.ufixed(1, EXP);
     const value = valid.ufixed(2, EXP);
+    const account = valid.str(3);
 
     if (!name || !rules.verifyName(name))
       throw new RPCError(errs.TYPE_ERROR, 'Invalid name.');
@@ -1981,119 +1997,145 @@ class RPC extends RPCBase {
     return {
       name,
       bid,
-      value
+      value,
+      account
     };
   }
 
   async sendReveal(args, help) {
-    const { name } = this._validateReveal(args, help, 'sendreveal');
+    const opts = this._validateReveal(args, help, 'sendreveal');
     const wallet = this.wallet;
 
-    if (!name) {
+    if (!opts.name) {
       const tx = await wallet.sendRevealAll();
       return tx.getJSON(this.network);
     }
 
-    if (!rules.verifyName(name))
+    if (!rules.verifyName(opts.name))
       throw new RPCError(errs.TYPE_ERROR, 'Invalid name.');
 
-    const tx = await wallet.sendReveal(name);
+    const tx = await wallet.sendReveal(opts.name, { account: opts.account });
 
     return tx.getJSON(this.network);
   }
 
   async createReveal(args, help) {
-    const { name } = this._validateReveal(args, help, 'createreveal');
+    const opts = this._validateReveal(args, help, 'createreveal');
     const wallet = this.wallet;
 
-    if (!name) {
-      const mtx = await wallet.createRevealAll({ paths: true });
+    if (!opts.name) {
+      const mtx = await wallet.createRevealAll({
+        paths: true,
+        account: opts.account
+      });
+
       return mtx.getJSON(this.network);
     }
 
-    if (!rules.verifyName(name))
+    if (!rules.verifyName(opts.name))
       throw new RPCError(errs.TYPE_ERROR, 'Invalid name.');
 
-    const mtx = await wallet.createReveal(name, { paths: true });
+    const mtx = await wallet.createReveal(opts.name, {
+      paths: true,
+      account: opts.account
+    });
 
     return mtx.getJSON(this.network);
   }
 
   _validateReveal(args, help, method) {
     if (help || args.length > 1)
-      throw new RPCError(errs.MISC_ERROR, `${method} "name"`);
+      throw new RPCError(errs.MISC_ERROR, `${method} "name" ( "account" )`);
 
     const valid = new Validator(args);
     const name = valid.str(0);
+    const account = valid.str(1);
 
-    return {name}
+    return {name, account}
   }
 
   async sendRedeem(args, help) {
-    const { name } = this._validateRedeem(args, help, 'sendredeem');
+    const opts = this._validateRedeem(args, help, 'sendredeem');
     const wallet = this.wallet;
 
-    if (!name) {
-      const tx = await wallet.sendRedeemAll();
+    if (!opts.name) {
+      const tx = await wallet.sendRedeemAll({ account: opts.account });
       return tx.getJSON(this.network);
     }
 
-    if (!rules.verifyName(name))
+    if (!rules.verifyName(opts.name))
       throw new RPCError(errs.TYPE_ERROR, 'Invalid name.');
 
-    const tx = await wallet.sendRedeem(name);
+    const tx = await wallet.sendRedeem(opts.name, {
+      account: opts.account
+    });
 
     return tx.getJSON(this.network);
   }
 
   async createRedeem(args, help) {
-    const { name } = this._validateRedeem(args, help, 'createredeem');
+    const opts = this._validateRedeem(args, help, 'createredeem');
     const wallet = this.wallet;
 
-    if (!name) {
-      const mtx = await wallet.createRedeemAll({ paths: true });
+    if (!opts.name) {
+      const mtx = await wallet.createRedeemAll({
+        paths: true,
+        account: opts.account
+      });
       return mtx.getJSON(this.network);
     }
 
-    if (!rules.verifyName(name))
+    if (!rules.verifyName(opts.name))
       throw new RPCError(errs.TYPE_ERROR, 'Invalid name.');
 
-    const mtx = await wallet.createRedeem(name, { paths: true });
+    const mtx = await wallet.createRedeem(opts.name, {
+      paths: true,
+      account: opts.account
+    });
 
     return mtx.getJSON(this.network);
   }
 
   _validateRedeem(args, help, method) {
     if (help || args.length > 1)
-      throw new RPCError(errs.MISC_ERROR, `${method} "name"`);
+      throw new RPCError(errs.MISC_ERROR, `${method} "name" ( "account" )`);
 
     const valid = new Validator(args);
     const name = valid.str(0);
+    const account = valid.str(1);
 
-    return {name};
+    return {name, account};
   }
 
   async sendUpdate(args, help) {
-    const { name, resource } = this._validateUpdate(args, help, 'sendupdate');
+    const opts = this._validateUpdate(args, help, 'sendupdate');
     const wallet = this.wallet;
-    const tx = await wallet.sendUpdate(name, resource);
+    const tx = await wallet.sendUpdate(opts.name, opts.resource, {
+      account: opts.account
+    });
+
     return tx.getJSON(this.network);
   }
 
   async createUpdate(args, help) {
-    const { name, resource } = this._validateUpdate(args, help, 'createupdate');
+    const opts = this._validateUpdate(args, help, 'createupdate');
     const wallet = this.wallet;
-    const mtx = await wallet.createUpdate(name, resource, { paths: true });
+    const mtx = await wallet.createUpdate(opts.name, opts.resource, {
+      paths: true,
+      account: opts.account
+    });
+
     return mtx.getJSON(this.network);
   }
 
   _validateUpdate(args, help, method) {
     if (help || args.length !== 2)
-      throw new RPCError(errs.MISC_ERROR, `${method} "name" "data"`);
+      throw new RPCError(errs.MISC_ERROR, `${method} "name" "data" ( "account" )`);
 
     const valid = new Validator(args);
     const name = valid.str(0);
     const data = valid.obj(1);
+    const account = valid.str(2);
 
     if (!name || !rules.verifyName(name))
       throw new RPCError(errs.TYPE_ERROR, 'Invalid name.');
@@ -2105,58 +2147,73 @@ class RPC extends RPCBase {
 
     return {
       name,
-      resource
+      resource,
+      account
     };
   }
 
   async sendRenewal(args, help) {
     const wallet = this.wallet;
-    const { name } = this._validateRenewal(args, help, 'sendrenewal');
-    const tx = await wallet.sendRenewal(name);
+    const opts = this._validateRenewal(args, help, 'sendrenewal');
+    const tx = await wallet.sendRenewal(opts.name, { account: opts.account });
+
     return tx.getJSON(this.network);
   }
 
   async createRenewal(args, help) {
     const wallet = this.wallet;
-    const { name } = this._validateRenewal(args, help, 'createrenewal');
-    const mtx = await wallet.createRenewal(name, { paths: true });
+    const opts = this._validateRenewal(args, help, 'createrenewal');
+    const mtx = await wallet.createRenewal(opts.name, {
+      paths: true,
+      account: opts.account
+    });
+
     return mtx.getJSON(this.network);
   }
 
   _validateRenewal(args, help, method) {
     if (help || args.length !== 1)
-      throw new RPCError(errs.MISC_ERROR, `${method} "name"`);
+      throw new RPCError(errs.MISC_ERROR, `${method} "name" ( "account" )`);
 
     const valid = new Validator(args);
     const name = valid.str(0);
+    const account = valid.str(1);
 
     if (!name || !rules.verifyName(name))
       throw new RPCError(errs.TYPE_ERROR, 'Invalid name.');
 
-    return {name};
+    return {name, account};
   }
 
   async sendTransfer(args, help) {
-    const {name, address} = this._validateTransfer(args, help, 'sendtransfer');
+    const opts = this._validateTransfer(args, help, 'sendtransfer');
     const wallet = this.wallet;
-    const tx = await wallet.sendTransfer(name, address);
+    const tx = await wallet.sendTransfer(opts.name, opts.address, {
+      account: opts.account
+    });
+
     return tx.getJSON(this.network);
   }
 
   async createTransfer(args, help) {
-    const {name, address} = this._validateTransfer(args, help, 'createtransfer');
+    const opts = this._validateTransfer(args, help, 'createtransfer');
     const wallet = this.wallet;
-    const tx = await wallet.createTransfer(name, address, { paths: true });
+    const tx = await wallet.createTransfer(opts.name, opts.address, {
+      paths: true,
+      account: opts.account
+    });
+
     return tx.getJSON(this.network);
   }
 
   _validateTransfer(args, help, method) {
     if (help || args.length !== 2)
-      throw new RPCError(errs.MISC_ERROR, `${method} "name" "address"`);
+      throw new RPCError(errs.MISC_ERROR, `${method} "name" "address" ( "account" )`);
 
     const valid = new Validator(args);
     const name = valid.str(0);
     const addr = valid.str(1);
+    const account = valid.str(2);
 
     if (!name || !rules.verifyName(name))
       throw new RPCError(errs.TYPE_ERROR, 'Invalid name.');
@@ -2168,89 +2225,112 @@ class RPC extends RPCBase {
 
     return {
       name,
-      address
+      address,
+      account
     };
   }
 
   async sendCancel(args, help) {
-    const { name } = this._validateCancel(args, help, 'sendcancel');
+    const opts = this._validateCancel(args, help, 'sendcancel');
     const wallet = this.wallet;
-    const tx = await wallet.sendCancel(name);
+    const tx = await wallet.sendCancel(opts.name, {
+      account: opts.account
+    });
+
     return tx.getJSON(this.network);
   }
 
   async createCancel(args, help) {
-    const { name } = this._validateCancel(args, help, 'createcancel');
+    const opts = this._validateCancel(args, help, 'createcancel');
     const wallet = this.wallet;
-    const mtx = await wallet.createCancel(name, { paths: true });
+    const mtx = await wallet.createCancel(opts.name, {
+      paths: true,
+      account: opts.account
+    });
+
     return mtx.getJSON(this.network);
   }
 
   _validateCancel(args, help, method) {
     if (help || args.length !== 1)
-      throw new RPCError(errs.MISC_ERROR, `${method} "name"`);
+      throw new RPCError(errs.MISC_ERROR, `${method} "name" ( "account" )`);
 
     const valid = new Validator(args);
     const name = valid.str(0);
+    const account = valid.str(1);
 
     if (!name || !rules.verifyName(name))
       throw new RPCError(errs.TYPE_ERROR, 'Invalid name.');
 
-    return {name};
+    return {name, account};
   }
 
   async sendFinalize(args, help) {
-    const { name } = this._validateFinalize(args, help, 'sendfinalize');
+    const opts = this._validateFinalize(args, help, 'sendfinalize');
     const wallet = this.wallet;
-    const tx = await wallet.sendFinalize(name);
+    const tx = await wallet.sendFinalize(opts.name, {
+      account: opts.account
+    });
+
     return tx.getJSON(this.network);
   }
 
   async createFinalize(args, help) {
-    const { name } = this._validateFinalize(args, help, 'createfinalize');
+    const opts = this._validateFinalize(args, help, 'createfinalize');
     const wallet = this.wallet;
-    const mtx = await wallet.createFinalize(name, { paths: true });
+    const mtx = await wallet.createFinalize(opts.name, {
+      paths: true,
+      account: opts.account
+    });
+
     return mtx.getJSON(this.network);
   }
 
   _validateFinalize(args, help, method) {
     if (help || args.length !== 1)
-      throw new RPCError(errs.MISC_ERROR, `${method} "name"`);
+      throw new RPCError(errs.MISC_ERROR, `${method} "name" ( "account" )`);
 
     const valid = new Validator(args);
     const name = valid.str(0);
+    const account = valid.str(1);
 
     if (!name || !rules.verifyName(name))
       throw new RPCError(errs.TYPE_ERROR, 'Invalid name.');
 
-    return {name};
+    return {name, account};
   }
 
   async sendRevoke(args, help) {
-    const { name } = this._validateRevoke(args, help, 'sendrevoke');
+    const opts = this._validateRevoke(args, help, 'sendrevoke');
     const wallet = this.wallet;
-    const tx = await wallet.sendRevoke(name);
+    const tx = await wallet.sendRevoke(opts.name, {
+      account: opts.account
+    });
     return tx.getJSON(this.network);
   }
 
   async createRevoke(args, help) {
-    const { name } = this._validateRevoke(args, help, 'createrevoke');
+    const opts = this._validateRevoke(args, help, 'createrevoke');
     const wallet = this.wallet;
-    const mtx = await wallet.createRevoke(name, { paths: true });
+    const mtx = await wallet.createRevoke(opts.name, {
+      paths: true,
+      account: opts.account
+    });
     return mtx.getJSON(this.network);
   }
 
   _validateRevoke(args, help, method) {
     if (help || args.length !== 1)
-      throw new RPCError(errs.MISC_ERROR, `${method} "name"`);
+      throw new RPCError(errs.MISC_ERROR, `${method} "name" ( "account" )`);
 
     const valid = new Validator(args);
     const name = valid.str(0);
+    const account = valid.str(1);
 
     if (!name || !rules.verifyName(name))
       throw new RPCError(errs.TYPE_ERROR, 'Invalid name.');
 
-    return {name}
+    return {name, account}
   }
 
   async importNonce(args, help) {

--- a/lib/wallet/rpc.js
+++ b/lib/wallet/rpc.js
@@ -1430,15 +1430,16 @@ class RPC extends RPCBase {
   }
 
   async createSendToAddress(args, help) {
-    const {addr, value, subtract} = this._validateSendToAddress(args, help, 'createsendtoaddress');
+    const opts = this._validateSendToAddress(args, help, 'createsendtoaddress');
     const wallet = this.wallet;
 
     const options = {
       paths: true,
-      subtractFee: subtract,
+      account: opts.account,
+      subtractFee: opts.subtract,
       outputs: [{
-        address: addr,
-        value: value
+        address: opts.addr,
+        value: opts.value
       }]
     };
 
@@ -1448,16 +1449,17 @@ class RPC extends RPCBase {
   }
 
   _validateSendToAddress(args, help, method) {
-    if (help || args.length < 2 || args.length > 5) {
+    if (help || args.length < 2 || args.length > 6) {
       throw new RPCError(errs.MISC_ERROR,
         `${method} "address" amount`
-        + ' ( "comment" "comment-to" subtractfeefromamount )');
+        + ' ( "comment" "comment-to" subtractfeefromamount "account")');
     }
 
     const valid = new Validator(args);
     const str = valid.str(0);
     const value = valid.ufixed(1, EXP);
     const subtract = valid.bool(4, false);
+    const account = valid.str(5);
 
     const addr = parseAddress(str, this.network);
 
@@ -1467,7 +1469,8 @@ class RPC extends RPCBase {
     return {
       subtract,
       addr,
-      value
+      value,
+      account
     };
   }
 

--- a/lib/wallet/rpc.js
+++ b/lib/wallet/rpc.js
@@ -1434,6 +1434,7 @@ class RPC extends RPCBase {
     const wallet = this.wallet;
 
     const options = {
+      paths: true,
       subtractFee: subtract,
       outputs: [{
         address: addr,
@@ -1442,6 +1443,7 @@ class RPC extends RPCBase {
     };
 
     const mtx = await wallet.createTX(options);
+
     return mtx.getJSON(this.network);
   }
 
@@ -1923,7 +1925,7 @@ class RPC extends RPCBase {
   async createOpen(args, help) {
     const { name, force } = this._validateOpen(args, help, 'createopen');
     const wallet = this.wallet;
-    const mtx = await wallet.createOpen(name, force);
+    const mtx = await wallet.createOpen(name, force, { paths: true });
     return mtx.getJSON(this.network);
   }
 
@@ -1951,7 +1953,7 @@ class RPC extends RPCBase {
   async createBid(args, help) {
     const {name, bid, value} = this._validateBid(args, help, 'createbid');
     const wallet = this.wallet;
-    const mtx = await wallet.createBid(name, bid, value);
+    const mtx = await wallet.createBid(name, bid, value, { paths: true });
     return mtx.getJSON(this.network);
   }
 
@@ -2002,14 +2004,14 @@ class RPC extends RPCBase {
     const wallet = this.wallet;
 
     if (!name) {
-      const mtx = await wallet.createRevealAll();
+      const mtx = await wallet.createRevealAll({ paths: true });
       return mtx.getJSON(this.network);
     }
 
     if (!rules.verifyName(name))
       throw new RPCError(errs.TYPE_ERROR, 'Invalid name.');
 
-    const mtx = await wallet.createReveal(name);
+    const mtx = await wallet.createReveal(name, { paths: true });
 
     return mtx.getJSON(this.network);
   }
@@ -2040,31 +2042,31 @@ class RPC extends RPCBase {
 
     return tx.getJSON(this.network);
   }
-  
+
   async createRedeem(args, help) {
     const { name } = this._validateRedeem(args, help, 'createredeem');
     const wallet = this.wallet;
 
     if (!name) {
-      const mtx = await wallet.createRedeemAll();
+      const mtx = await wallet.createRedeemAll({ paths: true });
       return mtx.getJSON(this.network);
     }
 
     if (!rules.verifyName(name))
       throw new RPCError(errs.TYPE_ERROR, 'Invalid name.');
 
-    const mtx = await wallet.createRedeem(name);
+    const mtx = await wallet.createRedeem(name, { paths: true });
 
     return mtx.getJSON(this.network);
   }
-  
+
   _validateRedeem(args, help, method) {
     if (help || args.length > 1)
       throw new RPCError(errs.MISC_ERROR, `${method} "name"`);
-    
+
     const valid = new Validator(args);
     const name = valid.str(0);
-    
+
     return {name};
   }
 
@@ -2078,7 +2080,7 @@ class RPC extends RPCBase {
   async createUpdate(args, help) {
     const { name, resource } = this._validateUpdate(args, help, 'createupdate');
     const wallet = this.wallet;
-    const mtx = await wallet.createUpdate(name, resource);
+    const mtx = await wallet.createUpdate(name, resource, { paths: true });
     return mtx.getJSON(this.network);
   }
 
@@ -2114,7 +2116,7 @@ class RPC extends RPCBase {
   async createRenewal(args, help) {
     const wallet = this.wallet;
     const { name } = this._validateRenewal(args, help, 'createrenewal');
-    const mtx = await wallet.createRenewal(name);
+    const mtx = await wallet.createRenewal(name, { paths: true });
     return mtx.getJSON(this.network);
   }
 
@@ -2141,7 +2143,7 @@ class RPC extends RPCBase {
   async createTransfer(args, help) {
     const {name, address} = this._validateTransfer(args, help, 'createtransfer');
     const wallet = this.wallet;
-    const tx = await wallet.createTransfer(name, address);
+    const tx = await wallet.createTransfer(name, address, { paths: true });
     return tx.getJSON(this.network);
   }
 
@@ -2177,7 +2179,7 @@ class RPC extends RPCBase {
   async createCancel(args, help) {
     const { name } = this._validateCancel(args, help, 'createcancel');
     const wallet = this.wallet;
-    const mtx = await wallet.createCancel(name);
+    const mtx = await wallet.createCancel(name, { paths: true });
     return mtx.getJSON(this.network);
   }
 
@@ -2204,7 +2206,7 @@ class RPC extends RPCBase {
   async createFinalize(args, help) {
     const { name } = this._validateFinalize(args, help, 'createfinalize');
     const wallet = this.wallet;
-    const mtx = await wallet.createFinalize(name);
+    const mtx = await wallet.createFinalize(name, { paths: true });
     return mtx.getJSON(this.network);
   }
 
@@ -2231,7 +2233,7 @@ class RPC extends RPCBase {
   async createRevoke(args, help) {
     const { name } = this._validateRevoke(args, help, 'createrevoke');
     const wallet = this.wallet;
-    const mtx = await wallet.createRevoke(name);
+    const mtx = await wallet.createRevoke(name, { paths: true });
     return mtx.getJSON(this.network);
   }
 

--- a/lib/wallet/rpc.js
+++ b/lib/wallet/rpc.js
@@ -155,6 +155,7 @@ class RPC extends RPCBase {
     this.add('sendfrom', this.sendFrom);
     this.add('sendmany', this.sendMany);
     this.add('sendtoaddress', this.sendToAddress);
+    this.add('createsendtoaddress', this.createSendToAddress);
     this.add('setaccount', this.setAccount);
     this.add('settxfee', this.setTXFee);
     this.add('signmessage', this.signMessage);
@@ -186,6 +187,16 @@ class RPC extends RPCBase {
     this.add('sendfinalize', this.sendFinalize);
     this.add('sendrevoke', this.sendRevoke);
     this.add('importnonce', this.importNonce);
+    this.add('createopen', this.createOpen);
+    this.add('createbid', this.createBid);
+    this.add('createreveal', this.createReveal);
+    this.add('createredeem', this.createRedeem);
+    this.add('createupdate', this.createUpdate);
+    this.add('createrenewal', this.createRenewal);
+    this.add('createtransfer', this.createTransfer);
+    this.add('createcancel', this.createCancel);
+    this.add('createfinalize', this.createFinalize);
+    this.add('createrevoke', this.createRevoke);
 
     // Compat
     this.add('getauctions', this.getNames);
@@ -1402,22 +1413,8 @@ class RPC extends RPCBase {
   }
 
   async sendToAddress(args, help) {
-    if (help || args.length < 2 || args.length > 5) {
-      throw new RPCError(errs.MISC_ERROR,
-        'sendtoaddress "address" amount'
-        + ' ( "comment" "comment-to" subtractfeefromamount )');
-    }
-
+    const {addr, value, subtract} = this._validateSendToAddress(args, help, 'sendtoaddress');
     const wallet = this.wallet;
-    const valid = new Validator(args);
-    const str = valid.str(0);
-    const value = valid.ufixed(1, EXP);
-    const subtract = valid.bool(4, false);
-
-    const addr = parseAddress(str, this.network);
-
-    if (!addr || value == null)
-      throw new RPCError(errs.TYPE_ERROR, 'Invalid parameter.');
 
     const options = {
       subtractFee: subtract,
@@ -1430,6 +1427,46 @@ class RPC extends RPCBase {
     const tx = await wallet.send(options);
 
     return tx.txid();
+  }
+
+  async createSendToAddress(args, help) {
+    const {addr, value, subtract} = this._validateSendToAddress(args, help, 'createsendtoaddress');
+    const wallet = this.wallet;
+
+    const options = {
+      subtractFee: subtract,
+      outputs: [{
+        address: addr,
+        value: value
+      }]
+    };
+
+    const mtx = await wallet.createTX(options);
+    return mtx.getJSON(this.network);
+  }
+
+  async _validateSendToAddress(args, help, method) {
+    if (help || args.length < 2 || args.length > 5) {
+      throw new RPCError(errs.MISC_ERROR,
+        `${method} "address" amount`
+        + ' ( "comment" "comment-to" subtractfeefromamount )');
+    }
+
+    const valid = new Validator(args);
+    const str = valid.str(0);
+    const value = valid.ufixed(1, EXP);
+    const subtract = valid.bool(4, false);
+
+    const addr = parseAddress(str, this.network);
+
+    if (!addr || value == null)
+      throw new RPCError(errs.TYPE_ERROR, 'Invalid parameter.');
+
+    return {
+      subtract,
+      addr,
+      value
+    };
   }
 
   async setAccount(args, help) {
@@ -1877,10 +1914,23 @@ class RPC extends RPCBase {
   }
 
   async sendOpen(args, help) {
-    if (help || args.length < 1 || args.length > 2)
-      throw new RPCError(errs.MISC_ERROR, 'sendopen "name" ( force )');
-
+    const { name, force } = this._validateOpen(args, help, 'sendopen');
     const wallet = this.wallet;
+    const tx = await wallet.sendOpen(name, force);
+    return tx.getJSON(this.network);
+  }
+
+  async createOpen(args, help) {
+    const { name, force } = this._validateOpen(args, help, 'createopen');
+    const wallet = this.wallet;
+    const mtx = await wallet.createOpen(name, force);
+    return mtx.getJSON(this.network);
+  }
+
+  _validateOpen(args, help, method) {
+    if (help || args.length < 1 || args.length > 2)
+      throw new RPCError(errs.MISC_ERROR, `${method} "name" ( force )`);
+
     const valid = new Validator(args);
     const name = valid.str(0);
     const force = valid.bool(1, false);
@@ -1888,16 +1938,27 @@ class RPC extends RPCBase {
     if (!name || !rules.verifyName(name))
       throw new RPCError(errs.TYPE_ERROR, 'Invalid name.');
 
-    const tx = await wallet.sendOpen(name, force);
-
-    return tx.getJSON(this.network);
+    return {name, force};
   }
 
   async sendBid(args, help) {
-    if (help || args.length !== 3)
-      throw new RPCError(errs.MISC_ERROR, 'sendbid "name" bid value');
-
+    const {name, bid, value} = this._validateBid(args, help, 'sendbid');
     const wallet = this.wallet;
+    const tx = await wallet.sendBid(name, bid, value);
+    return tx.getJSON(this.network);
+  }
+
+  async createBid(args, help) {
+    const {name, bid, value} = this._validateBid(args, help, 'createbid');
+    const wallet = this.wallet;
+    const mtx = await wallet.createBid(name, bid, value);
+    return mtx.getJSON(this.network);
+  }
+
+  _validateBid(args, help, method) {
+    if (help || args.length !== 3)
+      throw new RPCError(errs.MISC_ERROR, `${method} "name" bid value`);
+
     const valid = new Validator(args);
     const name = valid.str(0);
     const bid = valid.ufixed(1, EXP);
@@ -1912,18 +1973,16 @@ class RPC extends RPCBase {
     if (bid > value)
       throw new RPCError(errs.TYPE_ERROR, 'Invalid bid.');
 
-    const tx = await wallet.sendBid(name, bid, value);
-
-    return tx.getJSON(this.network);
+    return {
+      name,
+      bid,
+      value
+    };
   }
 
   async sendReveal(args, help) {
-    if (help || args.length > 1)
-      throw new RPCError(errs.MISC_ERROR, 'sendreveal "name"');
-
+    const { name } = this._validateReveal(args, help, 'sendreveal');
     const wallet = this.wallet;
-    const valid = new Validator(args);
-    const name = valid.str(0);
 
     if (!name) {
       const tx = await wallet.sendRevealAll();
@@ -1938,13 +1997,36 @@ class RPC extends RPCBase {
     return tx.getJSON(this.network);
   }
 
-  async sendRedeem(args, help) {
-    if (help || args.length > 1)
-      throw new RPCError(errs.MISC_ERROR, 'sendredeem "name"');
-
+  async createReveal(args, help) {
+    const { name } = this._validateReveal(args, help, 'createreveal');
     const wallet = this.wallet;
+
+    if (!name) {
+      const mtx = await wallet.createRevealAll();
+      return mtx.getJSON(this.network);
+    }
+
+    if (!rules.verifyName(name))
+      throw new RPCError(errs.TYPE_ERROR, 'Invalid name.');
+
+    const mtx = await wallet.createReveal(name);
+
+    return mtx.getJSON(this.network);
+  }
+
+  _validateReveal(args, help, method) {
+    if (help || args.length > 1)
+      throw new RPCError(errs.MISC_ERROR, `${method} "name"`);
+
     const valid = new Validator(args);
     const name = valid.str(0);
+
+    return {name}
+  }
+
+  async sendRedeem(args, help) {
+    const { name } = this._validateRedeem(args, help, 'sendredeem');
+    const wallet = this.wallet;
 
     if (!name) {
       const tx = await wallet.sendRedeemAll();
@@ -1958,12 +2040,52 @@ class RPC extends RPCBase {
 
     return tx.getJSON(this.network);
   }
+  
+  async createRedeem(args, help) {
+    const { name } = this._validateRedeem(args, help, 'createredeem');
+    const wallet = this.wallet;
+
+    if (!name) {
+      const mtx = await wallet.createRedeemAll();
+      return mtx.getJSON(this.network);
+    }
+
+    if (!rules.verifyName(name))
+      throw new RPCError(errs.TYPE_ERROR, 'Invalid name.');
+
+    const mtx = await wallet.createRedeem(name);
+
+    return mtx.getJSON(this.network);
+  }
+  
+  _validateRedeem(args, help, method) {
+    if (help || args.length > 1)
+      throw new RPCError(errs.MISC_ERROR, `${method} "name"`);
+    
+    const valid = new Validator(args);
+    const name = valid.str(0);
+    
+    return {name};
+  }
 
   async sendUpdate(args, help) {
-    if (help || args.length !== 2)
-      throw new RPCError(errs.MISC_ERROR, 'sendupdate "name" "data"');
-
+    const { name, resource } = this._validateUpdate(args, help, 'sendupdate');
     const wallet = this.wallet;
+    const tx = await wallet.sendUpdate(name, resource);
+    return tx.getJSON(this.network);
+  }
+
+  async createUpdate(args, help) {
+    const { name, resource } = this._validateUpdate(args, help, 'createupdate');
+    const wallet = this.wallet;
+    const mtx = await wallet.createUpdate(name, resource);
+    return mtx.getJSON(this.network);
+  }
+
+  _validateUpdate(args, help, method) {
+    if (help || args.length !== 2)
+      throw new RPCError(errs.MISC_ERROR, `${method} "name" "data"`);
+
     const valid = new Validator(args);
     const name = valid.str(0);
     const data = valid.obj(1);
@@ -1975,32 +2097,58 @@ class RPC extends RPCBase {
       throw new RPCError(errs.TYPE_ERROR, 'Invalid hex string.');
 
     const resource = Resource.fromJSON(data);
-    const tx = await wallet.sendUpdate(name, resource);
 
-    return tx.getJSON(this.network);
+    return {
+      name,
+      resource
+    };
   }
 
   async sendRenewal(args, help) {
-    if (help || args.length !== 1)
-      throw new RPCError(errs.MISC_ERROR, 'sendrenewal "name"');
-
     const wallet = this.wallet;
+    const { name } = this._validateRenewal(args, help, 'sendrenewal');
+    const tx = await wallet.sendRenewal(name);
+    return tx.getJSON(this.network);
+  }
+
+  async createRenewal(args, help) {
+    const wallet = this.wallet;
+    const { name } = this._validateRenewal(args, help, 'createrenewal');
+    const mtx = await wallet.createRenewal(name);
+    return mtx.getJSON(this.network);
+  }
+
+  _validateRenewal(args, help, method) {
+    if (help || args.length !== 1)
+      throw new RPCError(errs.MISC_ERROR, `${method} "name"`);
+
     const valid = new Validator(args);
     const name = valid.str(0);
 
     if (!name || !rules.verifyName(name))
       throw new RPCError(errs.TYPE_ERROR, 'Invalid name.');
 
-    const tx = await wallet.sendRenewal(name);
-
-    return tx.getJSON(this.network);
+    return {name};
   }
 
   async sendTransfer(args, help) {
-    if (help || args.length !== 2)
-      throw new RPCError(errs.MISC_ERROR, 'sendtransfer "name" "address"');
-
+    const {name, address} = this._validateTransfer(args, help, 'sendtransfer');
     const wallet = this.wallet;
+    const tx = await wallet.sendTransfer(name, address);
+    return tx.getJSON(this.network);
+  }
+
+  async createTransfer(args, help) {
+    const {name, address} = this._validateTransfer(args, help, 'createtransfer');
+    const wallet = this.wallet;
+    const tx = await wallet.createTransfer(name, address);
+    return tx.getJSON(this.network);
+  }
+
+  _validateTransfer(args, help, method) {
+    if (help || args.length !== 2)
+      throw new RPCError(errs.MISC_ERROR, `${method} "name" "address"`);
+
     const valid = new Validator(args);
     const name = valid.str(0);
     const addr = valid.str(1);
@@ -2012,57 +2160,92 @@ class RPC extends RPCBase {
       throw new RPCError(errs.TYPE_ERROR, 'Invalid address.');
 
     const address = parseAddress(addr, this.network);
-    const tx = await wallet.sendTransfer(name, address);
 
-    return tx.getJSON(this.network);
+    return {
+      name,
+      address
+    };
   }
 
   async sendCancel(args, help) {
-    if (help || args.length !== 1)
-      throw new RPCError(errs.MISC_ERROR, 'sendcancel "name"');
-
+    const { name } = this._validateCancel(args, help, 'sendcancel');
     const wallet = this.wallet;
+    const tx = await wallet.sendCancel(name);
+    return tx.getJSON(this.network);
+  }
+
+  async createCancel(args, help) {
+    const { name } = this._validateCancel(args, help, 'createcancel');
+    const wallet = this.wallet;
+    const mtx = await wallet.createCancel(name);
+    return mtx.getJSON(this.network);
+  }
+
+  _validateCancel(args, help, method) {
+    if (help || args.length !== 1)
+      throw new RPCError(errs.MISC_ERROR, `${method} "name"`);
+
     const valid = new Validator(args);
     const name = valid.str(0);
 
     if (!name || !rules.verifyName(name))
       throw new RPCError(errs.TYPE_ERROR, 'Invalid name.');
 
-    const tx = await wallet.sendCancel(name);
-
-    return tx.getJSON(this.network);
+    return {name};
   }
 
   async sendFinalize(args, help) {
-    if (help || args.length !== 1)
-      throw new RPCError(errs.MISC_ERROR, 'sendfinalize "name"');
-
+    const { name } = this._validateFinalize(args, help, 'sendfinalize');
     const wallet = this.wallet;
-    const valid = new Validator(args);
-    const name = valid.str(0);
-
-    if (!name || !rules.verifyName(name))
-      throw new RPCError(errs.TYPE_ERROR, 'Invalid name.');
-
     const tx = await wallet.sendFinalize(name);
-
     return tx.getJSON(this.network);
   }
 
-  async sendRevoke(args, help) {
-    if (help || args.length !== 1)
-      throw new RPCError(errs.MISC_ERROR, 'sendrevoke "name"');
-
+  async createFinalize(args, help) {
+    const { name } = this._validateFinalize(args, help, 'createfinalize');
     const wallet = this.wallet;
+    const mtx = await wallet.createFinalize(name);
+    return mtx.getJSON(this.network);
+  }
+
+  _validateFinalize(args, help, method) {
+    if (help || args.length !== 1)
+      throw new RPCError(errs.MISC_ERROR, `${method} "name"`);
+
     const valid = new Validator(args);
     const name = valid.str(0);
 
     if (!name || !rules.verifyName(name))
       throw new RPCError(errs.TYPE_ERROR, 'Invalid name.');
 
-    const tx = await wallet.sendRevoke(name);
+    return {name};
+  }
 
+  async sendRevoke(args, help) {
+    const { name } = this._validateRevoke(args, help, 'sendrevoke');
+    const wallet = this.wallet;
+    const tx = await wallet.sendRevoke(name);
     return tx.getJSON(this.network);
+  }
+
+  async createRevoke(args, help) {
+    const { name } = this._validateRevoke(args, help, 'createrevoke');
+    const wallet = this.wallet;
+    const mtx = await wallet.createRevoke(name);
+    return mtx.getJSON(this.network);
+  }
+
+  _validateRevoke(args, help, method) {
+    if (help || args.length !== 1)
+      throw new RPCError(errs.MISC_ERROR, `${method} "name"`);
+
+    const valid = new Validator(args);
+    const name = valid.str(0);
+
+    if (!name || !rules.verifyName(name))
+      throw new RPCError(errs.TYPE_ERROR, 'Invalid name.');
+
+    return {name}
   }
 
   async importNonce(args, help) {

--- a/lib/wallet/wallet.js
+++ b/lib/wallet/wallet.js
@@ -3202,7 +3202,7 @@ class Wallet extends EventEmitter {
       throw new Error('Not all coins available.');
 
     const network = this.network.type;
-    const addrs = await mtx.getAddresses(mtx);
+    const addrs = await mtx.getInputAddresses(mtx);
 
     for (const addr of addrs) {
       const address = addr.toString(network);

--- a/lib/wallet/wallet.js
+++ b/lib/wallet/wallet.js
@@ -3205,16 +3205,31 @@ class Wallet extends EventEmitter {
     const addrs = await mtx.getInputAddresses(mtx);
 
     for (const addr of addrs) {
-      const address = addr.toString(network);
-      const path = await this.getPath(addr);
+      let path = await this.getPath(addr);
 
       if (!path)
         continue;
 
       if (!mtx.paths)
-        mtx.paths = { network };
+        mtx.paths = Object.create(null);
 
-      mtx.paths[address] = path;
+      const purpose = 44;
+      const coinType = this.network.keyPrefix.coinType;
+
+      // Convert to derivation string, e.g. "m/0'/0/1"
+      path = path.toPath();
+
+      // Split into individual elements
+      path = path.split('/');
+
+      // Remove root prefix
+      path.shift();
+
+      const address = addr.toString(network);
+      const prefix = `m/${purpose}'/${coinType}'`;
+      const suffix = path.join('/');
+
+      mtx.paths[address] = prefix + '/' + suffix;
     }
   }
 

--- a/lib/wallet/wallet.js
+++ b/lib/wallet/wallet.js
@@ -186,7 +186,7 @@ class Wallet extends EventEmitter {
    */
 
   async open() {
-    const account = await this.getAccount(0);
+    const account = await this.getAccount('default');
 
     if (!account)
       throw new Error('Default account not found.');
@@ -583,6 +583,7 @@ class Wallet extends EventEmitter {
 
     await this.unlock(passphrase);
 
+    let index;
     let key;
     if (this.watchOnly && options.accountKey) {
       key = options.accountKey;
@@ -590,12 +591,18 @@ class Wallet extends EventEmitter {
       if (typeof key === 'string')
         key = HD.PublicKey.fromBase58(key, this.network);
 
+      index = key.childIndex;
+
+      if (index & HD.common.HARDENED)
+         index &= 0x7fffffff;
+
       if (!HD.isPublic(key))
         throw new Error('Must add HD public keys to watch only wallet.');
     } else {
       assert(this.master.key);
       const type = this.network.keyPrefix.coinType;
-      key = this.master.key.deriveAccount(44, type, this.accountDepth);
+      index = this.accountDepth;
+      key = this.master.key.deriveAccount(44, type, index);
       key = key.toPublic();
     }
 
@@ -605,7 +612,7 @@ class Wallet extends EventEmitter {
       name: this.accountDepth === 0 ? 'default' : name,
       watchOnly: this.watchOnly,
       accountKey: key,
-      accountIndex: this.accountDepth,
+      accountIndex: index,
       type: options.type,
       m: options.m,
       n: options.n,

--- a/lib/wallet/wallet.js
+++ b/lib/wallet/wallet.js
@@ -2982,6 +2982,10 @@ class Wallet extends EventEmitter {
     if (options.locktime != null)
       mtx.setLocktime(options.locktime);
 
+    // Add the hd paths for each input to the mtx.
+    if (options.paths !== false)
+      await this.addPaths(mtx);
+
     // Consensus sanity checks.
     assert(mtx.isSane(), 'TX failed sanity check.');
     assert(mtx.verifyInputs(this.wdb.height + 1, this.network),
@@ -3181,6 +3185,37 @@ class Wallet extends EventEmitter {
       await this.wdb.send(tx);
 
     return txs;
+  }
+
+
+  /**
+   * Add necessary paths for signing a transaction.
+   * The paths object is a map keyed by coin address.
+   * @param {MTX} mtx
+   * @returns {Promise}
+   */
+
+  async addPaths(mtx) {
+    assert(mtx.mutable);
+
+    if (!mtx.hasCoins())
+      throw new Error('Not all coins available.');
+
+    const network = this.network.type;
+    const addrs = await mtx.getAddresses(mtx);
+
+    for (const addr of addrs) {
+      const address = addr.toString(network);
+      const path = await this.getPath(addr);
+
+      if (!path)
+        continue;
+
+      if (!mtx.paths)
+        mtx.paths = { network };
+
+      mtx.paths[address] = path;
+    }
   }
 
   /**


### PR DESCRIPTION
As discussed in #89, this PR adds support for transaction-creating mirror RPC methods.

How are RPC endpoints tested? I don't see any unit tests for the RPC layer right now.