### PR TITLE
http: identify node/wallet in log

### DIFF
--- a/lib/node/http.js
+++ b/lib/node/http.js
@@ -38,7 +38,7 @@ class HTTP extends Server {
     super(new HTTPOptions(options));
 
     this.network = this.options.network;
-    this.logger = this.options.logger.context('http');
+    this.logger = this.options.logger.context('node-http');
     this.node = this.options.node;
 
     this.chain = this.node.chain;

--- a/lib/wallet/http.js
+++ b/lib/wallet/http.js
@@ -40,7 +40,7 @@ class HTTP extends Server {
     super(new HTTPOptions(options));
 
     this.network = this.options.network;
-    this.logger = this.options.logger.context('http');
+    this.logger = this.options.logger.context('wallet-http');
     this.wdb = this.options.node.wdb;
     this.rpc = this.options.node.rpc;
 


### PR DESCRIPTION
Cherry-picked from https://github.com/bcoin-org/bcoin/pull/603


> I dunno if this helpful for anyone else, but when playing with socket testing I noticed that both wallet and node http servers report some identical messages like `(http) Successful auth from 127.0.0.1.` but I wasn't sure which server I was hitting.
> 
> This PR simply changes the log context identifiers to `node-http` and `wallet-http` instead of just `http`

Example log: 
```
[debug] (node-http) Request for method=GET path=/ (127.0.0.1).
...
[debug] (wallet-http) Request for method=GET path=/wallet (127.0.0.1).
...
[debug] (wallet-http) Request for method=GET path=/wallet (127.0.0.1).
```