### PR TITLE
bin: allow wallet to run separately from node server

### DIFF
--- a/bin/spvnode
+++ b/bin/spvnode
@@ -54,7 +54,7 @@ const node = new SPVNode({
 });
 
 // Temporary hack
-if (!node.has('walletdb')) {
+if (!node.config.bool('no-wallet') && !node.has('walletdb')) {
   const plugin = require('../lib/wallet/plugin');
   node.use(plugin);
 }

--- a/bin/wallet
+++ b/bin/wallet
@@ -19,7 +19,7 @@ if (process.argv.indexOf('--version') !== -1
   throw new Error('Could not exit.');
 }
 
-const Node = require('../lib/wallet/server');
+const Node = require('../lib/wallet/node');
 
 const node = new Node({
   config: true,

--- a/package.json
+++ b/package.json
@@ -60,7 +60,8 @@
   "bin": {
     "hsd": "./bin/hsd",
     "hsd-node": "./bin/node",
-    "hsd-spvnode": "./bin/spvnode"
+    "hsd-spvnode": "./bin/spvnode",
+    "hs-wallet": "./bin/hsw"
   },
   "scripts": {
     "lint": "eslint $(cat .eslintfiles) || exit 0",


### PR DESCRIPTION
This is a cherry-pick of https://github.com/bcoin-org/bcoin/pull/652
(fullnode already parses `--no-wallet`)

...which also relies on a needed backport from bcoin: https://github.com/bcoin-org/bcoin/commit/d25e553605eaa8e8a55a04aacec0e238bc0e111d

and the more subtle: https://github.com/bcoin-org/bcoin/commit/2efa5275d53c8f2efbb4c1af638ce9ac85889520

...which are included in this PR.


Launch hsd full or spv with no wallet plugin:
`$ hsd --spv --no-wallet`

Install globally (after merging or pulling):
`npm install -g`

Launch wallet as separate server:
`$ hswallet --network=testnet`

Client commands work normally:
`$ hsw-cli --network=testnet send ts1qwdd3xdw54u2mfdnltz6lnt4vr8ks5lc3seexjc 0.1`

