### PR TITLE
Wallet: require public key for watchonly 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Wallet API changes
 
 Creating a watch-only wallet now requires an `account-key` (or `accountKey`)
-argument. This is to prevent bcoin from generating keys and addresses the user
+argument. This is to prevent hsd from generating keys and addresses the user
 can not spend from.
 
 ## v0.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # HSD Release Notes & Changelog
 
+## vX.Y.Z
+
+### Wallet API changes
+
+Creating a watch-only wallet now requires an `account-key` (or `accountKey`)
+argument. This is to prevent bcoin from generating keys and addresses the user
+can not spend from.
+
 ## v0.0.0
 
 ### Notable Changes

--- a/lib/wallet/wallet.js
+++ b/lib/wallet/wallet.js
@@ -584,7 +584,7 @@ class Wallet extends EventEmitter {
     await this.unlock(passphrase);
 
     let key;
-    if (this.watchOnly && options.accountKey) {
+    if (this.watchOnly) {
       key = options.accountKey;
 
       if (typeof key === 'string')

--- a/test/wallet-test.js
+++ b/test/wallet-test.js
@@ -18,6 +18,8 @@ const KeyRing = require('../lib/primitives/keyring');
 const Input = require('../lib/primitives/input');
 const Outpoint = require('../lib/primitives/outpoint');
 const Script = require('../lib/script/script');
+const HD = require('../lib/hd');
+const PrivateKey = require('../lib/hd/private.js');
 
 const KEY1 = 'xprv9s21ZrQH143K3Aj6xQBymM31Zb4BVc7wxqfUhMZrzewdDVCt'
   + 'qUP9iWfcHgJofs25xbaUpCps9GDXj83NiWvQCAkWQhVj5J4CorfnpKX94AZ';
@@ -35,6 +37,7 @@ let importedWallet = null;
 let importedKey = null;
 let doubleSpendWallet = null;
 let doubleSpendCoin = null;
+let watchWallet = null;
 
 function fromU32(num) {
   const data = Buffer.allocUnsafe(4);
@@ -1175,37 +1178,49 @@ describe('Wallet', function() {
     importedKey = key;
   });
 
+  it('should require account key to create watch only wallet', async () => {
+    try {
+      watchWallet = await wdb.create({
+        watchOnly: true
+      });
+    } catch (e) {
+      assert.strictEqual(
+        e.message,
+        'Must add HD public keys to watch only wallet.'
+      );
+    }
+
+    const privateKey = PrivateKey.generate();
+    const xpub = privateKey.xpubkey('main');
+    watchWallet = await wdb.create({
+      watchOnly: true,
+      accountKey: xpub
+    });
+  });
+
   it('should import pubkey', async () => {
     const key = KeyRing.generate();
     const pub = new KeyRing(key.publicKey);
 
-    const wallet = await wdb.create({
-      watchOnly: true
-    });
+    await watchWallet.importKey('default', pub);
 
-    await wallet.importKey('default', pub);
-
-    const path = await wallet.getPath(pub.getHash());
+    const path = await watchWallet.getPath(pub.getHash());
     assert.bufferEqual(path.hash, pub.getHash());
 
-    const wkey = await wallet.getKey(pub.getHash());
+    const wkey = await watchWallet.getKey(pub.getHash());
     assert(wkey);
   });
 
   it('should import address', async () => {
     const key = KeyRing.generate();
 
-    const wallet = await wdb.create({
-      watchOnly: true
-    });
+    await watchWallet.importAddress('default', key.getAddress());
 
-    await wallet.importAddress('default', key.getAddress());
-
-    const path = await wallet.getPath(key.getHash());
+    const path = await watchWallet.getPath(key.getHash());
     assert(path);
     assert.bufferEqual(path.hash, key.getHash());
 
-    const wkey = await wallet.getKey(key.getHash());
+    const wkey = await watchWallet.getKey(key.getHash());
     assert(!wkey);
   });
 


### PR DESCRIPTION
This is a cherry-pick of https://github.com/bcoin-org/bcoin/pull/639

> Addresses #636 in which a user creates private keys they could never access due to a wallet being watch-only.
> 
> This PR goes along with #637 and [bcoin-org/bclient#15](https://github.com/bcoin-org/bclient/pull/15), maybe we can decide if we need all three safeties in place or which ones we do or don't need.
> 
> In this pull request, we prevent a watch-only wallet from ever generating a master (private) key which could lead to a user seeing addresses they can not spend from.
> 
> I think `watchOnly` should always require an `accountKey`. The reverse isn't necessarily required, for example in `bclient`, creating a wallet with `accountKey` automatically sets `watchOnly` to `true`. In bcoin `wallet._createAccount()`, `accountKey` is just ignored if `watchOnly` is false, but at least that doesn't lead to unrecoverable keys!

**Note in `hsw-cli` the params for `watch-only` and `account-key` (in bcoin/bwallet-cli) are `watch` and `key` (in hsw-cli)**

Example:
```
$ hsw-cli mkwallet --id=watchtest --watch=true
Error: Must add HD public keys to watch only wallet.
    at WalletClient.request (/Users/matthewzipkin/Desktop/work/hs-client/node_modules/bcurl/lib/client.js:213:19)
    at process._tickCallback (internal/process/next_tick.js:68:7)

$ hsw-cli mkwallet --id=watchtest --watch=true --key=tpubDDuC5zidzkFVJSETSQnpzNv5yESw3TKSAJsYmYT1XaLYmr7kZa3bZ7CFKSQGb2E9AmktZf1QMj9FuxmBEDZ6U5TAYNLtgfZcqQ
uLqJhoZ6c
{
  "network": "testnet",
  "wid": 6,
  "id": "watchtest",
  "watchOnly": true,
  "accountDepth": 1,
  "token": "69a02638a83dae00d6583974fc7862a9ec3afc85d258e86601a678cc631f287d",
  "tokenDepth": 0,
  "master": {
    "encrypted": false
  },
  "balance": {
    "account": -1,
    "tx": 0,
    "coin": 0,
    "unconfirmed": 0,
    "confirmed": 0,
    "lockedUnconfirmed": 0,
    "lockedConfirmed": 0
  }
}
```