### PR TITLE
txmeta: fix confirmations calculation

### DIFF
--- a/lib/primitives/txmeta.js
+++ b/lib/primitives/txmeta.js
@@ -136,7 +136,7 @@ class TXMeta extends bio.Struct {
     json.time = this.time;
     json.confirmations = 0;
 
-    if (chainHeight != null)
+    if (chainHeight != null && this.height !== -1)
       json.confirmations = chainHeight - this.height + 1;
 
     return json;

--- a/test/txmeta-test.js
+++ b/test/txmeta-test.js
@@ -1,0 +1,25 @@
+/* eslint-env mocha */
+/* eslint prefer-arrow-callback: "off" */
+
+'use strict';
+
+const assert = require('./util/assert');
+const Network = require('../lib/protocol/network');
+const TXMeta = require('../lib/primitives/txmeta');
+
+const network = Network.get('regtest');
+
+describe('TXMeta', function() {
+  it('should return JSON for txmeta', async () => {
+    // unconfirmed at height 100
+    const txmeta1 = new TXMeta();
+    const txJSON1 = txmeta1.getJSON(network, null, 100);
+    assert.strictEqual(txJSON1.confirmations, 0);
+
+    // confirmed once at height 100
+    const txmeta2 = TXMeta.fromOptions( {height: 100} );
+    txmeta2.height = 100;
+    const txJSON2 = txmeta2.getJSON(network, null, 100);
+    assert.strictEqual(txJSON2.confirmations, 1);
+  });
+});


### PR DESCRIPTION
Cherry-pick of https://github.com/bcoin-org/bcoin/pull/461

> 
> 
> Current behavior: the unconfirmed tx reports 505 confirmations, which is the current block height plus 2 (`chainheight - txheight + 1`) because `txheight` is `-1` when unconfirmed.
> 
> ```
> $ bwallet-cli send rb1qpymv5nnjcwngwpx93nvxm0wc7470nzu9rz2r99 0.01
> {
>   "hash": "0babb01107d616b27e1831877558e369b00dffd7827fdcd624b7b21434869005",
>   "height": -1,
>   "block": null,
> ...
> 
> $ bcoin-cli tx 0babb01107d616b27e1831877558e369b00dffd7827fdcd624b7b21434869005
> {
>   "hash": "0babb01107d616b27e1831877558e369b00dffd7827fdcd624b7b21434869005",
>   "witnessHash": "aec9b25b8f178ea4bd6b9811e02dbc775986a376b40986b85e1976ef6b25328c",
>   "fee": 2860,
>   "rate": 19861,
>   "mtime": 1526317134,
>   "height": -1,
> ...
>   "hex": "01000000000101c5a2e6171f2054b5c5f2a4e108136dbda11d89735e5918f88a04bc0846a762610000000000ffffffff0240420f00000000001600140936ca4e72c3a68704c58cd86dbdd8f57cf98b8594a4f629010000001976a914df437e604043f2eee2e7c5b77e49b667b9c344a688ac02473044022017e4f6d15e5960a6afed7c770533147113eb53048f5c88619a10eb0df0b5a3b50
> 2207087370b2dddf935d139d59e19fc182473d580baab9c59ee1da9c8f6849254c201210398ec96840a74cdc0084cd5fbc9b9dae4794f88e247fc63379bd6243732a0018000000000",
>   "confirmations": 505
> }
> ```
> After this pull request:
> 
> ```
> $ bcoin-cli tx 8c78001885b0aabcde76ed079c374a1326dff64256ce75033c7b26d8e30fed3b
> {
>   "hash": "8c78001885b0aabcde76ed079c374a1326dff64256ce75033c7b26d8e30fed3b",
>   "witnessHash": "0b109d2b9f6ca86ee8c7fc69bf1618eed9a201d5651bceecfe019e3dfa53908e",
>   "fee": 2860,
>   "rate": 19861,
>   "mtime": 1526317315,
>   "height": -1,
> ...
>   "hex": "01000000000101776ef04e005e29d541a7d8e2a683d3c3b0163643e9ae3aba84dec8b8646a23460000000000ffffffff0240420f00000000001600140936ca4e72c3a68704c58cd86dbdd8f57cf98b8594a4f629010000001976a9143f16fe481a7066747ac5615a195332a27686ac4988ac02483045022100e6026198a5c2eb6b2867b08b67364ce78c76c3db3e84cd841f5cc2110a723052022036b4d35f8c35cbfb93381399f2c9ccea5c5bdb0d1f00811d4cf6cc356ab0534201210398ec96840a74cdc0084cd5fbc9b9dae4794f88e247fc63379bd6243732a0018000000000",
>   "confirmations": 0
> }
> ```
> Also note, `bcoin-cli rpc getrawtransaction` does not behave this way, it accurately reports 0 confirmations.