### PR TITLE
wallet: prevent sendupdate with bad resource

### DIFF
--- a/lib/dns/resource.js
+++ b/lib/dns/resource.js
@@ -1551,6 +1551,30 @@ class Resource extends Struct {
 
     return this;
   }
+
+  isSane() {
+    if (
+      this.canonical ||
+      this.delegate ||
+      this.ns.length ||
+      this.service.length ||
+      this.uri.length ||
+      this.email.length ||
+      this.text.length ||
+      this.location.length ||
+      this.magnet.length ||
+      this.ds.length ||
+      this.tls.length ||
+      this.smime.length ||
+      this.ssh.length ||
+      this.pgp.length ||
+      this.addr.length ||
+      this.extra.length
+    )
+      return true;
+    else
+      return false;
+  }
 }
 
 /*

--- a/lib/wallet/wallet.js
+++ b/lib/wallet/wallet.js
@@ -2250,6 +2250,9 @@ class Wallet extends EventEmitter {
     if (!rules.verifyName(name))
       throw new Error('Invalid name.');
 
+    if(!resource.isSane())
+      throw new Error('Resource is empty');
+
     const rawName = Buffer.from(name, 'ascii');
     const nameHash = rules.hashName(rawName);
     const ns = await this.getNameState(nameHash);
@@ -2326,6 +2329,9 @@ class Wallet extends EventEmitter {
 
     if (!rules.verifyName(name))
       throw new Error('Invalid name.');
+
+    if (!resource.isSane())
+      throw new Error('Resource is empty');
 
     const rawName = Buffer.from(name, 'ascii');
     const nameHash = rules.hashName(rawName);

--- a/test/wallet-test.js
+++ b/test/wallet-test.js
@@ -19,6 +19,7 @@ const Input = require('../lib/primitives/input');
 const Outpoint = require('../lib/primitives/outpoint');
 const Script = require('../lib/script/script');
 const PrivateKey = require('../lib/hd/private.js');
+const Resource = require('../lib/dns/resource');
 
 const KEY1 = 'xprv9s21ZrQH143K3Aj6xQBymM31Zb4BVc7wxqfUhMZrzewdDVCt'
   + 'qUP9iWfcHgJofs25xbaUpCps9GDXj83NiWvQCAkWQhVj5J4CorfnpKX94AZ';
@@ -1461,6 +1462,20 @@ describe('Wallet', function() {
     assert(await wdb.get('alice100'));
     await wdb.remove('alice100');
     assert(!await wdb.get('alice100'));
+  });
+
+  it('should prevent sending malformed resource', async () => {
+    const badResource =
+      Resource.fromJSON({MyCatsBreath: 'SmellsLikeCatFood'});
+
+    let err = null;
+    try {
+      await currentWallet.makeUpdate('wiggum', badResource);
+    } catch (e) {
+      err = e;
+    }
+    assert(err);
+    assert.strictEqual(err.message, 'Resource is empty');
   });
 
   it('should cleanup', async () => {


### PR DESCRIPTION
To reproduce: Win an auction, then attempt to `update` with malformed Resource, wasting your miner fees:
```
$ hsw-rpc --network=regtest sendupdate hello '{"MyCatsBreath":["SmellsLikeCatFood"]}'
```
...results in a tx with a covenant with sad empty bytes:
```
"covenant": {
  "type": 7,
  "action": "UPDATE",
  "items": [
    "3338be694f50c5f338814986cdf0686453a888b84f424d792af4b9202398f392",
    "81040000",
    "00000000"
  ]
}
```
This PR checks the resource for at least one value in any of the possible fields (`ns`, `service`, `uri`...) and if all fields are empty arrays, we throw:
```
Resource is empty
```
I didn't write the counter-test yet (successful update with correctly formed resource) because that also requires an auction process. If #94 gets merged, I can write more tests in the `wallet-test-auctions.js` file introduced by that PR