### PR TITLE
wallet: include the name in "auction not found" and "name has expired" error messages

### DIFF
--- a/lib/wallet/rpc.js
+++ b/lib/wallet/rpc.js
@@ -1735,7 +1735,7 @@ class RPC extends RPCBase {
     const ns = await wallet.getNameStateByName(name);
 
     if (!ns)
-      throw new RPCError(errs.MISC_ERROR, 'Auction not found.');
+      throw new RPCError(errs.MISC_ERROR, `Auction not found: "${name}".`);
 
     const bids = await wallet.getBidsByName(name);
     const reveals = await wallet.getRevealsByName(name);
@@ -1769,7 +1769,7 @@ class RPC extends RPCBase {
     const ns = await wallet.getNameStateByName(name);
 
     if (!ns)
-      throw new RPCError(errs.MISC_ERROR, 'Auction not found.');
+      throw new RPCError(errs.MISC_ERROR, `Auction not found: "${name}".`);
 
     return ns.getJSON(height, network);
   }

--- a/lib/wallet/wallet.js
+++ b/lib/wallet/wallet.js
@@ -1722,7 +1722,7 @@ class Wallet extends EventEmitter {
     const network = this.network;
 
     if (!ns)
-      throw new Error('Auction not found.');
+      throw new Error(`Auction not found: "${name}".`);
 
     if (ns.isExpired(height, network))
       ns.reset(height);
@@ -1942,10 +1942,10 @@ class Wallet extends EventEmitter {
     const network = this.network;
 
     if (!ns)
-      throw new Error('Auction not found.');
+      throw new Error(`Auction not found: "${name}".`);
 
     if (ns.isExpired(height, network))
-      throw new Error('Name has expired!');
+      throw new Error(`Name has expired: "${name}"!`);
 
     const state = ns.state(height, network);
 
@@ -1987,7 +1987,7 @@ class Wallet extends EventEmitter {
     }
 
     if (mtx.outputs.length === 0)
-      throw new Error('No reveals to redeem.');
+      throw new Error(`No reveals to redeem (${name}).`);
 
     return mtx;
   }
@@ -2152,7 +2152,7 @@ class Wallet extends EventEmitter {
     const network = this.network;
 
     if (!ns)
-      throw new Error('Auction not found.');
+      throw new Error(`Auction not found: "${name}".`);
 
     const {hash, index} = ns.owner;
     const coin = await this.getCoin(hash, index);
@@ -2161,7 +2161,7 @@ class Wallet extends EventEmitter {
       throw new Error('Wallet did not win the auction.');
 
     if (ns.isExpired(height, network))
-      throw new Error('Name has expired!');
+      throw new Error(`Name has expired: "${name}"!`);
 
     // Is local?
     if (coin.height < ns.height)
@@ -2229,7 +2229,7 @@ class Wallet extends EventEmitter {
     const network = this.network;
 
     if (!ns)
-      throw new Error('Auction not found.');
+      throw new Error(`Auction not found: "${name}".`);
 
     const {hash, index} = ns.owner;
     const coin = await this.getCoin(hash, index);
@@ -2241,7 +2241,7 @@ class Wallet extends EventEmitter {
       return this._makeRegister(name, resource);
 
     if (ns.isExpired(height, network))
-      throw new Error('Name has expired!');
+      throw new Error(`Name has expired: "${name}"!`);
 
     // Is local?
     if (coin.height < ns.height)
@@ -2343,7 +2343,7 @@ class Wallet extends EventEmitter {
     const network = this.network;
 
     if (!ns)
-      throw new Error('Auction not found.');
+      throw new Error(`Auction not found: "${name}".`);
 
     const {hash, index} = ns.owner;
     const coin = await this.getCoin(hash, index);
@@ -2352,7 +2352,7 @@ class Wallet extends EventEmitter {
       throw new Error(`Wallet does not own: "${name}".`);
 
     if (ns.isExpired(height, network))
-      throw new Error('Name has expired!');
+      throw new Error(`Name has expired: "${name}"!`);
 
     // Is local?
     if (coin.height < ns.height)
@@ -2449,7 +2449,7 @@ class Wallet extends EventEmitter {
     const network = this.network;
 
     if (!ns)
-      throw new Error('Auction not found.');
+      throw new Error(`Auction not found: "${name}".`);
 
     const {hash, index} = ns.owner;
     const coin = await this.getCoin(hash, index);
@@ -2458,7 +2458,7 @@ class Wallet extends EventEmitter {
       throw new Error(`Wallet does not own: "${name}".`);
 
     if (ns.isExpired(height, network))
-      throw new Error('Name has expired!');
+      throw new Error(`Name has expired: "${name}"!`);
 
     // Is local?
     if (coin.height < ns.height)
@@ -2562,7 +2562,7 @@ class Wallet extends EventEmitter {
     const network = this.network;
 
     if (!ns)
-      throw new Error('Auction not found.');
+      throw new Error(`Auction not found: "${name}".`);
 
     const {hash, index} = ns.owner;
     const coin = await this.getCoin(hash, index);
@@ -2571,7 +2571,7 @@ class Wallet extends EventEmitter {
       throw new Error(`Wallet does not own: "${name}".`);
 
     if (ns.isExpired(height, network))
-      throw new Error('Name has expired!');
+      throw new Error(`Name has expired: "${name}"!`);
 
     // Is local?
     if (coin.height < ns.height)
@@ -2660,7 +2660,7 @@ class Wallet extends EventEmitter {
     const network = this.network;
 
     if (!ns)
-      throw new Error('Auction not found.');
+      throw new Error(`Auction not found: "${name}".`);
 
     const {hash, index} = ns.owner;
     const coin = await this.getCoin(hash, index);
@@ -2669,7 +2669,7 @@ class Wallet extends EventEmitter {
       throw new Error(`Wallet does not own: "${name}".`);
 
     if (ns.isExpired(height, network))
-      throw new Error('Name has expired!');
+      throw new Error(`Name has expired: "${name}"!`);
 
     // Is local?
     if (coin.height < ns.height)
@@ -2774,7 +2774,7 @@ class Wallet extends EventEmitter {
     const network = this.network;
 
     if (!ns)
-      throw new Error('Auction not found.');
+      throw new Error(`Auction not found: "${name}".`);
 
     const {hash, index} = ns.owner;
     const coin = await this.getCoin(hash, index);
@@ -2787,7 +2787,7 @@ class Wallet extends EventEmitter {
       throw new Error(`Wallet does not own: "${name}".`);
 
     if (ns.isExpired(height, network))
-      throw new Error('Name has expired!');
+      throw new Error(`Name has expired: "${name}"!`);
 
     const state = ns.state(height, network);
 

--- a/test/util/memwallet.js
+++ b/test/util/memwallet.js
@@ -1091,7 +1091,7 @@ class MemWallet {
     const network = this.network;
 
     if (!ns)
-      throw new Error('Auction not found.');
+      throw new Error(`Auction not found: "${name}".`);
 
     if (ns.isExpired(height, network))
       ns.reset(height);
@@ -1159,10 +1159,10 @@ class MemWallet {
     const network = this.network;
 
     if (!ns)
-      throw new Error('Auction not found.');
+      throw new Error(`Auction not found: "${name}".`);
 
     if (ns.isExpired(height, network))
-      throw new Error('Name has expired!');
+      throw new Error(`Name has expired: "${name}"!`);
 
     const state = ns.state(height, network);
 
@@ -1224,7 +1224,7 @@ class MemWallet {
     const network = this.network;
 
     if (!ns)
-      throw new Error('Auction not found.');
+      throw new Error(`Auction not found: "${name}".`);
 
     const coin = this.getCoin(ns.owner.toKey());
 
@@ -1232,7 +1232,7 @@ class MemWallet {
       throw new Error('Wallet did not win the auction.');
 
     if (ns.isExpired(height, network))
-      throw new Error('Name has expired!');
+      throw new Error(`Name has expired: "${name}"!`);
 
     // Is local?
     if (coin.height < ns.height)
@@ -1291,7 +1291,7 @@ class MemWallet {
     const network = this.network;
 
     if (!ns)
-      throw new Error('Auction not found.');
+      throw new Error(`Auction not found: "${name}".`);
 
     const coin = this.getCoin(ns.owner.toKey());
 
@@ -1302,7 +1302,7 @@ class MemWallet {
       return this.createRegister(name, resource, options);
 
     if (ns.isExpired(height, network))
-      throw new Error('Name has expired!');
+      throw new Error(`Name has expired: "${name}"!`);
 
     // Is local?
     if (coin.height < ns.height)
@@ -1348,7 +1348,7 @@ class MemWallet {
     const network = this.network;
 
     if (!ns)
-      throw new Error('Auction not found.');
+      throw new Error(`Auction not found: "${name}".`);
 
     const coin = this.getCoin(ns.owner.toKey());
 
@@ -1356,7 +1356,7 @@ class MemWallet {
       throw new Error(`Wallet does not own: "${name}".`);
 
     if (ns.isExpired(height, network))
-      throw new Error('Name has expired!');
+      throw new Error(`Name has expired: "${name}"!`);
 
     // Is local?
     if (coin.height < ns.height)
@@ -1406,7 +1406,7 @@ class MemWallet {
     const network = this.network;
 
     if (!ns)
-      throw new Error('Auction not found.');
+      throw new Error(`Auction not found: "${name}".`);
 
     const coin = this.getCoin(ns.owner.toKey());
 
@@ -1414,7 +1414,7 @@ class MemWallet {
       throw new Error(`Wallet does not own: "${name}".`);
 
     if (ns.isExpired(height, network))
-      throw new Error('Name has expired!');
+      throw new Error(`Name has expired: "${name}"!`);
 
     // Is local?
     if (coin.height < ns.height)
@@ -1469,7 +1469,7 @@ class MemWallet {
     const network = this.network;
 
     if (!ns)
-      throw new Error('Auction not found.');
+      throw new Error(`Auction not found: "${name}".`);
 
     const coin = this.getCoin(ns.owner.toKey());
 
@@ -1477,7 +1477,7 @@ class MemWallet {
       throw new Error(`Wallet does not own: "${name}".`);
 
     if (ns.isExpired(height, network))
-      throw new Error('Name has expired!');
+      throw new Error(`Name has expired: "${name}"!`);
 
     // Is local?
     if (coin.height < ns.height)
@@ -1519,7 +1519,7 @@ class MemWallet {
     const network = this.network;
 
     if (!ns)
-      throw new Error('Auction not found.');
+      throw new Error(`Auction not found: "${name}".`);
 
     const coin = this.getCoin(ns.owner.toKey());
 
@@ -1527,7 +1527,7 @@ class MemWallet {
       throw new Error(`Wallet does not own: "${name}".`);
 
     if (ns.isExpired(height, network))
-      throw new Error('Name has expired!');
+      throw new Error(`Name has expired: "${name}"!`);
 
     // Is local?
     if (coin.height < ns.height)
@@ -1586,7 +1586,7 @@ class MemWallet {
     const network = this.network;
 
     if (!ns)
-      throw new Error('Auction not found.');
+      throw new Error(`Auction not found: "${name}".`);
 
     const coin = this.getCoin(ns.owner.toKey());
 
@@ -1598,7 +1598,7 @@ class MemWallet {
       throw new Error(`Wallet does not own: "${name}".`);
 
     if (ns.isExpired(height, network))
-      throw new Error('Name has expired!');
+      throw new Error(`Name has expired: "${name}"!`);
 
     const state = ns.state(height, network);
 


### PR DESCRIPTION
### Before

The wallet would throw "Auction not found" and "Name has expired" errors if something went wrong. It was not easy to figure out which name led to which error.

### After

The "Auction not found" and "Name has expired" errors now include the name the error message refers to. This makes it easier to debug what went wrong.