### PR TITLE
all: add READMEs to bin/ and test/

### DIFF
--- a/bin/README.md
+++ b/bin/README.md
@@ -1,0 +1,8 @@
+# bin
+Executable scripts related to **HSD**.
+- `cli` - DEPRECATED
+- `hsd` - The entry point for **HSD**.
+- `hsw` - The entry point for **HSD**'s wallet interface.
+- `node` - Initialization code for **HSD**'s full node.
+- `spvnode` - Initialization code for **HSD**'s SPV node.
+- `wallet` - Initialization code for **HSD**'s wallet interface.

--- a/test/README.md
+++ b/test/README.md
@@ -1,0 +1,5 @@
+# test
+Unit tests related to the project.
+
+- `data/` - Ephemeral  data used during unit tests.
+- `util/` - Utility functions to assist unit testing.


### PR DESCRIPTION
Adding READMEs to some modules, in reference to #102.

Also, should there exist one of these READMEs for every module in `lib/`?