### PR TITLE
wallet: support the creation of unsigned auction txs

### DIFF
--- a/lib/primitives/mtx.js
+++ b/lib/primitives/mtx.js
@@ -1300,7 +1300,12 @@ class MTX extends TX {
    */
 
   format() {
-    return super.format(this.view);
+    const mtx = super.format(this.view);
+
+    if (this.paths)
+      mtx.paths = this.paths;
+
+    return mtx;
   }
 
   /**
@@ -1309,7 +1314,12 @@ class MTX extends TX {
    */
 
   toJSON() {
-    return super.getJSON(null, this.view);
+    const json = super.getJSON(null, this.view);
+
+    if (this.paths)
+      json.paths = this.paths;
+
+    return json;
   }
 
   /**
@@ -1319,7 +1329,12 @@ class MTX extends TX {
    */
 
   getJSON(network) {
-    return super.getJSON(network, this.view);
+    const json = super.getJSON(network, this.view);
+
+    if (this.paths)
+      json.paths = this.paths;
+
+    return json;
   }
 
   /**
@@ -1329,6 +1344,9 @@ class MTX extends TX {
 
   fromJSON(json) {
     super.fromJSON(json);
+
+    if (json.paths)
+      this.paths = json.paths;
 
     for (let i = 0; i < json.inputs.length; i++) {
       const input = json.inputs[i];
@@ -1343,6 +1361,7 @@ class MTX extends TX {
       coin.index = prevout.index;
 
       this.view.addCoin(coin);
+      this.inputs[i].coin = coin;
     }
 
     return this;

--- a/lib/wallet/layout.js
+++ b/lib/wallet/layout.js
@@ -16,7 +16,7 @@ const bdb = require('bdb');
  *  D -> wallet id depth
  *  p[addr-hash] -> wallet ids
  *  P[wid][addr-hash] -> path data
- *  r[wid][index][hash] -> path account index
+ *  r[wid][index][hash] -> dummy
  *  w[wid] -> wallet
  *  W[wid] -> wallet id
  *  l[id] -> wid

--- a/lib/wallet/rpc.js
+++ b/lib/wallet/rpc.js
@@ -155,6 +155,7 @@ class RPC extends RPCBase {
     this.add('sendfrom', this.sendFrom);
     this.add('sendmany', this.sendMany);
     this.add('sendtoaddress', this.sendToAddress);
+    this.add('createsendtoaddress', this.createSendToAddress);
     this.add('setaccount', this.setAccount);
     this.add('settxfee', this.setTXFee);
     this.add('signmessage', this.signMessage);
@@ -186,6 +187,16 @@ class RPC extends RPCBase {
     this.add('sendfinalize', this.sendFinalize);
     this.add('sendrevoke', this.sendRevoke);
     this.add('importnonce', this.importNonce);
+    this.add('createopen', this.createOpen);
+    this.add('createbid', this.createBid);
+    this.add('createreveal', this.createReveal);
+    this.add('createredeem', this.createRedeem);
+    this.add('createupdate', this.createUpdate);
+    this.add('createrenewal', this.createRenewal);
+    this.add('createtransfer', this.createTransfer);
+    this.add('createcancel', this.createCancel);
+    this.add('createfinalize', this.createFinalize);
+    this.add('createrevoke', this.createRevoke);
 
     // Compat
     this.add('getauctions', this.getNames);
@@ -1402,34 +1413,65 @@ class RPC extends RPCBase {
   }
 
   async sendToAddress(args, help) {
-    if (help || args.length < 2 || args.length > 5) {
-      throw new RPCError(errs.MISC_ERROR,
-        'sendtoaddress "address" amount'
-        + ' ( "comment" "comment-to" subtractfeefromamount )');
-    }
-
+    const opts = this._validateSendToAddress(args, help, 'sendtoaddress');
     const wallet = this.wallet;
-    const valid = new Validator(args);
-    const str = valid.str(0);
-    const value = valid.ufixed(1, EXP);
-    const subtract = valid.bool(4, false);
-
-    const addr = parseAddress(str, this.network);
-
-    if (!addr || value == null)
-      throw new RPCError(errs.TYPE_ERROR, 'Invalid parameter.');
 
     const options = {
-      subtractFee: subtract,
+      subtractFee: opts.subtract,
       outputs: [{
-        address: addr,
-        value: value
+        address: opts.addr,
+        value: opts.value
       }]
     };
 
     const tx = await wallet.send(options);
 
     return tx.txid();
+  }
+
+  async createSendToAddress(args, help) {
+    const opts = this._validateSendToAddress(args, help, 'createsendtoaddress');
+    const wallet = this.wallet;
+
+    const options = {
+      paths: true,
+      account: opts.account,
+      subtractFee: opts.subtract,
+      outputs: [{
+        address: opts.addr,
+        value: opts.value
+      }]
+    };
+
+    const mtx = await wallet.createTX(options);
+
+    return mtx.getJSON(this.network);
+  }
+
+  _validateSendToAddress(args, help, method) {
+    const msg = `${method} "address" amount `;
+      + '( "comment" "comment-to" subtractfeefromamount "account" )';
+
+    if (help || args.length < 2 || args.length > 6)
+      throw new RPCError(errs.MISC_ERROR, msg);
+
+    const valid = new Validator(args);
+    const str = valid.str(0);
+    const value = valid.ufixed(1, EXP);
+    const subtract = valid.bool(4, false);
+    const account = valid.str(5);
+
+    const addr = parseAddress(str, this.network);
+
+    if (!addr || value == null)
+      throw new RPCError(errs.TYPE_ERROR, 'Invalid parameter.');
+
+    return {
+      subtract,
+      addr,
+      value,
+      account
+    };
   }
 
   async setAccount(args, help) {
@@ -1877,31 +1919,75 @@ class RPC extends RPCBase {
   }
 
   async sendOpen(args, help) {
-    if (help || args.length < 1 || args.length > 2)
-      throw new RPCError(errs.MISC_ERROR, 'sendopen "name" ( force )');
-
+    const opts = this._validateOpen(args, help, 'sendopen');
     const wallet = this.wallet;
-    const valid = new Validator(args);
-    const name = valid.str(0);
-    const force = valid.bool(1, false);
-
-    if (!name || !rules.verifyName(name))
-      throw new RPCError(errs.TYPE_ERROR, 'Invalid name.');
-
-    const tx = await wallet.sendOpen(name, force);
+    const tx = await wallet.sendOpen(opts.name, opts.force, {
+      account: opts.account
+    });
 
     return tx.getJSON(this.network);
   }
 
-  async sendBid(args, help) {
-    if (help || args.length !== 3)
-      throw new RPCError(errs.MISC_ERROR, 'sendbid "name" bid value');
-
+  async createOpen(args, help) {
+    const opts = this._validateOpen(args, help, 'createopen');
     const wallet = this.wallet;
+    const mtx = await wallet.createOpen(opts.name, opts.force, {
+      paths: true,
+      account: opts.account
+    });
+
+    return mtx.getJSON(this.network);
+  }
+
+  _validateOpen(args, help, method) {
+    const msg = `${method} "name" ( force "account" )`;
+
+    if (help || args.length < 1 || args.length > 3)
+      throw new RPCError(errs.MISC_ERROR, msg);
+
+    const valid = new Validator(args);
+    const name = valid.str(0);
+    const force = valid.bool(1, false);
+    const account = valid.str(2);
+
+    if (!name || !rules.verifyName(name))
+      throw new RPCError(errs.TYPE_ERROR, 'Invalid name.');
+
+    return {name, force, account};
+  }
+
+  async sendBid(args, help) {
+    const opts = this._validateBid(args, help, 'sendbid');
+    const wallet = this.wallet;
+    const tx = await wallet.sendBid(opts.name, opts.bid, opts.value, {
+      account: opts.account
+    });
+
+    return tx.getJSON(this.network);
+  }
+
+  async createBid(args, help) {
+    const opts = this._validateBid(args, help, 'createbid');
+    const wallet = this.wallet;
+    const mtx = await wallet.createBid(opts.name, opts.bid, opts.value, {
+      paths: true,
+      account: opts.account
+    });
+
+    return mtx.getJSON(this.network);
+  }
+
+  _validateBid(args, help, method) {
+    const msg = `${method} "name" bid value ( "account" )`;
+
+    if (help || args.length < 3 || args.length > 4)
+      throw new RPCError(errs.MISC_ERROR, msg);
+
     const valid = new Validator(args);
     const name = valid.str(0);
     const bid = valid.ufixed(1, EXP);
     const value = valid.ufixed(2, EXP);
+    const account = valid.str(3);
 
     if (!name || !rules.verifyName(name))
       throw new RPCError(errs.TYPE_ERROR, 'Invalid name.');
@@ -1912,61 +1998,148 @@ class RPC extends RPCBase {
     if (bid > value)
       throw new RPCError(errs.TYPE_ERROR, 'Invalid bid.');
 
-    const tx = await wallet.sendBid(name, bid, value);
-
-    return tx.getJSON(this.network);
+    return {
+      name,
+      bid,
+      value,
+      account
+    };
   }
 
   async sendReveal(args, help) {
-    if (help || args.length > 1)
-      throw new RPCError(errs.MISC_ERROR, 'sendreveal "name"');
-
+    const opts = this._validateReveal(args, help, 'sendreveal');
     const wallet = this.wallet;
-    const valid = new Validator(args);
-    const name = valid.str(0);
 
-    if (!name) {
+    if (!opts.name) {
       const tx = await wallet.sendRevealAll();
       return tx.getJSON(this.network);
     }
 
-    if (!rules.verifyName(name))
+    if (!rules.verifyName(opts.name))
       throw new RPCError(errs.TYPE_ERROR, 'Invalid name.');
 
-    const tx = await wallet.sendReveal(name);
+    const tx = await wallet.sendReveal(opts.name, { account: opts.account });
 
     return tx.getJSON(this.network);
+  }
+
+  async createReveal(args, help) {
+    const opts = this._validateReveal(args, help, 'createreveal');
+    const wallet = this.wallet;
+
+    if (!opts.name) {
+      const mtx = await wallet.createRevealAll({
+        paths: true,
+        account: opts.account
+      });
+
+      return mtx.getJSON(this.network);
+    }
+
+    if (!rules.verifyName(opts.name))
+      throw new RPCError(errs.TYPE_ERROR, 'Invalid name.');
+
+    const mtx = await wallet.createReveal(opts.name, {
+      paths: true,
+      account: opts.account
+    });
+
+    return mtx.getJSON(this.network);
+  }
+
+  _validateReveal(args, help, method) {
+    if (help || args.length > 2)
+      throw new RPCError(errs.MISC_ERROR, `${method} "name" ( "account" )`);
+
+    const valid = new Validator(args);
+    const name = valid.str(0);
+    const account = valid.str(1);
+
+    return {name, account}
   }
 
   async sendRedeem(args, help) {
-    if (help || args.length > 1)
-      throw new RPCError(errs.MISC_ERROR, 'sendredeem "name"');
-
+    const opts = this._validateRedeem(args, help, 'sendredeem');
     const wallet = this.wallet;
-    const valid = new Validator(args);
-    const name = valid.str(0);
 
-    if (!name) {
-      const tx = await wallet.sendRedeemAll();
+    if (!opts.name) {
+      const tx = await wallet.sendRedeemAll({ account: opts.account });
       return tx.getJSON(this.network);
     }
 
-    if (!rules.verifyName(name))
+    if (!rules.verifyName(opts.name))
       throw new RPCError(errs.TYPE_ERROR, 'Invalid name.');
 
-    const tx = await wallet.sendRedeem(name);
+    const tx = await wallet.sendRedeem(opts.name, {
+      account: opts.account
+    });
 
     return tx.getJSON(this.network);
   }
 
-  async sendUpdate(args, help) {
-    if (help || args.length !== 2)
-      throw new RPCError(errs.MISC_ERROR, 'sendupdate "name" "data"');
-
+  async createRedeem(args, help) {
+    const opts = this._validateRedeem(args, help, 'createredeem');
     const wallet = this.wallet;
+
+    if (!opts.name) {
+      const mtx = await wallet.createRedeemAll({
+        paths: true,
+        account: opts.account
+      });
+      return mtx.getJSON(this.network);
+    }
+
+    if (!rules.verifyName(opts.name))
+      throw new RPCError(errs.TYPE_ERROR, 'Invalid name.');
+
+    const mtx = await wallet.createRedeem(opts.name, {
+      paths: true,
+      account: opts.account
+    });
+
+    return mtx.getJSON(this.network);
+  }
+
+  _validateRedeem(args, help, method) {
+    if (help || args.length < 1 || args.length > 2)
+      throw new RPCError(errs.MISC_ERROR, `${method} "name" ( "account" )`);
+
+    const valid = new Validator(args);
+    const name = valid.str(0);
+    const account = valid.str(1);
+
+    return {name, account};
+  }
+
+  async sendUpdate(args, help) {
+    const opts = this._validateUpdate(args, help, 'sendupdate');
+    const wallet = this.wallet;
+    const tx = await wallet.sendUpdate(opts.name, opts.resource, {
+      account: opts.account
+    });
+
+    return tx.getJSON(this.network);
+  }
+
+  async createUpdate(args, help) {
+    const opts = this._validateUpdate(args, help, 'createupdate');
+    const wallet = this.wallet;
+    const mtx = await wallet.createUpdate(opts.name, opts.resource, {
+      paths: true,
+      account: opts.account
+    });
+
+    return mtx.getJSON(this.network);
+  }
+
+  _validateUpdate(args, help, method) {
+    if (help || args.length < 2 || args.length > 3)
+      throw new RPCError(errs.MISC_ERROR, `${method} "name" "data" ( "account" )`);
+
     const valid = new Validator(args);
     const name = valid.str(0);
     const data = valid.obj(1);
+    const account = valid.str(2);
 
     if (!name || !rules.verifyName(name))
       throw new RPCError(errs.TYPE_ERROR, 'Invalid name.');
@@ -1975,35 +2148,76 @@ class RPC extends RPCBase {
       throw new RPCError(errs.TYPE_ERROR, 'Invalid hex string.');
 
     const resource = Resource.fromJSON(data);
-    const tx = await wallet.sendUpdate(name, resource);
+
+    return {
+      name,
+      resource,
+      account
+    };
+  }
+
+  async sendRenewal(args, help) {
+    const wallet = this.wallet;
+    const opts = this._validateRenewal(args, help, 'sendrenewal');
+    const tx = await wallet.sendRenewal(opts.name, { account: opts.account });
 
     return tx.getJSON(this.network);
   }
 
-  async sendRenewal(args, help) {
-    if (help || args.length !== 1)
-      throw new RPCError(errs.MISC_ERROR, 'sendrenewal "name"');
-
+  async createRenewal(args, help) {
     const wallet = this.wallet;
+    const opts = this._validateRenewal(args, help, 'createrenewal');
+    const mtx = await wallet.createRenewal(opts.name, {
+      paths: true,
+      account: opts.account
+    });
+
+    return mtx.getJSON(this.network);
+  }
+
+  _validateRenewal(args, help, method) {
+    if (help || args.length < 1 || args.length > 2)
+      throw new RPCError(errs.MISC_ERROR, `${method} "name" ( "account" )`);
+
     const valid = new Validator(args);
     const name = valid.str(0);
+    const account = valid.str(1);
 
     if (!name || !rules.verifyName(name))
       throw new RPCError(errs.TYPE_ERROR, 'Invalid name.');
 
-    const tx = await wallet.sendRenewal(name);
+    return {name, account};
+  }
+
+  async sendTransfer(args, help) {
+    const opts = this._validateTransfer(args, help, 'sendtransfer');
+    const wallet = this.wallet;
+    const tx = await wallet.sendTransfer(opts.name, opts.address, {
+      account: opts.account
+    });
 
     return tx.getJSON(this.network);
   }
 
-  async sendTransfer(args, help) {
-    if (help || args.length !== 2)
-      throw new RPCError(errs.MISC_ERROR, 'sendtransfer "name" "address"');
-
+  async createTransfer(args, help) {
+    const opts = this._validateTransfer(args, help, 'createtransfer');
     const wallet = this.wallet;
+    const tx = await wallet.createTransfer(opts.name, opts.address, {
+      paths: true,
+      account: opts.account
+    });
+
+    return tx.getJSON(this.network);
+  }
+
+  _validateTransfer(args, help, method) {
+    if (help || args.length < 2 || args.length > 3)
+      throw new RPCError(errs.MISC_ERROR, `${method} "name" "address" ( "account" )`);
+
     const valid = new Validator(args);
     const name = valid.str(0);
     const addr = valid.str(1);
+    const account = valid.str(2);
 
     if (!name || !rules.verifyName(name))
       throw new RPCError(errs.TYPE_ERROR, 'Invalid name.');
@@ -2012,57 +2226,117 @@ class RPC extends RPCBase {
       throw new RPCError(errs.TYPE_ERROR, 'Invalid address.');
 
     const address = parseAddress(addr, this.network);
-    const tx = await wallet.sendTransfer(name, address);
 
-    return tx.getJSON(this.network);
+    return {
+      name,
+      address,
+      account
+    };
   }
 
   async sendCancel(args, help) {
-    if (help || args.length !== 1)
-      throw new RPCError(errs.MISC_ERROR, 'sendcancel "name"');
-
+    const opts = this._validateCancel(args, help, 'sendcancel');
     const wallet = this.wallet;
+    const tx = await wallet.sendCancel(opts.name, {
+      account: opts.account
+    });
+
+    return tx.getJSON(this.network);
+  }
+
+  async createCancel(args, help) {
+    const opts = this._validateCancel(args, help, 'createcancel');
+    const wallet = this.wallet;
+    const mtx = await wallet.createCancel(opts.name, {
+      paths: true,
+      account: opts.account
+    });
+
+    return mtx.getJSON(this.network);
+  }
+
+  _validateCancel(args, help, method) {
+    if (help || args.length < 1 || args.length > 2)
+      throw new RPCError(errs.MISC_ERROR, `${method} "name" ( "account" )`);
+
     const valid = new Validator(args);
     const name = valid.str(0);
+    const account = valid.str(1);
 
     if (!name || !rules.verifyName(name))
       throw new RPCError(errs.TYPE_ERROR, 'Invalid name.');
 
-    const tx = await wallet.sendCancel(name);
-
-    return tx.getJSON(this.network);
+    return {name, account};
   }
 
   async sendFinalize(args, help) {
-    if (help || args.length !== 1)
-      throw new RPCError(errs.MISC_ERROR, 'sendfinalize "name"');
-
+    const opts = this._validateFinalize(args, help, 'sendfinalize');
     const wallet = this.wallet;
-    const valid = new Validator(args);
-    const name = valid.str(0);
-
-    if (!name || !rules.verifyName(name))
-      throw new RPCError(errs.TYPE_ERROR, 'Invalid name.');
-
-    const tx = await wallet.sendFinalize(name);
+    const tx = await wallet.sendFinalize(opts.name, {
+      account: opts.account
+    });
 
     return tx.getJSON(this.network);
   }
 
-  async sendRevoke(args, help) {
-    if (help || args.length !== 1)
-      throw new RPCError(errs.MISC_ERROR, 'sendrevoke "name"');
-
+  async createFinalize(args, help) {
+    const opts = this._validateFinalize(args, help, 'createfinalize');
     const wallet = this.wallet;
+    const mtx = await wallet.createFinalize(opts.name, {
+      paths: true,
+      account: opts.account
+    });
+
+    return mtx.getJSON(this.network);
+  }
+
+  _validateFinalize(args, help, method) {
+    if (help || args.length < 1 || args.length > 2)
+      throw new RPCError(errs.MISC_ERROR, `${method} "name" ( "account" )`);
+
     const valid = new Validator(args);
     const name = valid.str(0);
+    const account = valid.str(1);
 
     if (!name || !rules.verifyName(name))
       throw new RPCError(errs.TYPE_ERROR, 'Invalid name.');
 
-    const tx = await wallet.sendRevoke(name);
+    return {name, account};
+  }
+
+  async sendRevoke(args, help) {
+    const opts = this._validateRevoke(args, help, 'sendrevoke');
+    const wallet = this.wallet;
+    const tx = await wallet.sendRevoke(opts.name, {
+      account: opts.account
+    });
 
     return tx.getJSON(this.network);
+  }
+
+  async createRevoke(args, help) {
+    const opts = this._validateRevoke(args, help, 'createrevoke');
+    const wallet = this.wallet;
+    const mtx = await wallet.createRevoke(opts.name, {
+      paths: true,
+      account: opts.account
+    });
+
+    return mtx.getJSON(this.network);
+  }
+
+  _validateRevoke(args, help, method) {
+    if (help || args.length < 1 || args.length > 2)
+      throw new RPCError(errs.MISC_ERROR, `${method} "name" ( "account" )`);
+
+    const valid = new Validator(args);
+    const name = valid.str(0);
+    const account = valid.str(1);
+
+    if (!name || !rules.verifyName(name))
+      throw new RPCError(errs.TYPE_ERROR, 'Invalid name.');
+
+    return {name, account}
   }
 
   async importNonce(args, help) {

--- a/lib/wallet/wallet.js
+++ b/lib/wallet/wallet.js
@@ -2982,6 +2982,10 @@ class Wallet extends EventEmitter {
     if (options.locktime != null)
       mtx.setLocktime(options.locktime);
 
+    // Add the hd paths for each input to the mtx.
+    if (options.paths !== false)
+      await this.addPaths(mtx);
+
     // Consensus sanity checks.
     assert(mtx.isSane(), 'TX failed sanity check.');
     assert(mtx.verifyInputs(this.wdb.height + 1, this.network),
@@ -3183,6 +3187,60 @@ class Wallet extends EventEmitter {
       await this.wdb.send(tx);
 
     return txs;
+  }
+
+
+  /**
+   * Add necessary HD paths for signing a transaction.
+   * The paths object is a map keyed by coin address.
+   * @param {MTX} mtx
+   * @returns {Promise}
+   */
+
+  async addPaths(mtx) {
+    assert(mtx.mutable);
+
+    if (!mtx.hasCoins())
+      throw new Error('Not all coins available.');
+
+    const network = this.network.type;
+    const addrs = await mtx.getInputAddresses(mtx);
+
+    for (const addr of addrs) {
+      let path = await this.getPath(addr);
+
+      if (!path)
+        continue;
+
+      if (!mtx.paths)
+        mtx.paths = Object.create(null);
+
+      const address = addr.toString(this.network.type);
+      const account = await this.getAccount(path.account);
+
+      if (!account)
+        continue;
+
+      const purpose = 44;
+      const coinType = this.network.keyPrefix.coinType;
+
+      // The account index on the path may be wrong.
+      // We must read it from the stored xpub to be
+      // sure of its correctness.
+      //
+      // For more details see:
+      // https://github.com/bcoin-org/bcoin/issues/698.
+      let accountIndex = account.accountKey.childIndex;
+
+      // Unharden the account index, if necessary.
+      if (accountIndex & HD.common.HARDENED)
+        accountIndex ^= HD.common.HARDENED;
+
+      const hardened = `${purpose}'/${coinType}'/${accountIndex}'`;
+      const unhardened = `${path.branch}/${path.index}`
+
+      mtx.paths[address] = `m/${hardened}/${unhardened}`;
+    }
   }
 
   /**


### PR DESCRIPTION
This PR introduces new RPC calls, for each covenant type, which create unsigned txs to be signed offline. This PR also introduces a paths object to the MTX class. This object is used to indicate the HD paths of the signing keys. The MTX class has also been updated to persist coin information during de/serialization.

This functionality allows hardware wallet signing. End-to-end tests can be found in [hsd-ledger][hsd-ledger] and require a Ledger Nanos S hardware wallet.

This PR supersedes #90.

[hsd-ledger]: https://github.com/boymanjor/hsd-ledger/blob/master/test/e2e/hsd-test.js