### PR TITLE
rpc: new wallet rpc 'getaddressinfo'

### DIFF
--- a/lib/node/rpc.js
+++ b/lib/node/rpc.js
@@ -2093,8 +2093,10 @@ class RPC extends RPCBase {
     return {
       isvalid: true,
       address: addr.toString(this.network),
-      ismine: false,
-      iswatchonly: false
+      isscript: addr.isScripthash(),
+      isspendable: !addr.isUnspendable(),
+      witness_version: addr.version,
+      witness_program: addr.hash.toString('hex')
     };
   }
 

--- a/lib/wallet/rpc.js
+++ b/lib/wallet/rpc.js
@@ -129,6 +129,7 @@ class RPC extends RPCBase {
     this.add('getaccountaddress', this.getAccountAddress);
     this.add('getaccount', this.getAccount);
     this.add('getaddressesbyaccount', this.getAddressesByAccount);
+    this.add('getaddressinfo', this.getAddressInfo);
     this.add('getbalance', this.getBalance);
     this.add('getnewaddress', this.getNewAddress);
     this.add('getrawchangeaddress', this.getRawChangeAddress);
@@ -458,6 +459,31 @@ class RPC extends RPCBase {
     }
 
     return addrs;
+  }
+
+  async getAddressInfo(args, help) {
+    if (help || args.length !== 1)
+      throw new RPCError(errs.MISC_ERROR, 'getaddressinfo "address"');
+
+    const valid = new Validator(args);
+    const addr = valid.str(0, '');
+    const address = parseAddress(addr, this.network);
+
+    const script = Script.decode(address.hash);
+    const wallet = this.wallet.toJSON();
+
+    const path = await this.wallet.getPath(address);
+
+    return {
+      address: address.toString(this.network),
+      ismine: path != null,
+      iswatchonly: wallet.watchOnly,
+      ischange: path ? path.branch === 1 : false,
+      isspendable: !address.isUnspendable(),
+      isscript: address.isScripthash(),
+      witness_version: address.version,
+      witness_program: script.toHex()
+    };
   }
 
   async getBalance(args, help) {

--- a/test/node-test.js
+++ b/test/node-test.js
@@ -510,10 +510,12 @@ describe('Node', function() {
     }, {});
 
     assert.deepStrictEqual(json.result, {
-      isvalid: true,
       address: addr.toString(node.network),
-      ismine: false,
-      iswatchonly: false
+      isvalid: true,
+      isscript: false,
+      isspendable: true,
+      witness_version: addr.version,
+      witness_program: addr.hash.toString('hex')
     });
   });
 

--- a/test/util/assert.js
+++ b/test/util/assert.js
@@ -107,6 +107,18 @@ assert.notBufferEqual = function notBufferEqual(actual, expected, message) {
   }
 };
 
+// node V10 implements assert.rejects() but this is compatible with V8
+assert.asyncThrows = async function asyncThrows(func, expectedError) {
+  let err = null;
+  try {
+    await func();
+  } catch (e) {
+    err = e;
+  }
+  const re = new RegExp('^' + expectedError);
+  assert(re.test(err.message));
+};
+
 function _isString(value, message, stackStartFunction) {
   if (typeof value !== 'string') {
     throw new assert.AssertionError({

--- a/test/wallet-rpc-test.js
+++ b/test/wallet-rpc-test.js
@@ -1,0 +1,249 @@
+/* eslint-env mocha */
+
+'use strict';
+
+const {NodeClient,WalletClient} = require('hs-client');
+const assert = require('./util/assert');
+const FullNode = require('../lib/node/fullnode');
+const Network = require('../lib/protocol/network');
+const Mnemonic = require('../lib/hd/mnemonic');
+const HDPrivateKey = require('../lib/hd/private');
+const Script = require('../lib/script/script');
+const Address = require('../lib/primitives/address');
+const network = Network.get('regtest');
+const mnemonics = require('./data/mnemonic-english.json');
+// Commonly used test mnemonic
+const phrase = mnemonics[0][1];
+
+const node = new FullNode({
+  network: network.type,
+  apiKey: 'bar',
+  walletAuth: true,
+  memory: true,
+  workers: true,
+  plugins: [require('../lib/wallet/plugin')]
+});
+
+const nclient = new NodeClient({
+  port: network.rpcPort,
+  apiKey: 'bar'
+});
+
+const wclient = new WalletClient({
+  port: network.walletPort,
+  apiKey: 'bar'
+});
+
+describe('Wallet RPC Methods', function() {
+  this.timeout(15000);
+
+  let xpub;
+
+  before(async () => {
+    await node.open();
+    await nclient.open();
+    await wclient.open();
+
+    // Derive the xpub using the well known
+    // mnemonic and network's coin type
+    const mnemonic = Mnemonic.fromPhrase(phrase);
+    const priv = HDPrivateKey.fromMnemonic(mnemonic);
+    const type = network.keyPrefix.coinType;
+    const key = priv.derive(44, true).derive(type, true).derive(0, true);
+
+    xpub = key.toPublic();
+
+    assert.equal(phrase, [
+      'abandon', 'abandon', 'abandon', 'abandon',
+      'abandon', 'abandon', 'abandon', 'abandon',
+      'abandon', 'abandon', 'abandon', 'about'
+    ].join(' '));
+  });
+
+  after(async () => {
+    await nclient.close();
+    await wclient.close();
+    await node.close();
+  });
+
+  describe('getaddressinfo', () => {
+    const watchOnlyWalletId = 'foo';
+    const standardWalletId = 'bar';
+
+    // m/44'/5355'/0'/0/{0,1}
+    const pubkeys = [
+      Buffer.from('03253ea6d6486d1b9cc3a'
+        + 'b01a9a321d65c350c6c26a9c536633e2ef36163316bf2', 'hex'),
+      Buffer.from('02cd38edb6f9cb4fd7380'
+        + '3b49aed97bfa95ef402cac2c34e8f551f8537811d2159', 'hex')
+    ];
+
+    // set up the initial testing state
+    before(async () => {
+      {
+        // Set up the testing environment
+        // by creating a wallet and a watch
+        // only wallet
+        const info = await nclient.getInfo();
+        assert.equal(info.chain.height, 0);
+      }
+
+      {
+        // Create a watch only wallet using the path
+        // m/44'/1'/0' and assert that the wallet
+        // was properly created
+        const accountKey = xpub.xpubkey(network.type);
+        const response = await wclient.createWallet(watchOnlyWalletId, {
+          watchOnly: true,
+          accountKey: accountKey
+        });
+
+        assert.equal(response.id, watchOnlyWalletId);
+
+        const wallet = wclient.wallet(watchOnlyWalletId);
+        const info = await wallet.getAccount('default');
+        assert.equal(info.accountKey, accountKey);
+        assert.equal(info.watchOnly, true);
+      }
+
+      {
+        // Create a wallet that manages the private keys itself
+        const response = await wclient.createWallet(standardWalletId);
+        assert.equal(response.id, standardWalletId);
+
+        const info = await wclient.getAccount(standardWalletId, 'default');
+        assert.equal(info.watchOnly, false);
+      };
+    });
+
+    // the rpc interface requires the wallet to be selected first
+    it('should return iswatchonly correctly', async () => {
+      // m/44'/5355'/0'/0/0
+      const receive = 'rs1q4rvs9pp9496qawp2zyqpz3s90fjfk362q92vq8';
+
+      {
+        await wclient.execute('selectwallet', [standardWalletId]);
+        const response = await wclient.execute('getaddressinfo', [receive]);
+        assert.equal(response.iswatchonly, false);
+      }
+      {
+        await wclient.execute('selectwallet', [watchOnlyWalletId]);
+        const response = await wclient.execute('getaddressinfo', [receive]);
+        assert.equal(response.iswatchonly, true);
+      }
+    });
+
+    it('should return the correct address', async () => {
+      // m/44'/5355'/0'/0/0
+      const receive = 'rs1q4rvs9pp9496qawp2zyqpz3s90fjfk362q92vq8';
+
+      await wclient.execute('selectwallet', [watchOnlyWalletId]);
+      const response = await wclient.execute('getaddressinfo', [receive]);
+      assert.equal(response.address, receive);
+    });
+
+    it('should detect owned address', async () => {
+      // m/44'/5355'/0'/0/0
+      const receive = 'rs1q4rvs9pp9496qawp2zyqpz3s90fjfk362q92vq8';
+
+      {
+        await wclient.execute('selectwallet', [watchOnlyWalletId]);
+        const response = await wclient.execute('getaddressinfo', [receive]);
+        assert.equal(response.ismine, true);
+      }
+      {
+        await wclient.execute('selectwallet', [standardWalletId]);
+        const response = await wclient.execute('getaddressinfo', [receive]);
+        assert.equal(response.ismine, false);
+      }
+    });
+
+    it('should return the correct program for a p2pkh address', async () => {
+      // m/44'/5355'/0'/0/0
+      const receive = 'rs1q4rvs9pp9496qawp2zyqpz3s90fjfk362q92vq8';
+
+      const address = Address.fromString(receive);
+      const script = Script.decode(address.hash);
+      const addr = address.toString(network);
+      await wclient.execute('selectwallet', [watchOnlyWalletId]);
+      const response = await wclient.execute('getaddressinfo', [addr]);
+      assert.equal(response.witness_program, script.toHex());
+    });
+
+    it('should detect a p2sh and its witness program', async () => {
+      const script = Script.fromMultisig(2, 2, pubkeys);
+      const address = Address.fromScript(script);
+      const program = Script.decode(address.hash).toHex();
+
+      const addr = address.toString(network);
+      const response = await wclient.execute('getaddressinfo', [addr]);
+
+      assert.equal(response.isscript, true);
+      assert.equal(response.witness_program, program);
+    });
+
+    it('should detect ismine up to the lookahead', async ($) => {
+      const info = await wclient.getAccount(watchOnlyWalletId, 'default');
+      await wclient.execute('selectwallet', [watchOnlyWalletId]);
+
+      const addresses = [
+        'rs1q4rvs9pp9496qawp2zyqpz3s90fjfk362q92vq8', // 0/0
+        'rs1qwkzdtg56m5zqu4wuwtwuqltn4s9uxd3s93ec2n', // 0/1
+        'rs1q9atns2u4ayv2hsug0xuha3acqxz450mgvaer4z', // 0/2
+        'rs1qve2kd3lyhnm6r7knzvl3s5pkgem9a25xk42y5d', // 0/3
+        'rs1q799vpn8u7524p54kaumclcfuayxxkuga84xle2', // 0/4
+        'rs1q748rcdq767cxla4d0gkpc35r4cl6kk72z47qdq', // 0/5
+        'rs1qq7fkaj2ruwcdsdr4l2f4jx0a8nqyg9qdr7y6am', // 0/6
+        'rs1qm8jx0q9y2tq990tswes08gnjhfhej9vfjcql92', // 0/7
+        'rs1qf3zef3m8tnl8el5wurtrg5qgt6c2aepu7pqeqc', // 0/8
+        'rs1qermzxwthx9tz2h64fgmmxwc8k05zhxhfhx5khm', // 0/9
+        'rs1qlvysusse4qgym5s7mv8ddaatgvgfq6g6vcjhvf'  // 0/10
+      ];
+
+      // Assert that the lookahead is configured as expected
+      // subtract one from addresses.length, it is 0 indexed
+      assert.equal(addresses.length - 1, info.lookahead);
+
+      // Each address through the lookahead number should
+      // be recognized as an owned address
+      for (let i = 0; i < info.lookahead+1; i++) {
+        const address = addresses[i];
+        const response = await wclient.execute('getaddressinfo', [address]);
+        assert.equal(response.ismine, true);
+      }
+
+      // m/44'/5355'/0'/11
+      // This address is outside of the lookahead range
+      const failed = 'rs1qg8h0n5mrdt5u8jaxq9jequ3nekj8fg820lr5xg';
+
+      const response = await wclient.execute('getaddressinfo', [failed]);
+      assert.equal(response.ismine, false);
+    });
+
+    it('should detect change addresses', async () => {
+      await wclient.execute('selectwallet', [watchOnlyWalletId]);
+      // m/44'/5355'/0'/1/0
+      const address = 'rs1qxps2ljf5604tgyz7pvecuq6twwt4k9qsxcd27y';
+      const info = await wclient.execute('getaddressinfo', [address]);
+
+      assert.equal(info.ischange, true);
+    });
+
+    it('should throw for the wrong network', async () => {
+      // m/44'/5355'/0'/0/0
+      const failed = 'hs1q4rvs9pp9496qawp2zyqpz3s90fjfk362rl50q4';
+
+      const fn = async () => await wclient.execute('getaddressinfo', [failed]);
+      await assert.asyncThrows(fn, 'Invalid address.');
+    });
+
+    it('should throw for invalid address', async () => {
+      let failed = 'rs1q4rvs9pp9496qawp2zyqpz3s90fjfk362q92vq8';
+      // remove the first character
+      failed = failed.slice(1, failed.length);
+
+      const fn = async () => await wclient.execute('getaddressinfo', [failed]);
+      await assert.asyncThrows(fn, 'Invalid address.');
+    });
+  });
+});

--- a/test/wallet-test.js
+++ b/test/wallet-test.js
@@ -18,7 +18,6 @@ const KeyRing = require('../lib/primitives/keyring');
 const Input = require('../lib/primitives/input');
 const Outpoint = require('../lib/primitives/outpoint');
 const Script = require('../lib/script/script');
-const HD = require('../lib/hd');
 const PrivateKey = require('../lib/hd/private.js');
 
 const KEY1 = 'xprv9s21ZrQH143K3Aj6xQBymM31Zb4BVc7wxqfUhMZrzewdDVCt'


### PR DESCRIPTION
Update: integrated changes done here - https://github.com/bcoin-org/bcoin/pull/731
Update: This PR has been merged into `bcoin`

## getaddressinfo

This ports the `bitcoind` rpc method `getaddressinfo` to the Handshake wallet.
It includes `ismine` and `iswatchonly` values that can use the wallet database
to return the correct values since `validateaddress` hard codes in `ismine: false`.
This can throw off people who want to build on top of handshake, the `getaddressinfo` rpc method can help users who desire an accurate `ismine` property. 
The full list of properties that it returns are `address`, `ismine`, `iswatchonly`, `ischange`, `isspendable`, `isscript`, `isspendable`, `witness_version` and `witness_program`.
`isspendable` is a Handshake specific property derived from `Address.isUnspendable`
which calls this method:

```javascript
  isNulldata() {
    return this.version === 31;
  }
```

https://bitcoincore.org/en/doc/0.17.0/rpc/wallet/getaddressinfo/


## validateaddress

This updates the `validateaddress` RPC method to match `bitcoind` v0.17.0 by adding
`witness_version`, `witness_program`, and `isscript`. It also includes the Handshake
specific property `isspendable`.
https://bitcoincore.org/en/doc/0.17.0/rpc/util/validateaddress/

