### PR TITLE
keyring: delete left over assertions from bcoin

### DIFF
--- a/lib/primitives/keyring.js
+++ b/lib/primitives/keyring.js
@@ -518,8 +518,6 @@ class KeyRing extends bio.Struct {
 
   fromJSON(json) {
     assert(json);
-    assert(typeof json.witness === 'boolean');
-    assert(typeof json.nested === 'boolean');
     assert(typeof json.publicKey === 'string');
     assert(!json.script || typeof json.script === 'string');
 


### PR DESCRIPTION
This pull request deletes some left over values in the `Keyring.fromJSON` method from bcoin.

See this for their original usage:
https://github.com/bcoin-org/bcoin/blob/2b2e53d83d4def08d25a2ed5c17c5638c3efa7b7/lib/primitives/keyring.js#L791