### PR TITLE
test: add ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,61 @@
+defaults: &defaults
+  working_directory: ~/repo
+  docker:
+    - image: circleci/node:10.2
+
+version: 2.0
+jobs:
+  install:
+    <<: *defaults
+    docker:
+      - image: circleci/node:10.2
+    working_directory: ~/repo
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+          - v1-dependencies-{{ checksum "package.json" }}
+          # fallback to using the latest cache if no exact match is found
+          - v1-dependencies-
+      - run: npm install
+      - run: npm install eslint istanbul@1.1.0-alpha.1 codecov
+      - save_cache:
+          paths:
+            - node_modules
+          key: v1-dependencies-{{ checksum "package.json" }}
+      - persist_to_workspace:
+          root: .
+          paths: .
+
+  test:
+    <<: *defaults
+    steps:
+      - attach_workspace:
+          at: .
+      - run:
+          name: Tests with coverage
+          command: npm run test-ci
+      - run:
+          name: Submit coverage
+          command: ./node_modules/.bin/codecov
+
+  lint:
+    <<: *defaults
+    steps:
+      - attach_workspace:
+          at: .
+      - run:
+          name: Lint
+          command: npm run lint-ci
+
+workflows:
+  version: 2
+  test_and_lint:
+    jobs:
+      - install
+      - lint:
+          requires:
+            - install
+      - test:
+          requires:
+            - install

--- a/package.json
+++ b/package.json
@@ -64,11 +64,13 @@
   },
   "scripts": {
     "lint": "eslint $(cat .eslintfiles) || exit 0",
+    "lint-ci": "eslint $(cat .eslintfiles)",
     "lint-file": "eslint",
     "test": "bmocha --reporter spec test/*.js",
     "test-browser": "NODE_BACKEND=js bmocha --reporter spec test/*.js",
     "test-file": "bmocha --reporter spec",
-    "test-file-browser": "NODE_BACKEND=js bmocha --reporter spec"
+    "test-file-browser": "NODE_BACKEND=js bmocha --reporter spec",
+    "test-ci": "istanbul cover --report lcovonly node_modules/.bin/bmocha -- --reporter spec test/*.js"
   },
   "browser": {
     "./lib/covenants/reserved": "./lib/covenants/reserved-browser.js",

--- a/test/node-test.js
+++ b/test/node-test.js
@@ -111,7 +111,8 @@ describe('Node', function() {
     await chain.add(block);
   });
 
-  it('should mine competing chains', async () => {
+  it('should mine competing chains', async function() {
+    this.timeout(20000);
     for (let i = 0; i < 10; i++) {
       const block1 = await mineBlock(tip1, cb1);
       cb1 = block1.txs[0];


### PR DESCRIPTION
This adds CI using Circle CI, copied directly from bcoin
at commit df1e8c06216f919d90c86cc89784f4c65d66eff3

The Circle CI project needs to be registered still
It would be really helpful if a project admin could go here to set it up:
https://circleci.com/add-projects/gh/handshake-org