### PR TITLE
readme: document minimum node.js version

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 ## Install
 
+`hsd` requires Node.js v10 or higher
+
 ```
 $ git clone git://github.com/handshake-org/hsd.git
 $ cd hsd


### PR DESCRIPTION
Documents to use Node.js v10 right at the top of the `README.md`

There have been multiple issues that people were having that could have to do with the version of Node.js that they were running.

See:
https://github.com/handshake-org/hsd/issues/41
https://github.com/handshake-org/hsd/issues/28