### PR TITLE
walletdb: remove references to witness

### DIFF
--- a/lib/wallet/walletdb.js
+++ b/lib/wallet/walletdb.js
@@ -2299,7 +2299,6 @@ class WalletOptions {
     this.compression = true;
 
     this.spv = false;
-    this.witness = false;
     this.checkpoints = false;
     this.wipeNoReally = false;
 
@@ -2372,11 +2371,6 @@ class WalletOptions {
     if (options.spv != null) {
       assert(typeof options.spv === 'boolean');
       this.spv = options.spv;
-    }
-
-    if (options.witness != null) {
-      assert(typeof options.witness === 'boolean');
-      this.witness = options.witness;
     }
 
     if (options.checkpoints != null) {


### PR DESCRIPTION
This pull request removes dead code left over from `bcoin` in the `WalletDB`.
The `walletdb.witness` value was initially set to `false`, which doesn't make sense
in the context of Handshake.  I searched through the code for places where the
`witness` value could be referenced from outside the `WalletDB` class and could
not find any. The tests all still pass