### PR TITLE
blockchain: remove coin-cache

### DIFF
--- a/etc/sample.conf
+++ b/etc/sample.conf
@@ -37,7 +37,6 @@ log-file: true
 
 prune: false
 checkpoints: true
-coin-cache: 0
 entry-cache: 5000
 index-tx: false
 index-address: false

--- a/lib/blockchain/chain.js
+++ b/lib/blockchain/chain.js
@@ -84,9 +84,6 @@ class Chain extends AsyncEmitter {
     if (this.options.checkpoints)
       this.logger.info('Checkpoints are enabled.');
 
-    if (this.options.coinCache)
-      this.logger.info('Coin cache is enabled.');
-
     await this.db.open();
 
     const tip = await this.db.getTip();
@@ -2055,11 +2052,6 @@ class Chain extends AsyncEmitter {
       block.getSize(),
       block.txs.length,
       elapsed);
-
-    if (this.db.coinCache.capacity > 0) {
-      this.logger.debug('Coin Cache: size=%dmb, items=%d.',
-        this.db.coinCache.size / (1 << 20), this.db.coinCache.items);
-    }
   }
 
   /**
@@ -3272,7 +3264,6 @@ class ChainOptions {
     this.indexAddress = false;
     this.forceFlags = false;
 
-    this.coinCache = 0;
     this.entryCache = 5000;
     this.maxOrphans = 20;
     this.checkpoints = true;
@@ -3365,11 +3356,6 @@ class ChainOptions {
     if (options.forceFlags != null) {
       assert(typeof options.forceFlags === 'boolean');
       this.forceFlags = options.forceFlags;
-    }
-
-    if (options.coinCache != null) {
-      assert((options.coinCache >>> 0) === options.coinCache);
-      this.coinCache = options.coinCache;
     }
 
     if (options.entryCache != null) {

--- a/lib/blockchain/chaindb.js
+++ b/lib/blockchain/chaindb.js
@@ -56,7 +56,6 @@ class ChainDB {
     this.pending = null;
     this.current = null;
 
-    this.coinCache = new LRU(this.options.coinCache, getSize, BufferMap);
     this.cacheHash = new LRU(this.options.entryCache, null, BufferMap);
     this.cacheHeight = new LRU(this.options.entryCache);
   }
@@ -146,7 +145,6 @@ class ChainDB {
     this.current = this.db.batch();
     this.pending = this.state.clone();
 
-    this.coinCache.start();
     this.cacheHash.start();
     this.cacheHeight.start();
 
@@ -198,7 +196,6 @@ class ChainDB {
     this.current = null;
     this.pending = null;
 
-    this.coinCache.drop();
     this.cacheHash.drop();
     this.cacheHeight.drop();
     this.stateCache.drop();
@@ -220,7 +217,6 @@ class ChainDB {
     } catch (e) {
       this.current = null;
       this.pending = null;
-      this.coinCache.drop();
       this.cacheHash.drop();
       this.cacheHeight.drop();
       throw e;
@@ -237,7 +233,6 @@ class ChainDB {
     this.current = null;
     this.pending = null;
 
-    this.coinCache.commit();
     this.cacheHash.commit();
     this.cacheHeight.commit();
     this.stateCache.commit();
@@ -996,21 +991,11 @@ class ChainDB {
       return null;
 
     const {hash, index} = prevout;
-    const key = prevout.toKey();
-    const state = this.state;
-
-    const cache = this.coinCache.get(key);
-
-    if (cache)
-      return CoinEntry.decode(cache);
 
     const raw = await this.db.get(layout.c.encode(hash, index));
 
     if (!raw)
       return null;
-
-    if (state === this.state)
-      this.coinCache.set(key, raw);
 
     return CoinEntry.decode(raw);
   }
@@ -1827,17 +1812,12 @@ class ChainDB {
       for (const [index, coin] of coins.outputs) {
         if (coin.spent) {
           this.del(layout.c.encode(hash, index));
-          if (this.coinCache.capacity > 0)
-            this.coinCache.unpush(Outpoint.toKey(hash, index));
           continue;
         }
 
         const raw = coin.encode();
 
         this.put(layout.c.encode(hash, index), raw);
-
-        if (this.coinCache.capacity > 0)
-          this.coinCache.push(Outpoint.toKey(hash, index), raw);
       }
     }
 
@@ -2468,10 +2448,6 @@ class CacheUpdate {
 /*
  * Helpers
  */
-
-function getSize(value) {
-  return value.length + 80;
-}
 
 function fromU32(num) {
   const data = Buffer.allocUnsafe(4);

--- a/lib/node/fullnode.js
+++ b/lib/node/fullnode.js
@@ -53,7 +53,6 @@ class FullNode extends Node {
       forceFlags: this.config.bool('force-flags'),
       prune: this.config.bool('prune'),
       checkpoints: this.config.bool('checkpoints'),
-      coinCache: this.config.mb('coin-cache'),
       entryCache: this.config.uint('entry-cache'),
       indexTX: this.config.bool('index-tx'),
       indexAddress: this.config.bool('index-address')


### PR DESCRIPTION
This PR removes the coin-cache from the blockchain. It was determined that using the coin-cache actually slows down the initial block download and can be easily configured in such a way that it crashes Node.js. This is a port of work done by braydonf on bcoin.

See relevant comment from jj:
https://github.com/bcoin-org/bcoin/issues/626#issuecomment-442059074
See PR on bcoin here: https://github.com/bcoin-org/bcoin/pull/736

Thank you at @braydonf for doing great work on `bcoin` regarding this issue