### PR TITLE
rpc: new wallet rpc getaddressinfo

### DIFF
--- a/lib/wallet/rpc.js
+++ b/lib/wallet/rpc.js
@@ -129,6 +129,7 @@ class RPC extends RPCBase {
     this.add('getaccountaddress', this.getAccountAddress);
     this.add('getaccount', this.getAccount);
     this.add('getaddressesbyaccount', this.getAddressesByAccount);
+    this.add('getaddressinfo', this.getAddressInfo);
     this.add('getbalance', this.getBalance);
     this.add('getnewaddress', this.getNewAddress);
     this.add('getrawchangeaddress', this.getRawChangeAddress);
@@ -447,6 +448,29 @@ class RPC extends RPCBase {
     }
 
     return addrs;
+  }
+
+  async getAddressInfo(args, help) {
+    if (help || args.length !== 1)
+      throw new RPCError(errs.MISC_ERROR, 'getaddressinfo "address"');
+
+    const valid = new Validator(args);
+    const addr = valid.str(0, '');
+    const address = parseAddress(addr, this.network);
+
+    const wallet = this.wallet.toJSON();
+    const path = await this.wallet.getPath(address);
+
+    return {
+      address: address.toString(this.network),
+      ismine: path != null,
+      iswatchonly: wallet.watchOnly,
+      ischange: path ? path.branch === 1 : false,
+      isspendable: !address.isUnspendable(),
+      isscript: address.isScripthash(),
+      witness_version: address.version,
+      witness_program: address.hash.toString('hex')
+    };
   }
 
   async getBalance(args, help) {

--- a/test/wallet-rpc-test.js
+++ b/test/wallet-rpc-test.js
@@ -1,0 +1,247 @@
+/* eslint-env mocha */
+
+'use strict';
+
+const {NodeClient,WalletClient} = require('hs-client');
+const assert = require('bsert');
+const FullNode = require('../lib/node/fullnode');
+const Network = require('../lib/protocol/network');
+const Mnemonic = require('../lib/hd/mnemonic');
+const HDPrivateKey = require('../lib/hd/private');
+const Script = require('../lib/script/script');
+const Address = require('../lib/primitives/address');
+const network = Network.get('regtest');
+const mnemonics = require('./data/mnemonic-english.json');
+// Commonly used test mnemonic
+const phrase = mnemonics[0][1];
+
+const node = new FullNode({
+  network: network.type,
+  apiKey: 'bar',
+  walletAuth: true,
+  memory: true,
+  workers: true,
+  plugins: [require('../lib/wallet/plugin')]
+});
+
+const nclient = new NodeClient({
+  port: network.rpcPort,
+  apiKey: 'bar'
+});
+
+const wclient = new WalletClient({
+  port: network.walletPort,
+  apiKey: 'bar'
+});
+
+describe('Wallet RPC Methods', function() {
+  this.timeout(15000);
+
+  let xpub;
+
+  before(async () => {
+    await node.open();
+    await nclient.open();
+    await wclient.open();
+
+    // Derive the xpub using the well known
+    // mnemonic and network's coin type
+    const mnemonic = Mnemonic.fromPhrase(phrase);
+    const priv = HDPrivateKey.fromMnemonic(mnemonic);
+    const type = network.keyPrefix.coinType;
+    const key = priv.derive(44, true).derive(type, true).derive(0, true);
+
+    xpub = key.toPublic();
+
+    assert.equal(phrase, [
+      'abandon', 'abandon', 'abandon', 'abandon',
+      'abandon', 'abandon', 'abandon', 'abandon',
+      'abandon', 'abandon', 'abandon', 'about'
+    ].join(' '));
+  });
+
+  after(async () => {
+    await nclient.close();
+    await wclient.close();
+    await node.close();
+  });
+
+  describe('getaddressinfo', () => {
+    const watchOnlyWalletId = 'foo';
+    const standardWalletId = 'bar';
+
+    // m/44'/5355'/0'/0/{0,1}
+    const pubkeys = [
+      Buffer.from('03253ea6d6486d1b9cc3a'
+        + 'b01a9a321d65c350c6c26a9c536633e2ef36163316bf2', 'hex'),
+      Buffer.from('02cd38edb6f9cb4fd7380'
+        + '3b49aed97bfa95ef402cac2c34e8f551f8537811d2159', 'hex')
+    ];
+
+    // set up the initial testing state
+    before(async () => {
+      {
+        // Set up the testing environment
+        // by creating a wallet and a watch
+        // only wallet
+        const info = await nclient.getInfo();
+        assert.equal(info.chain.height, 0);
+      }
+
+      {
+        // Create a watch only wallet using the path
+        // m/44'/5355'/0' and assert that the wallet
+        // was properly created
+        const accountKey = xpub.xpubkey(network.type);
+        const response = await wclient.createWallet(watchOnlyWalletId, {
+          watchOnly: true,
+          accountKey: accountKey
+        });
+
+        assert.equal(response.id, watchOnlyWalletId);
+
+        const wallet = wclient.wallet(watchOnlyWalletId);
+        const info = await wallet.getAccount('default');
+        assert.equal(info.accountKey, accountKey);
+        assert.equal(info.watchOnly, true);
+      }
+
+      {
+        // Create a wallet that manages the private keys itself
+        const response = await wclient.createWallet(standardWalletId);
+        assert.equal(response.id, standardWalletId);
+
+        const info = await wclient.getAccount(standardWalletId, 'default');
+        assert.equal(info.watchOnly, false);
+      };
+    });
+
+    // the rpc interface requires the wallet to be selected first
+    it('should return iswatchonly correctly', async () => {
+      // m/44'/5355'/0'/0/0
+      const receive = 'rs1q4rvs9pp9496qawp2zyqpz3s90fjfk362q92vq8';
+
+      {
+        await wclient.execute('selectwallet', [standardWalletId]);
+        const response = await wclient.execute('getaddressinfo', [receive]);
+        assert.equal(response.iswatchonly, false);
+      }
+      {
+        await wclient.execute('selectwallet', [watchOnlyWalletId]);
+        const response = await wclient.execute('getaddressinfo', [receive]);
+        assert.equal(response.iswatchonly, true);
+      }
+    });
+
+    it('should return the correct address', async () => {
+      // m/44'/5355'/0'/0/0
+      const receive = 'rs1q4rvs9pp9496qawp2zyqpz3s90fjfk362q92vq8';
+
+      await wclient.execute('selectwallet', [watchOnlyWalletId]);
+      const response = await wclient.execute('getaddressinfo', [receive]);
+      assert.equal(response.address, receive);
+    });
+
+    it('should detect owned address', async () => {
+      // m/44'/5355'/0'/0/0
+      const receive = 'rs1q4rvs9pp9496qawp2zyqpz3s90fjfk362q92vq8';
+
+      {
+        await wclient.execute('selectwallet', [watchOnlyWalletId]);
+        const response = await wclient.execute('getaddressinfo', [receive]);
+        assert.equal(response.ismine, true);
+      }
+      {
+        await wclient.execute('selectwallet', [standardWalletId]);
+        const response = await wclient.execute('getaddressinfo', [receive]);
+        assert.equal(response.ismine, false);
+      }
+    });
+
+    it('should return the correct program for a p2pkh address', async () => {
+      // m/44'/5355'/0'/0/0
+      const receive = 'rs1q4rvs9pp9496qawp2zyqpz3s90fjfk362q92vq8';
+
+      const address = Address.fromString(receive);
+      const addr = address.toString(network);
+      await wclient.execute('selectwallet', [watchOnlyWalletId]);
+      const response = await wclient.execute('getaddressinfo', [addr]);
+      assert.equal(response.witness_program, address.hash.toString('hex'));
+    });
+
+    it('should detect a p2wsh and its witness program', async () => {
+      const script = Script.fromMultisig(2, 2, pubkeys);
+      const address = Address.fromScript(script);
+
+      const addr = address.toString(network);
+      const response = await wclient.execute('getaddressinfo', [addr]);
+
+      assert.equal(response.isscript, true);
+      assert.equal(response.witness_program, address.hash.toString('hex'));
+    });
+
+    it('should detect ismine up to the lookahead', async () => {
+      const info = await wclient.getAccount(watchOnlyWalletId, 'default');
+      await wclient.execute('selectwallet', [watchOnlyWalletId]);
+
+      const addresses = [
+        'rs1q4rvs9pp9496qawp2zyqpz3s90fjfk362q92vq8', // 0/0
+        'rs1qwkzdtg56m5zqu4wuwtwuqltn4s9uxd3s93ec2n', // 0/1
+        'rs1q9atns2u4ayv2hsug0xuha3acqxz450mgvaer4z', // 0/2
+        'rs1qve2kd3lyhnm6r7knzvl3s5pkgem9a25xk42y5d', // 0/3
+        'rs1q799vpn8u7524p54kaumclcfuayxxkuga84xle2', // 0/4
+        'rs1q748rcdq767cxla4d0gkpc35r4cl6kk72z47qdq', // 0/5
+        'rs1qq7fkaj2ruwcdsdr4l2f4jx0a8nqyg9qdr7y6am', // 0/6
+        'rs1qm8jx0q9y2tq990tswes08gnjhfhej9vfjcql92', // 0/7
+        'rs1qf3zef3m8tnl8el5wurtrg5qgt6c2aepu7pqeqc', // 0/8
+        'rs1qermzxwthx9tz2h64fgmmxwc8k05zhxhfhx5khm', // 0/9
+        'rs1qlvysusse4qgym5s7mv8ddaatgvgfq6g6vcjhvf'  // 0/10
+      ];
+
+      // Assert that the lookahead is configured as expected
+      // subtract one from addresses.length, it is 0 indexed
+      assert.equal(addresses.length - 1, info.lookahead);
+
+      // Each address through the lookahead number should
+      // be recognized as an owned address
+      for (let i = 0; i < info.lookahead+1; i++) {
+        const address = addresses[i];
+        const response = await wclient.execute('getaddressinfo', [address]);
+        assert.equal(response.ismine, true);
+      }
+
+      // m/44'/5355'/0'/11
+      // This address is outside of the lookahead range
+      const failed = 'rs1qg8h0n5mrdt5u8jaxq9jequ3nekj8fg820lr5xg';
+
+      const response = await wclient.execute('getaddressinfo', [failed]);
+      assert.equal(response.ismine, false);
+    });
+
+    it('should detect change addresses', async () => {
+      await wclient.execute('selectwallet', [watchOnlyWalletId]);
+      // m/44'/5355'/0'/1/0
+      const address = 'rs1qxps2ljf5604tgyz7pvecuq6twwt4k9qsxcd27y';
+      const info = await wclient.execute('getaddressinfo', [address]);
+
+      assert.equal(info.ischange, true);
+    });
+
+    it('should throw for the wrong network', async () => {
+      // m/44'/5355'/0'/0/0
+      const failed = 'hs1q4rvs9pp9496qawp2zyqpz3s90fjfk362rl50q4';
+
+      const fn = async () => await wclient.execute('getaddressinfo', [failed]);
+      await assert.rejects(fn, 'Invalid address.');
+    });
+
+    it('should throw for invalid address', async () => {
+      let failed = 'rs1q4rvs9pp9496qawp2zyqpz3s90fjfk362q92vq8';
+      // remove the first character
+      failed = failed.slice(1, failed.length);
+
+      const fn = async () => await wclient.execute('getaddressinfo', [failed]);
+      await assert.rejects(fn, 'Invalid address.');
+    });
+  });
+});

--- a/test/wallet-rpc-test.js
+++ b/test/wallet-rpc-test.js
@@ -15,22 +15,33 @@ const mnemonics = require('./data/mnemonic-english.json');
 // Commonly used test mnemonic
 const phrase = mnemonics[0][1];
 
+const ports = {
+  p2p: 14331,
+  node: 14332,
+  wallet: 14333
+};
+
 const node = new FullNode({
   network: network.type,
   apiKey: 'bar',
   walletAuth: true,
   memory: true,
+  port: ports.p2p,
+  httpPort: ports.node,
   workers: true,
-  plugins: [require('../lib/wallet/plugin')]
+  plugins: [require('../lib/wallet/plugin')],
+  env: {
+    'HSD_WALLET_HTTP_PORT': ports.wallet.toString()
+  }
 });
 
 const nclient = new NodeClient({
-  port: network.rpcPort,
+  port: ports.node,
   apiKey: 'bar'
 });
 
 const wclient = new WalletClient({
-  port: network.walletPort,
+  port: ports.wallet,
   apiKey: 'bar'
 });
 


### PR DESCRIPTION
Adds a new wallet RPC method getaddressinfo that
corresponds to changes with bitcoind. Returns values:

- address
- ismine
- iswatchonly
- ischange
- isspendable
- isscript
- witness_version
- witness_program

The ismine property previously existed on the node RPC
method validateaddress which was always hardcoded to true.
An additional PR will be added to update validateaddress
to remove the ismine property. isspendable refers to
an address with null data, of version 31.

See PR in bcoin: https://github.com/bcoin-org/bcoin/pull/731
See bitcoind docs:
https://bitcoincore.org/en/doc/0.17.0/rpc/wallet/getaddressinfo/