### PR TITLE
rpc: update node rpc validateaddress

### DIFF
--- a/lib/node/rpc.js
+++ b/lib/node/rpc.js
@@ -2093,8 +2093,10 @@ class RPC extends RPCBase {
     return {
       isvalid: true,
       address: addr.toString(this.network),
-      ismine: false,
-      iswatchonly: false
+      isscript: addr.isScripthash(),
+      isspendable: !addr.isUnspendable(),
+      witness_version: addr.version,
+      witness_program: addr.hash.toString('hex')
     };
   }
 

--- a/test/node-test.js
+++ b/test/node-test.js
@@ -511,10 +511,12 @@ describe('Node', function() {
     }, {});
 
     assert.deepStrictEqual(json.result, {
-      isvalid: true,
       address: addr.toString(node.network),
-      ismine: false,
-      iswatchonly: false
+      isvalid: true,
+      isscript: false,
+      isspendable: true,
+      witness_version: addr.version,
+      witness_program: addr.hash.toString('hex')
     });
   });
 


### PR DESCRIPTION
This PR updates the node RPC validateaddress to
better seperate the wallet and the node. The RPC
was returning ismine and iswatch only. These values
were moved to the wallet rpc method getaddressinfo.
This corresponds to a change in bitcoind and bcoin.

The updated validateaddress rpc returns the values:

- isvalid
- address
- ismine
- iswatchonly
- isscript
- isspendable
- witness_version
- witness_program

See PR in bcoin: https://github.com/bcoin-org/bcoin/pull/731
See PR in bitcoind: https://github.com/bitcoin/bitcoin/pull/10583