### PR TITLE
node-rpc: getblockhash returns string

### DIFF
--- a/lib/node/rpc.js
+++ b/lib/node/rpc.js
@@ -709,7 +709,7 @@ class RPC extends RPCBase {
     if (!hash)
       throw new RPCError(errs.MISC_ERROR, 'Not found.');
 
-    return hash;
+    return hash.toString('hex');
   }
 
   async getBlockHeader(args, help) {


### PR DESCRIPTION
In commit add3235d5b0de380257a6d069ca19ba717b60db4, little-endian hashes were removed from hsd (😌 !) an with it, a lot of conversions of hash buffers to reverse hex strings. I think this one just got missed.

#### Before:
```
$ hsd-rpc getblockhash 10
{
  "type": "Buffer",
  "data": [
    207,
    158,
    216,
    73,
    80,
    83,
    4,
    223,
    214,
    43,
    41,
    113,
    173,
    108,
    145,
    0,
    98,
    160,
    4,
    221,
    62,
    132,
    59,
    136,
    119,
    162,
    66,
    8,
    74,
    233,
    1,
    39
  ]
}
```

#### After:
```
$ hsd-rpc getblockhash 10
cf9ed849505304dfd62b2971ad6c910062a004dd3e843b8877a242084ae90127
```