### PR TITLE
test: fix values from updated block reward

### DIFF
--- a/test/chain-test.js
+++ b/test/chain-test.js
@@ -172,7 +172,7 @@ describe('Chain', function() {
   });
 
   it('should have correct chain value', () => {
-    assert.strictEqual(chain.db.state.value, 421002210000);
+    assert.strictEqual(chain.db.state.value, 422002210000);
     assert.strictEqual(chain.db.state.coin, 221);
     assert.strictEqual(chain.db.state.tx, 221);
   });
@@ -204,7 +204,7 @@ describe('Chain', function() {
   });
 
   it('should have correct chain value', () => {
-    assert.strictEqual(chain.db.state.value, 423002210000);
+    assert.strictEqual(chain.db.state.value, 424002210000);
     assert.strictEqual(chain.db.state.coin, 222);
     assert.strictEqual(chain.db.state.tx, 222);
   });
@@ -284,7 +284,7 @@ describe('Chain', function() {
   });
 
   it('should have correct chain value', () => {
-    assert.strictEqual(chain.db.state.value, 427002210000);
+    assert.strictEqual(chain.db.state.value, 428002210000);
     assert.strictEqual(chain.db.state.coin, 225);
     assert.strictEqual(chain.db.state.tx, 225);
   });

--- a/test/http-test.js
+++ b/test/http-test.js
@@ -217,7 +217,7 @@ describe('HTTP', function() {
         + '0000000000000000000000000000000000000000000000000000000000000000'
         + 'ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff',
       curtime: json.curtime,
-      mintime: 1548148526,
+      mintime: 1554268736,
       maxtime: json.maxtime,
       expires: json.expires,
       sigoplimit: 80000,

--- a/test/node-test.js
+++ b/test/node-test.js
@@ -139,7 +139,7 @@ describe('Node', function() {
   });
 
   it('should have correct chain value', () => {
-    assert.strictEqual(chain.db.state.value, 23002210000);
+    assert.strictEqual(chain.db.state.value, 24002210000);
     assert.strictEqual(chain.db.state.coin, 21);
     assert.strictEqual(chain.db.state.tx, 21);
   });
@@ -176,7 +176,7 @@ describe('Node', function() {
   });
 
   it('should have correct chain value', () => {
-    assert.strictEqual(chain.db.state.value, 25002210000);
+    assert.strictEqual(chain.db.state.value, 26002210000);
     assert.strictEqual(chain.db.state.coin, 22);
     assert.strictEqual(chain.db.state.tx, 22);
   });
@@ -240,7 +240,7 @@ describe('Node', function() {
   });
 
   it('should have correct chain value', () => {
-    assert.strictEqual(chain.db.state.value, 27002210000);
+    assert.strictEqual(chain.db.state.value, 28002210000);
     assert.strictEqual(chain.db.state.coin, 24);
     assert.strictEqual(chain.db.state.tx, 24);
   });


### PR DESCRIPTION
This commit updates the values expected from the `chain.db.value` in the chain and node tests. The block reward was increased from 1000 to 2000 at commit 601267d1b598617a4eb2cde7b906ab89c45c377c. This commit also updates the expected blocktemplate mintime which was updated in commit be4331fc8d63addb8e5fa6722ad29ac2a922b852.