### PR TITLE
node rpc: add identitykey to getnetworkinfo

### DIFF
--- a/lib/node/rpc.js
+++ b/lib/node/rpc.js
@@ -325,6 +325,7 @@ class RPC extends RPCBase {
       version: pkg.version,
       subversion: this.pool.options.agent,
       protocolversion: this.pool.options.version,
+      identitykey: this.node.identityKey.toString('hex'),
       localservices: hex32(this.pool.options.services),
       localrelay: !this.pool.options.noRelay,
       timeoffset: this.network.time.offset,


### PR DESCRIPTION
This PR adds an `identitykey` field to the response of `getnetworkinfo`.

I had a testnet3 node running through the start of testnet4 and my IP is currently banned from the seeder nodes. I'd like it to be easier to add peers and since each node has a public identity key, exposing that key through an RPC method makes sense so that you can share it with others and build automation on top of it. 

Related PR: https://github.com/handshake-org/hsd/pull/129

I considered adding the identity key to `getinfo` but it seems to be more relevant to `getnetworkinfo`. The identity key is also used by the `RootServer`, so maybe it is useful information to have on `getinfo` as well. Maybe there should just be an additional rpc method specifically for getting info about the DNS servers

```
Add the node's P2P identity key to the node RPC
getnetworkinfo. This is useful information to be
able to query to share with other nodes that
want to be able to connect. getnetworkinfo seems
like the most relevant place to put the identity key.
```