### PR TITLE
node rpc: add identitykey to getpeerinfo

### DIFF
--- a/lib/node/rpc.js
+++ b/lib/node/rpc.js
@@ -490,6 +490,7 @@ class RPC extends RPCBase {
           ? peer.local.hostname
           : undefined,
         name: peer.name || undefined,
+        identitykey: peer.identityKey.toString('hex'),
         services: hex32(peer.services),
         relaytxes: !peer.noRelay,
         lastsend: peer.lastSend / 1000 | 0,


### PR DESCRIPTION
This adds the `identitykey` field to each of the peer objects returned from the node RPC `getpeerinfo`

Related PR: https://github.com/handshake-org/hsd/pull/128

```
Add the peer's identity key to each peer object
that is returned by the node RPC getpeerinfo.
This is useful information to build automation
on top of and also helpful for sharing with other
people instead of having to look at the hosts.json
file to share the node's peers.
```