### PR TITLE
node rpc: add pool identitykey to getnetworkinfo

### DIFF
--- a/lib/node/rpc.js
+++ b/lib/node/rpc.js
@@ -13,6 +13,7 @@ const IP = require('binet');
 const Validator = require('bval');
 const {BufferMap, BufferSet} = require('buffer-map');
 const blake2b = require('bcrypto/lib/blake2b');
+const base32 = require('bs32');
 const {safeEqual} = require('bcrypto/lib/safe');
 const secp256k1 = require('bcrypto/lib/secp256k1');
 const util = require('../utils/util');
@@ -325,6 +326,7 @@ class RPC extends RPCBase {
       version: pkg.version,
       subversion: this.pool.options.agent,
       protocolversion: this.pool.options.version,
+      identitykey: base32.encode(this.pool.hosts.address.key),
       localservices: hex32(this.pool.options.services),
       localrelay: !this.pool.options.noRelay,
       timeoffset: this.network.time.offset,


### PR DESCRIPTION
```
Add the node's P2P identity key to the node RPC
getnetworkinfo. This is useful information to be
able to query to share with other nodes that
want to be able to connect. getnetworkinfo seems
like the most relevant place to put the identity key.
```

This PR adds an `identitykey` field to the response of `getnetworkinfo`.

I had a testnet3 node running through the start of testnet4 and my IP is currently banned from the seeder nodes. I'd like it to be easier to add peers and since each node has a public identity key, exposing that key through an RPC method makes sense so that you can share it with others and build automation on top of it.

The identity key is the same identity key that is logged here:
https://github.com/handshake-org/hsd/blob/af86d4899791601d10212115c80a2f2136fdb004/lib/net/pool.js#L206

I considered adding the identity key to `getinfo` but it seems to be more relevant to `getnetworkinfo`. 

Another solution would be to add a method to the `Address` class that returns `base32.encode(this.key)`. Other consumers of the `Address` wouldn't need to import `base32` to get the same information. Thoughts? @boymanjor 

