### PR TITLE
brontide: fix typo in comments

### DIFF
--- a/lib/net/brontide.js
+++ b/lib/net/brontide.js
@@ -246,7 +246,7 @@ class Brontide extends HandshakeState {
     const ephemeral = getPublic(this.localEphemeral);
     this.mixHash(ephemeral);
 
-    // ec
+    // es
     const s = ecdh(this.remoteStatic, this.localEphemeral);
     this.mixKey(s);
 


### PR DESCRIPTION
According to [LND brontide package](https://github.com/lightningnetwork/lnd/blob/master/brontide/noise.go#L451), ECDH operation at genActOne returns `es`.