### PR TITLE
ci: install babel-eslint

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ jobs:
           # fallback to using the latest cache if no exact match is found
           - v1-dependencies-
       - run: npm install
-      - run: npm install eslint istanbul@1.1.0-alpha.1 codecov
+      - run: npm install eslint babel-eslint istanbul@1.1.0-alpha.1 codecov
       - save_cache:
           paths:
             - node_modules


### PR DESCRIPTION
This commit adds babel-eslint to the circle ci install script. The handshake parser was updated to babel-eslint in commit 726f7317939c679066c3cc27fb768673b7ca7d4a.