### PR TITLE
mempool: remove premature witness option

### DIFF
--- a/lib/mempool/mempool.js
+++ b/lib/mempool/mempool.js
@@ -2602,7 +2602,6 @@ class MempoolOptions {
     this.relayPriority = true;
     this.requireStandard = this.network.requireStandard;
     this.rejectAbsurdFees = true;
-    this.prematureWitness = false;
     this.paranoidChecks = false;
 
     this.maxSize = policy.MEMPOOL_MAX_SIZE;
@@ -2681,11 +2680,6 @@ class MempoolOptions {
     if (options.rejectAbsurdFees != null) {
       assert(typeof options.rejectAbsurdFees === 'boolean');
       this.rejectAbsurdFees = options.rejectAbsurdFees;
-    }
-
-    if (options.prematureWitness != null) {
-      assert(typeof options.prematureWitness === 'boolean');
-      this.prematureWitness = options.prematureWitness;
     }
 
     if (options.paranoidChecks != null) {


### PR DESCRIPTION
The `prematureWitness` options isn't used anywhere in the codebase besides in these places. It is initialized, the type is asserted and then a value is set. It is not relevant to the Handshake codebase