### PR TITLE
node/rpc: peer fullname, netaddress getkey

### DIFF
--- a/lib/net/netaddress.js
+++ b/lib/net/netaddress.js
@@ -9,6 +9,7 @@
 const assert = require('bsert');
 const bio = require('bufio');
 const IP = require('binet');
+const base32 = require('bs32');
 const Network = require('../protocol/network');
 const util = require('../utils/util');
 const common = require('./common');
@@ -250,6 +251,22 @@ class NetAddress extends bio.Struct {
 
     assert(Buffer.isBuffer(key) && key.length === 33);
     this.key = key;
+  }
+
+  /**
+   * Get key
+   * @param {String} enc
+   * @returns {String|Buffer}
+   */
+
+  getKey(enc) {
+    if (enc === 'base32')
+      return base32.encode(this.key);
+
+    if (enc === 'hex')
+      return this.key.toString('hex');
+
+    return this.key;
   }
 
   /**

--- a/lib/net/peer.js
+++ b/lib/net/peer.js
@@ -11,6 +11,7 @@ const EventEmitter = require('events');
 const {Lock} = require('bmutex');
 const {format} = require('util');
 const tcp = require('btcp');
+const IP = require('binet');
 const dns = require('bdns');
 const Logger = require('blgr');
 const {RollingFilter} = require('bfilter');
@@ -201,6 +202,28 @@ class Peer extends EventEmitter {
 
   hostname() {
     return this.address.hostname;
+  }
+
+  /**
+   * Getter to retrieve fullname.
+   * @returns {String}
+   */
+
+  fullname() {
+    return this.address.fullname();
+  }
+
+  /**
+   * Getter to retrieve local fullname.
+   * Pull the key from this.address to
+   * prevent storing the key twice
+   * @returns {String}
+   */
+
+  localname() {
+    const {hostname, port} = this.local;
+    const key = this.address.getKey();
+    return IP.toHostname(hostname, port, key);
   }
 
   /**

--- a/lib/node/rpc.js
+++ b/lib/node/rpc.js
@@ -485,9 +485,9 @@ class RPC extends RPCBase {
 
       peers.push({
         id: peer.id,
-        addr: peer.hostname(),
+        addr: peer.address.fullname(),
         addrlocal: !peer.local.isNull()
-          ? peer.local.hostname
+          ? peer.local.fullname()
           : undefined,
         name: peer.name || undefined,
         services: hex32(peer.services),

--- a/lib/node/rpc.js
+++ b/lib/node/rpc.js
@@ -485,9 +485,9 @@ class RPC extends RPCBase {
 
       peers.push({
         id: peer.id,
-        addr: peer.address.fullname(),
+        addr: peer.fullname(),
         addrlocal: !peer.local.isNull()
-          ? peer.local.fullname()
+          ? peer.localname()
           : undefined,
         name: peer.name || undefined,
         services: hex32(peer.services),


### PR DESCRIPTION

Use the peer method fullname to render the
full address returned in the peer json propery
addr. This matches the hosts.json file, where
addr is pubkey@ip:port. This is useful information
for building automation and helpful when sharing
peers with other people, so that the hosts.json
file doesn't need to be inspected.

Add a getKey method to the NetAddress. The
method accepts an optional string that
determines the serialization of the return
value. The serialization can be base32, hex
or will otherwise return a buffer.

Add fullname and localname methods to the
Peer class. fullname wraps the peer's
address.fullname and localname returns
the local address's fullname. Since
the local address should share the same
key as the address, there is no need to
hold both in memory. localname renders
the the full hostname using the address's
key along with the local hostname and port.

The peer should return its identity key as part of
the API. The getpeerinfo response should now return
the fullname for the addrlocal field.
