### PR TITLE
cli: fix typo

### DIFF
--- a/bin/cli
+++ b/bin/cli
@@ -4,7 +4,7 @@
 
 console.error('%s%s',
   'Warning: The `hsd cli` interface is deprecated.\n',
-  'Please use `hsd-cli` ($ npm install bclient).');
+  'Please use `hsd-cli` ($ npm install hs-client).');
 
 if (process.argv.length > 2 && process.argv[2] === 'wallet') {
   process.argv.splice(2, 1); // Evil hack.


### PR DESCRIPTION
Simple fix for the warning message to give the correct installation command. It was still instructing users to install `bclient` when instead it should instruct users to install `hs-client` 