### PR TITLE
net/netaddress: add getKey method

### DIFF
--- a/lib/net/netaddress.js
+++ b/lib/net/netaddress.js
@@ -206,6 +206,37 @@ class NetAddress extends bio.Struct {
   }
 
   /**
+   * Get key
+   * @param {String?} enc - Can be `"base32"`, `"hex"` or `null`.
+   * @returns {Buffer|String}
+   */
+
+  getKey(enc) {
+    if (enc === 'base32')
+      return base32.encode(this.key);
+
+    if (enc === 'hex')
+      return this.key.toString('hex');
+
+    return this.key;
+  }
+
+  /**
+   * Set key.
+   * @param {Buffer} key
+   */
+
+  setKey(key) {
+    if (!key) {
+      this.key = ZERO_KEY;
+      return;
+    }
+
+    assert(Buffer.isBuffer(key) && key.length === 33);
+    this.key = key;
+  }
+
+  /**
    * Set null host.
    */
 
@@ -235,21 +266,6 @@ class NetAddress extends bio.Struct {
     assert(port >= 0 && port <= 0xffff);
     this.port = port;
     this.hostname = IP.toHostname(this.host, port);
-  }
-
-  /**
-   * Set key.
-   * @param {Buffer} key
-   */
-
-  setKey(key) {
-    if (!key) {
-      this.key = ZERO_KEY;
-      return;
-    }
-
-    assert(Buffer.isBuffer(key) && key.length === 33);
-    this.key = key;
   }
 
   /**


### PR DESCRIPTION
```
Add a getKey method to the NetAddress. The
method accepts an optional string that
determines the serialization of the return
value. The serialization can be base32, hex
or will otherwise return a buffer.
```

It also moves the `setKey` function to be next to the `getKey` function