### PR TITLE
Update README.md For Fixing npm python2 issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,9 @@
 ```
 $ git clone git://github.com/handshake-org/hsd.git
 $ cd hsd
+$ (tr : \\n <<< $PATH | while read p ; do ls -l $p/python* 2> /dev/null ; done) | sort
+$ (install python2 if you find none from the above output, or do the following if you have python3 as default)
+$ npm config set python /usr/bin/python2.7 
 $ npm install --production
 $ ./bin/hsd
 ```


### PR DESCRIPTION
Add error fix for npm python2 dependency if you ran into problem like I did:

> bdb@1.1.7 install /Users/zhipeng/Workspace/hsd/node_modules/bdb
> node-gyp rebuild

gyp ERR! configure error 
gyp ERR! stack Error: Command failed: /anaconda3/bin/python -c import sys; print "%s.%s.%s" % sys.version_info[:3];
gyp ERR! stack   File "<string>", line 1
gyp ERR! stack     import sys; print "%s.%s.%s" % sys.version_info[:3];
gyp ERR! stack                                ^
gyp ERR! stack SyntaxError: invalid syntax
gyp ERR! stack 
gyp ERR! stack     at ChildProcess.exithandler (child_process.js:297:12)
gyp ERR! stack     at ChildProcess.emit (events.js:193:13)
gyp ERR! stack     at maybeClose (internal/child_process.js:1001:16)
gyp ERR! stack     at Socket.stream.socket.on (internal/child_process.js:405:11)
gyp ERR! stack     at Socket.emit (events.js:193:13)
gyp ERR! stack     at Pipe._handle.close (net.js:614:12)
gyp ERR! System Darwin 18.5.0
gyp ERR! command "/usr/local/Cellar/node/11.13.0/bin/node" "/usr/local/lib/node_modules/npm/node_modules/node-gyp/bin/node-gyp.js" "rebuild"
gyp ERR! cwd /Users/zhipeng/Workspace/hsd/node_modules/bdb
gyp ERR! node -v v11.13.0
gyp ERR! node-gyp -v v3.8.0
gyp ERR! not ok 
npm WARN optional SKIPPING OPTIONAL DEPENDENCY: unbound@0.3.4 (node_modules/unbound):
npm WARN optional SKIPPING OPTIONAL DEPENDENCY: unbound@0.3.4 install: `node-gyp rebuild`
npm WARN optional SKIPPING OPTIONAL DEPENDENCY: Exit status 1

npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! bdb@1.1.7 install: `node-gyp rebuild`
npm ERR! Exit status 1
npm ERR! 
npm ERR! Failed at the bdb@1.1.7 install script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/zhipeng/.npm/_logs/2019-04-07T00_18_34_789Z-debug.log