### PR TITLE
readme: update mining instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,8 +95,7 @@ $ hsd --listen --max-inbound=20
 
 ### Mining
 
-To mine with getwork on a GPU, HSD should be used in combination with
-[hs-miner] and [hs-client].
+To mine with a CPU, HSD should be used in combination with [hs-client].
 
 ``` bash
 # To boot and listen publicly on the HTTP server...
@@ -105,12 +104,12 @@ $ hsd --http-host '::' --api-key 'hunter2' \
   --coinbase-address 'ts1qsu62stru80svj5xk6mescy65v0lhg8xxtweqsr'
 ```
 
-Once HSD is running, we can run [hs-miner] on a machine with a CUDA-capable
-GPU and point it at our full node.
+Once HSD is running, we can use [hs-client] to activate the miner
+using the `setgenerate` RPC.
 
 ``` bash
-$ hs-miner --rpc-host 'my-ip-address' \
-  --rpc-user hnsrpc --rpc-pass 'hunter2'
+$ hsd-rpc --http-host 'my-ip-address' \
+  --api-key 'hunter2' setgenerate true 1
 ```
 
 ### Airdrop & Faucet


### PR DESCRIPTION
Users are confused because the Proof of Work algorithm has
changed and hs-miner is no longer the best way to mine.
It was observed during testnet3 that hashrate for the hsd
miner was far greater than the hashrate for hs-miner. There
is also a bug in hs-miner regarding an incorrect header size.
This PR updates the README.md to only mention the hsd CPU miner.
Community members are working on a GPU miner that is not
out of beta yet.

See:
https://github.com/handshake-org/hs-miner/issues/12
https://handshake.community/t/error-bad-header-size-when-starting-miner/66