### PR TITLE
wallet/http: allow creation of unsigned tx

### DIFF
--- a/lib/wallet/http.js
+++ b/lib/wallet/http.js
@@ -457,6 +457,7 @@ class HTTP extends Server {
       const valid = Validator.fromRequest(req);
       const passphrase = valid.str('passphrase');
       const outputs = valid.array('outputs', []);
+      const sign = valid.bool('sign', true);
 
       const options = {
         rate: valid.u64('rate'),
@@ -486,7 +487,8 @@ class HTTP extends Server {
 
       const tx = await req.wallet.createTX(options);
 
-      await req.wallet.sign(tx, passphrase);
+      if (sign)
+        await req.wallet.sign(tx, passphrase);
 
       res.json(200, tx.getJSON(this.network));
     });


### PR DESCRIPTION
Add a `sign` parameter that defaults to true.
The created transaction will only be signed if
`sign` is true. This makes it much easier to
create transactions for wallets where the keys
are not stored on the server. The client can pass
`sign: false` and the request will return an
unsigned transaction that can be signed using
a hardware device.