### PR TITLE
util: make hex32 function more concise.

### DIFF
--- a/lib/node/rpc.js
+++ b/lib/node/rpc.js
@@ -325,7 +325,7 @@ class RPC extends RPCBase {
       version: pkg.version,
       subversion: this.pool.options.agent,
       protocolversion: this.pool.options.version,
-      localservices: hex32(this.pool.options.services),
+      localservices: util.hex32(this.pool.options.services),
       localrelay: !this.pool.options.noRelay,
       timeoffset: this.network.time.offset,
       networkactive: this.pool.connected,
@@ -490,7 +490,7 @@ class RPC extends RPCBase {
           ? peer.local.hostname
           : undefined,
         name: peer.name || undefined,
-        services: hex32(peer.services),
+        services: util.hex32(peer.services),
         relaytxes: !peer.noRelay,
         lastsend: peer.lastSend / 1000 | 0,
         lastrecv: peer.lastRecv / 1000 | 0,
@@ -1484,7 +1484,7 @@ class RPC extends RPCBase {
       filterroot: attempt.filterRoot.toString('hex'),
       reservedroot: attempt.reservedRoot.toString('hex'),
       target: attempt.target.toString('hex'),
-      bits: hex32(attempt.bits),
+      bits: util.hex32(attempt.bits),
       noncerange:
         Array(consensus.NONCE_SIZE + 1).join('00')
         + Array(consensus.NONCE_SIZE + 1).join('ff'),
@@ -1496,7 +1496,9 @@ class RPC extends RPCBase {
       // sizelimit: consensus.MAX_RAW_BLOCK_SIZE,
       sizelimit: consensus.MAX_BLOCK_SIZE,
       weightlimit: consensus.MAX_BLOCK_WEIGHT,
-      longpollid: this.chain.tip.hash.toString('hex') + hex32(this.totalTX()),
+      longpollid:
+        this.chain.tip.hash.toString('hex')
+        + util.hex32(this.totalTX()),
       submitold: false,
       coinbaseaux: {
         flags: attempt.coinbaseFlags.toString('hex')
@@ -2857,7 +2859,7 @@ class RPC extends RPCBase {
       confirmations: this.chain.height - entry.height + 1,
       height: entry.height,
       version: entry.version,
-      versionHex: hex32(entry.version),
+      versionHex: util.hex32(entry.version),
       merkleroot: entry.merkleRoot.toString('hex'),
       witnessroot: entry.witnessRoot.toString('hex'),
       treeroot: entry.treeRoot.toString('hex'),
@@ -2897,7 +2899,7 @@ class RPC extends RPCBase {
       weight: block.getWeight(),
       height: entry.height,
       version: entry.version,
-      versionHex: hex32(entry.version),
+      versionHex: util.hex32(entry.version),
       merkleroot: entry.merkleRoot.toString('hex'),
       witnessroot: entry.witnessRoot.toString('hex'),
       treeroot: entry.treeRoot.toString('hex'),
@@ -2992,19 +2994,6 @@ function toDifficulty(bits) {
   }
 
   return diff;
-}
-
-function hex32(num) {
-  assert(num >= 0);
-
-  num = num.toString(16);
-
-  assert(num.length <= 8);
-
-  while (num.length < 8)
-    num = '0' + num;
-
-  return num;
 }
 
 /*

--- a/lib/utils/util.js
+++ b/lib/utils/util.js
@@ -100,28 +100,16 @@ util.time = function time(date) {
  */
 
 util.hex32 = function hex32(num) {
-  assert((num >>> 0) === num);
+  assert(num >= 0);
+
   num = num.toString(16);
-  switch (num.length) {
-    case 1:
-      return `0000000${num}`;
-    case 2:
-      return `000000${num}`;
-    case 3:
-      return `00000${num}`;
-    case 4:
-      return `0000${num}`;
-    case 5:
-      return `000${num}`;
-    case 6:
-      return `00${num}`;
-    case 7:
-      return `0${num}`;
-    case 8:
-      return `${num}`;
-    default:
-      throw new Error();
-  }
+
+  assert(num.length <= 8);
+
+  while (num.length < 8)
+    num = '0' + num;
+
+  return num;
 };
 
 /**


### PR DESCRIPTION
This commit takes the more concise hex32 function from node/rpc and
replaces the current util hex32 function with it. It then replaces all
calls to hex32 in node/rpc with util.hex32 to remain consistent with
all other files in the repo.