### PR TITLE
docker: add gmp-dev to fix compilation issues on Alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ COPY package.json \
 
 # Install build dependencies and compile
 FROM base AS build
-RUN apk add --no-cache g++ gcc make python2
+RUN apk add --no-cache g++ gcc make python2 gmp-dev
 RUN npm install --production
 
 FROM base


### PR DESCRIPTION
Recent versions of bcrypto have been linking to gmp.h which is causing
build issues inside of the alpine dockerfile.

This commit adds gmp-dev to the dependencies installed in the dockerfile
before npm install is called - allowing bcrypto to be compiled
successfully.