### PR TITLE
mempool: reflect spent coins in mempool coinview

### DIFF
--- a/lib/mempool/mempool.js
+++ b/lib/mempool/mempool.js
@@ -756,6 +756,28 @@ class Mempool extends EventEmitter {
   }
 
   /**
+   * Check whether coin is still unspent.
+   * @param {Hash} hash
+   * @param {Number} index
+   * @returns {boolean}
+   */
+
+  hasCoin(hash, index) {
+    const entry = this.map.get(hash);
+
+    if (!entry)
+      return false;
+
+    if (this.isSpent(hash, index))
+      return false;
+
+    if (index >= entry.tx.outputs.length)
+      return false;
+
+    return true;
+  }
+
+  /**
    * Check to see if a coin has been spent. This differs from
    * {@link ChainDB#isSpent} in that it actually maintains a
    * map of spent coins, whereas ChainDB may return `true`
@@ -2296,6 +2318,8 @@ class Mempool extends EventEmitter {
 
   /**
    * Get coin viewpoint (lock).
+   * Note: this does not return the historical
+   * view of coins from the indexers
    * @method
    * @param {TX} tx
    * @returns {Promise} - Returns {@link CoinView}.
@@ -2304,10 +2328,38 @@ class Mempool extends EventEmitter {
   async getSpentView(tx) {
     const unlock = await this.locker.lock();
     try {
-      return await this.getCoinView(tx);
+      return await this._getSpentView(tx);
     } finally {
       unlock();
     }
+  }
+
+  /**
+   * Get coin viewpoint
+   * @param {TX} tx
+   * @returns {Promise} - Returns {@link CoinView}
+   */
+
+  async _getSpentView(tx) {
+    const view = new CoinView();
+
+    for (const {prevout} of tx.inputs) {
+      const {hash, index} = prevout;
+      const tx = this.getTX(hash);
+
+      if (tx) {
+        if (index < tx.outputs.length)
+          view.addIndex(tx, index, -1);
+        continue;
+      }
+
+      const coin = await this.chain.readCoin(prevout);
+
+      if (coin)
+        view.addEntry(prevout, coin);
+    }
+
+    return view;
   }
 
   /**
@@ -2325,7 +2377,7 @@ class Mempool extends EventEmitter {
       const tx = this.getTX(hash);
 
       if (tx) {
-        if (index < tx.outputs.length)
+        if (this.hasCoin(hash, index))
           view.addIndex(tx, index, -1);
         continue;
       }


### PR DESCRIPTION
This updates the Mempool so that `mempool.getSpentView` specifically returns coins in the mempool that have been spent by other coins in the mempool.  Currently `mempool.getSpentView` just wraps `mempool.getCoinView`, so there is no functional distinction between the two methods.

It adds a test to cover the new functionality

This is a port of bcoin commit: 32cba1bf4aa293bcf49c1849587dc1482ce98050
https://github.com/bcoin-org/bcoin/commit/32cba1bf4aa293bcf49c1849587dc1482ce98050

