### PR TITLE
various: convert buffer to string for JSON

### DIFF
--- a/lib/node/rpc.js
+++ b/lib/node/rpc.js
@@ -709,7 +709,7 @@ class RPC extends RPCBase {
     if (!hash)
       throw new RPCError(errs.MISC_ERROR, 'Not found.');
 
-    return hash;
+    return hash.toString('hex');
   }
 
   async getBlockHeader(args, help) {

--- a/lib/primitives/tx.js
+++ b/lib/primitives/tx.js
@@ -1671,7 +1671,7 @@ class TX extends bio.Struct {
 
     if (entry) {
       height = entry.height;
-      block = entry.hash;
+      block = entry.hash.toString('hex');
       time = entry.time;
       date = util.date(time);
     }

--- a/lib/primitives/txmeta.js
+++ b/lib/primitives/txmeta.js
@@ -132,7 +132,7 @@ class TXMeta extends bio.Struct {
     const json = this.tx.getJSON(network, view, null, this.index);
     json.mtime = this.mtime;
     json.height = this.height;
-    json.block = this.block ? this.block : null;
+    json.block = this.block ? this.block.toString('hex') : null;
     json.time = this.time;
     json.confirmations = 0;
 

--- a/test/txmeta-test.js
+++ b/test/txmeta-test.js
@@ -10,7 +10,7 @@ const TXMeta = require('../lib/primitives/txmeta');
 const network = Network.get('regtest');
 
 describe('TXMeta', function() {
-  it('should return JSON for txmeta', async () => {
+  it('should return correct confirmations', async () => {
     // unconfirmed at height 100
     const txmeta1 = new TXMeta();
     const txJSON1 = txmeta1.getJSON(network, null, 100);
@@ -21,5 +21,14 @@ describe('TXMeta', function() {
     txmeta2.height = 100;
     const txJSON2 = txmeta2.getJSON(network, null, 100);
     assert.strictEqual(txJSON2.confirmations, 1);
+  });
+
+  it('should return blockhash as string', async () => {
+    // confirmed once at height 100
+    const block = Buffer.from('058f5cf9187d9f60729245956688022474ffc0eda80df6340a2053d5c4d149af');
+    const txmeta2 = TXMeta.fromOptions({ block });
+    const txJSON2 = txmeta2.getJSON(network, null, null);
+
+    assert.strictEqual(txJSON2.block, block.toString('hex'));
   });
 });


### PR DESCRIPTION
```
This commit adds the toString('hex') function to the following places:
- primitives -> txmeta -> getJSON()
- primitives -> tx -> format()
- node -> rpc -> getblockhash
In addition it adds a small test to txmeta-test to ensure that the getJSON function is working accordingly. 
```