### PR TITLE
exports: export Covenant along with other primitives

### DIFF
--- a/lib/hsd.js
+++ b/lib/hsd.js
@@ -95,6 +95,7 @@ hsd.define('primitives', './primitives');
 hsd.define('Address', './primitives/address');
 hsd.define('Block', './primitives/block');
 hsd.define('Coin', './primitives/coin');
+hsd.define('Covenant', './primitives/covenant');
 hsd.define('Headers', './primitives/headers');
 hsd.define('Input', './primitives/input');
 hsd.define('InvItem', './primitives/invitem');


### PR DESCRIPTION
This commit simply adds the Covenant to the list of exports. It's a
primtive that I believe is used quite a bit by external developers, so
it would be very useful to have it exported easily rather than having
the developers manually point to the path, especially considering that
every other primitive that makes up a block -> transaction is exported.