### PR TITLE
coinentry: remove unused parameter from JSDoc

### DIFF
--- a/lib/coins/coinentry.js
+++ b/lib/coins/coinentry.js
@@ -118,7 +118,6 @@ class CoinEntry extends bio.Struct {
   /**
    * Instantiate a coin from a TX
    * @param {TX} tx
-   * @param {Number} index - Output index.
    * @returns {CoinEntry}
    */
 


### PR DESCRIPTION
This commit just removes the index parameter from jsdoc as the function
no longer requires that parameter at all.