### PR TITLE
node/http: get name info

### DIFF
--- a/lib/node/http.js
+++ b/lib/node/http.js
@@ -20,6 +20,7 @@ const TX = require('../primitives/tx');
 const Claim = require('../primitives/claim');
 const Address = require('../primitives/address');
 const Network = require('../protocol/network');
+const rules = require('../covenants/rules');
 const pkg = require('../pkg');
 
 /**
@@ -355,6 +356,35 @@ class HTTP extends Server {
       await this.node.sendClaim(claim);
 
       res.json(200, { success: true });
+    });
+
+    // Get Name Info
+    this.get('/info/name/:name', async (req, res) => {
+      const valid = Validator.fromRequest(req);
+      const name = valid.str('name');
+
+      const network = this.network;
+      const height = this.chain.height;
+      const nameHash = rules.hashName(name);
+      const reserved = rules.isReserved(nameHash, height + 1, network);
+      const [start, week] = rules.getRollout(nameHash, network);
+      const ns = await this.chain.db.getNameState(nameHash);
+
+      let info = null;
+
+      if (ns) {
+        if (!ns.isExpired(height, network))
+          info = ns.getJSON(height, network);
+      }
+
+      res.json(200, {
+        start: {
+          reserved: reserved,
+          week: week,
+          start: start
+        },
+        info
+      });
     });
 
     // Estimate fee

--- a/test/http-test.js
+++ b/test/http-test.js
@@ -12,6 +12,7 @@ const Script = require('../lib/script/script');
 const FullNode = require('../lib/node/fullnode');
 const pkg = require('../lib/pkg');
 const Network = require('../lib/protocol/network');
+const rules = require('../lib/covenants/rules');
 const network = Network.get('regtest');
 
 const node = new FullNode({
@@ -307,6 +308,26 @@ describe('HTTP', function() {
       isvalid: true,
       witness_version: nullAddr.version,
       witness_program: nullAddr.hash.toString('hex')
+    });
+  });
+
+  it('should get name info', async () => {
+    const name = 'foobar';
+    const json = await nclient.get(`/info/name/${name}`);
+
+    const info = await nclient.getInfo();
+    const nameHash = rules.hashName(name);
+    const height = info.chain.height;
+    const [start, week] = rules.getRollout(nameHash, node.network);
+    const reserved = rules.isReserved(nameHash, height + 1, node.network);
+
+    assert.deepStrictEqual(json, {
+      start: {
+        reserved: reserved,
+        week: week,
+        start: start
+      },
+      info: null
     });
   });
 


### PR DESCRIPTION
This ports the node RPC getnameinfo to the
HTTP endpoint GET /info/name/:name and
includes a simple test.

See RPC implementation here:
https://github.com/handshake-org/hsd/blob/b32c27bbb05e69b86c0e80aea3ecc394c5589186/lib/node/rpc.js#L2313

This could also benefit from a PR to `hs-client` that adds a wrapper for
`client.get('/info/name/:name')`.