### PR TITLE
lint: convert eslint to bslint for ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ jobs:
           # fallback to using the latest cache if no exact match is found
           - v1-dependencies-
       - run: npm install
-      - run: npm install eslint babel-eslint istanbul@1.1.0-alpha.1 codecov
+      - run: npm install bslint istanbul@1.1.0-alpha.1 codecov
       - save_cache:
           paths:
             - node_modules


### PR DESCRIPTION
Currently we aren't able to run linting on Handshake without a globally
installed eslint. This will install bslint which should cover all of the
linting needs, as well as removes eslint install from the ci script.