### PR TITLE
wallet: add locktime and sort params for HTTP send/create

### DIFF
--- a/lib/wallet/http.js
+++ b/lib/wallet/http.js
@@ -465,6 +465,8 @@ class HTTP extends Server {
         maxFee: valid.u64('maxFee'),
         selection: valid.str('selection'),
         smart: valid.bool('smart'),
+        sort: valid.bool('sort'),
+        locktime: valid.u64('locktime'),
         account: valid.str('account'),
         subtractFee: valid.bool('subtractFee'),
         subtractIndex: valid.i32('subtractIndex'),

--- a/lib/wallet/http.js
+++ b/lib/wallet/http.js
@@ -424,6 +424,8 @@ class HTTP extends Server {
         maxFee: valid.u64('maxFee'),
         selection: valid.str('selection'),
         smart: valid.bool('smart'),
+        sort: valid.bool('sort'),
+        locktime: valid.u64('locktime'),
         account: valid.str('account'),
         subtractFee: valid.bool('subtractFee'),
         subtractIndex: valid.i32('subtractIndex'),

--- a/test/wallet-http.js
+++ b/test/wallet-http.js
@@ -1,0 +1,138 @@
+/* eslint-env mocha */
+/* eslint prefer-arrow-callback: "off" */
+/* eslint no-return-assign: "off" */
+
+'use strict';
+
+const {NodeClient, WalletClient} = require('hs-client');
+const Network = require('../lib/protocol/network');
+const FullNode = require('../lib/node/fullnode');
+const MTX = require('../lib/primitives/mtx');
+
+const network = Network.get('regtest');
+const assert = require('bsert');
+
+const node = new FullNode({
+  network: 'regtest',
+  apiKey: 'foo',
+  walletAuth: true,
+  memory: true,
+  workers: true,
+  plugins: [require('../lib/wallet/plugin')]
+});
+
+const nclient = new NodeClient({
+  port: network.rpcPort,
+  apiKey: 'foo'
+});
+
+const wclient = new WalletClient({
+  port: network.walletPort,
+  apiKey: 'foo'
+});
+
+const wallet = wclient.wallet('primary');
+
+let cbAddress;
+
+describe('Wallet HTTP', function() {
+  this.timeout(15000);
+
+  before(async () => {
+    await node.open();
+    await nclient.open();
+    await wclient.open();
+
+    cbAddress = (await wallet.createAddress('default')).address;
+  });
+
+  after(async () => {
+    await nclient.close();
+    await wclient.close();
+    await node.close();
+  });
+
+  afterEach(async () => {
+    await node.mempool.reset();
+  });
+
+  it('should mine to the primary/default wallet', async () => {
+    const height = 20;
+
+    for (let i = 0; i < height; i++)
+      await nclient.execute('generatetoaddress', [1, cbAddress]);
+
+    const info = await nclient.getInfo();
+    assert.equal(info.chain.height, height);
+  });
+
+  it('should create a transaction', async () => {
+    const tx = await wallet.createTX({
+      outputs: [{ address: cbAddress, value: 1e4 }]
+    });
+
+    assert.ok(tx);
+    assert.equal(tx.outputs.length, 1 + 1); // send + change
+    assert.equal(tx.locktime, 0);
+  });
+
+  it('should create a transaction with a locktime', async () => {
+    const locktime = 8e6;
+
+    const tx = await wallet.createTX({
+      locktime: locktime,
+      outputs: [{ address: cbAddress, value: 1e4 }]
+    });
+
+    assert.equal(tx.locktime, locktime);
+  });
+
+  it('should create a transaction that is not bip 69 sorted', async () => {
+    // create a list of outputs that descend in value
+    // bip 69 sorts in ascending order based on the value
+    const outputs = [];
+    for (let i = 0; i < 5; i++) {
+      const addr = await wallet.createAddress('default');
+      outputs.push({ address: addr.address, value: (5 - i) * 1e5 });
+    }
+
+    const tx = await wallet.createTX({
+      outputs: outputs,
+      sort: false
+    });
+
+    // assert outputs in the same order that they were sent from the client
+    for (const [i, output] of outputs.entries()) {
+      assert.equal(tx.outputs[i].value, output.value);
+      assert.equal(tx.outputs[i].address.toString(network), output.address);
+    }
+
+    const mtx = MTX.fromJSON(tx);
+    mtx.sortMembers();
+
+    // the order changes after sorting
+    assert.ok(tx.outputs[0].value !== mtx.outputs[0].value);
+  });
+
+  it('should create a transaction that is bip 69 sorted', async () => {
+    const outputs = [];
+    for (let i = 0; i < 5; i++) {
+      const addr = await wallet.createAddress('default');
+      outputs.push({ address: addr.address, value: (5 - i) * 1e5 });
+    }
+
+    const tx = await wallet.createTX({
+      outputs: outputs
+    });
+
+    const mtx = MTX.fromJSON(tx);
+    mtx.sortMembers();
+
+    // assert the ordering of the outputs is the
+    // same after sorting the response client side
+    for (const [i, output] of tx.outputs.entries()) {
+      assert.equal(output.value, mtx.outputs[i].value);
+      assert.equal(output.address, mtx.outputs[i].address.toString(network));
+    }
+  });
+});


### PR DESCRIPTION
This exposes the parameters `locktime` and `sort` through the REST API for the endpoint.

`locktime` will set the nLocktime field on the transaction and `sort` will sort the inputs/outputs using [bip 69](https://github.com/bitcoin/bips/blob/master/bip-0069.mediawiki)

- `POST /wallet/:id/send`
- `POST /wallet/:id/create`

It also includes tests