### PR TITLE
node/rpc: add treeRoot to getblockchaininfo

### DIFF
--- a/lib/node/rpc.js
+++ b/lib/node/rpc.js
@@ -592,6 +592,7 @@ class RPC extends RPCBase {
       blocks: this.chain.height,
       headers: this.chain.height,
       bestblockhash: this.chain.tip.hash.toString('hex'),
+      treeRoot: this.chain.tip.treeRoot.toString('hex'),
       difficulty: toDifficulty(this.chain.tip.bits),
       mediantime: await this.chain.getMedianTime(this.chain.tip),
       verificationprogress: this.chain.getProgress(),


### PR DESCRIPTION
Add an additional field to the response of `getblockchaininfo` for the `treeRoot`

Partially addresses https://github.com/handshake-org/hsd/issues/167