### PR TITLE
node/http: expose treeRoot of tip

### DIFF
--- a/lib/node/http.js
+++ b/lib/node/http.js
@@ -124,6 +124,7 @@ class HTTP extends Server {
         chain: {
           height: this.chain.height,
           tip: this.chain.tip.hash.toString('hex'),
+          treeRoot: this.chain.tip.treeRoot.toString('hex'),
           progress: this.chain.getProgress()
         },
         pool: {

--- a/test/http-test.js
+++ b/test/http-test.js
@@ -13,6 +13,7 @@ const FullNode = require('../lib/node/fullnode');
 const pkg = require('../lib/pkg');
 const Network = require('../lib/protocol/network');
 const network = Network.get('regtest');
+const {ZERO_HASH} = consensus;
 
 const node = new FullNode({
   network: 'regtest',
@@ -66,6 +67,7 @@ describe('HTTP', function() {
     assert.strictEqual(info.pool.agent, node.pool.options.agent);
     assert(info.chain);
     assert.strictEqual(info.chain.height, 0);
+    assert.strictEqual(info.chain.treeRoot, ZERO_HASH.toString('hex'));
   });
 
   it('should get wallet info', async () => {


### PR DESCRIPTION
`GET /` will now return the chain tip's `treeRoot` property at `.chain.treeRoot`

Partially addresses https://github.com/handshake-org/hsd/issues/167