### PR TITLE
node/http: return txn hex

### DIFF
--- a/lib/node/http.js
+++ b/lib/node/http.js
@@ -125,13 +125,14 @@ class HTTP extends Server {
           height: this.chain.height,
           tip: this.chain.tip.hash.toString('hex'),
           treeRoot: this.chain.tip.treeRoot.toString('hex'),
-          progress: this.chain.getProgress(),
+          txn: this.chain.db.txn.rootHash().toString('hex'),
           state: {
             tx: this.chain.db.state.tx,
             coin: this.chain.db.state.coin,
             value: this.chain.db.state.value,
             burned: this.chain.db.state.burned
-          }
+          },
+          progress: this.chain.getProgress()
         },
         pool: {
           host: addr.host,


### PR DESCRIPTION
Add the hash of the database transaction to the
result of `GET /` for the node HTTP server. This
could be useful in conjunction with the proof API,
since `.chain.treeRoot` is lagging (only is committed
to disk every so often).