### PR TITLE
node/http: add db state info to response

### DIFF
--- a/lib/node/http.js
+++ b/lib/node/http.js
@@ -125,7 +125,13 @@ class HTTP extends Server {
           height: this.chain.height,
           tip: this.chain.tip.hash.toString('hex'),
           treeRoot: this.chain.tip.treeRoot.toString('hex'),
-          progress: this.chain.getProgress()
+          progress: this.chain.getProgress(),
+          state: {
+            tx: this.chain.db.state.tx,
+            coin: this.chain.db.state.coin,
+            value: this.chain.db.state.value,
+            burned: this.chain.db.state.burned
+          }
         },
         pool: {
           host: addr.host,

--- a/test/http-test.js
+++ b/test/http-test.js
@@ -68,6 +68,10 @@ describe('HTTP', function() {
     assert(info.chain);
     assert.strictEqual(info.chain.height, 0);
     assert.strictEqual(info.chain.treeRoot, ZERO_HASH.toString('hex'));
+    // state comes from genesis block
+    assert.strictEqual(info.chain.state.tx, 1);
+    assert.strictEqual(info.chain.state.coin, 1);
+    assert.strictEqual(info.chain.state.burned, 0);
   });
 
   it('should get wallet info', async () => {


### PR DESCRIPTION
Add an object for the db state at `.chain.state`
that has the fields `tx`, `coin`, `value`, `burned`.
These values are pulled from the `chain.db.state`.