### PR TITLE
wallet: handle multiple conflicting inputs

### DIFF
--- a/lib/wallet/txdb.js
+++ b/lib/wallet/txdb.js
@@ -1364,6 +1364,9 @@ class TXDB {
   async removeRecursive(wtx) {
     const {tx, hash} = wtx;
 
+    if (!await this.hasTX(hash))
+      return null;
+
     for (let i = 0; i < tx.outputs.length; i++) {
       const spent = await this.getSpent(hash, i);
 

--- a/test/wallet-test.js
+++ b/test/wallet-test.js
@@ -323,6 +323,36 @@ describe('Wallet', function() {
     assert.strictEqual((await wallet.getBalance()).unconfirmed, 0);
   });
 
+  it('should handle double-spend (multiple inputs)', async () => {
+    const wallet = await wdb.create();
+    const address = await wallet.receiveAddress();
+
+    const hash = random.randomBytes(32);
+    const input0 = Input.fromOutpoint(new Outpoint(hash, 0));
+    const input1 = Input.fromOutpoint(new Outpoint(hash, 1));
+
+    const txa = new MTX();
+    txa.addInput(input0);
+    txa.addInput(input1);
+    txa.addOutput(address, 50000);
+    await wdb.addTX(txa.toTX());
+    assert.strictEqual((await wallet.getBalance()).unconfirmed, 50000);
+
+    let conflict = false;
+    wallet.on('conflict', () => {
+      conflict = true;
+    });
+
+    const txb = new MTX();
+    txb.addInput(input0);
+    txb.addInput(input1);
+    txb.addOutput(address, 49000);
+    await wdb.addTX(txb.toTX());
+
+    assert(conflict);
+    assert.strictEqual((await wallet.getBalance()).unconfirmed, 49000);
+  });
+
   it('should handle more missed txs', async () => {
     const alice = await wdb.create();
     const bob = await wdb.create();


### PR DESCRIPTION
Handle double spend with multiple inputs. Port of
https://github.com/bcoin-org/bcoin/commit/eba7bbeddc3f22c69ee249bb4f87e0dc9bec1bf9