### PR TITLE
mtx: update addInput jsdoc

### DIFF
--- a/lib/primitives/mtx.js
+++ b/lib/primitives/mtx.js
@@ -116,7 +116,7 @@ class MTX extends TX {
    * @returns {Input}
    *
    * @example
-   * mtx.addInput({ prevout: { hash: ... }, script: ... });
+   * mtx.addInput({ prevout: { hash: ... }, witness: ... });
    * mtx.addInput(new Input());
    */
 


### PR DESCRIPTION
Quick fix in the JSDoc, replaces the word `script` with `witness`