### PR TITLE
wallet: add locks for create code paths

### DIFF
--- a/lib/wallet/wallet.js
+++ b/lib/wallet/wallet.js
@@ -2763,32 +2763,52 @@ class Wallet extends EventEmitter {
   }
 
   /**
-   * Create and finalize a cancel MTX.
+   * Create and finalize a cancel
+   * MTX without a lock.
    * @param {String} name
    * @param {Object} options
    * @returns {MTX}
    */
 
-  async createCancel(name, options) {
+  async _createCancel(name, options) {
     const mtx = await this.makeCancel(name);
     await this.fill(mtx, options);
     return this.finalize(mtx, options);
   }
 
   /**
-   * Create and send a cancel MTX.
+   * Create and finalize a cancel
+   * MTX with a lock.
+   * @param {String} name
+   * @param {Object} options
+   * @returns {MTX}
+   */
+
+  async createCancel(name, options) {
+    const unlock = await this.fundLock.lock();
+    try {
+      return await this._createCancel(name, options);
+    } finally {
+      unlock();
+    }
+  }
+
+  /**
+   * Create and send a cancel
+   * MTX without a lock.
    * @param {String} name
    * @param {Object} options
    */
 
   async _sendCancel(name, options) {
     const passphrase = options ? options.passphrase : null;
-    const mtx = await this.createCancel(name, options);
+    const mtx = await this._createCancel(name, options);
     return this.sendMTX(mtx, passphrase);
   }
 
   /**
-   * Create and send a cancel MTX.
+   * Create and send a cancel
+   * MTX with a lock.
    * @param {String} name
    * @param {Object} options
    */

--- a/lib/wallet/wallet.js
+++ b/lib/wallet/wallet.js
@@ -2897,32 +2897,52 @@ class Wallet extends EventEmitter {
   }
 
   /**
-   * Create and finalize a finalize MTX.
+   * Create and finalize a finalize
+   * MTX without a lock.
    * @param {String} name
    * @param {Object} options
    * @returns {MTX}
    */
 
-  async createFinalize(name, options) {
+  async _createFinalize(name, options) {
     const mtx = await this.makeFinalize(name);
     await this.fill(mtx, options);
     return this.finalize(mtx, options);
   }
 
   /**
-   * Create and send a finalize MTX.
+   * Create and finalize a finalize
+   * MTX with a lock.
+   * @param {String} name
+   * @param {Object} options
+   * @returns {MTX}
+   */
+
+  async createFinalize(name, options) {
+    const unlock = await this.fundLock.lock();
+    try {
+      return await this._createFinalize(name, options);
+    } finally {
+      unlock();
+    }
+  }
+
+  /**
+   * Create and send a finalize
+   * MTX without a lock.
    * @param {String} name
    * @param {Object} options
    */
 
   async _sendFinalize(name, options) {
     const passphrase = options ? options.passphrase : null;
-    const mtx = await this.createFinalize(name, options);
+    const mtx = await this._createFinalize(name, options);
     return this.sendMTX(mtx, passphrase);
   }
 
   /**
-   * Create and send a finalize MTX.
+   * Create and send a finalize
+   * MTX with a lock.
    * @param {String} name
    * @param {Object} options
    */

--- a/lib/wallet/wallet.js
+++ b/lib/wallet/wallet.js
@@ -2383,7 +2383,23 @@ class Wallet extends EventEmitter {
   }
 
   /**
-   * Create and finalize an update MTX.
+   * Create and finalize an update
+   * MTX without a lock.
+   * @param {String} name
+   * @param {Resource} resource
+   * @param {Object} options
+   * @returns {MTX}
+   */
+
+  async _createUpdate(name, resource, options) {
+    const mtx = await this.makeUpdate(name, resource);
+    await this.fill(mtx, options);
+    return this.finalize(mtx, options);
+  }
+
+  /**
+   * Create and finalize an update
+   * MTX with a lock.
    * @param {String} name
    * @param {Resource} resource
    * @param {Object} options
@@ -2391,13 +2407,17 @@ class Wallet extends EventEmitter {
    */
 
   async createUpdate(name, resource, options) {
-    const mtx = await this.makeUpdate(name, resource);
-    await this.fill(mtx, options);
-    return this.finalize(mtx, options);
+    const unlock = await this.fundLock.lock();
+    try {
+      return await this._createUpdate(name, resource, options);
+    } finally {
+      unlock();
+    }
   }
 
   /**
-   * Create and send an update MTX.
+   * Create and send an update
+   * MTX without a lock.
    * @param {String} name
    * @param {Resource} resource
    * @param {Object} options
@@ -2405,12 +2425,13 @@ class Wallet extends EventEmitter {
 
   async _sendUpdate(name, resource, options) {
     const passphrase = options ? options.passphrase : null;
-    const mtx = await this.createUpdate(name, resource, options);
+    const mtx = await this._createUpdate(name, resource, options);
     return this.sendMTX(mtx, passphrase);
   }
 
   /**
-   * Create and send an update MTX.
+   * Create and send an update
+   * MTX with a lock.
    * @param {String} name
    * @param {Resource} resource
    * @param {Object} options

--- a/lib/wallet/wallet.js
+++ b/lib/wallet/wallet.js
@@ -1537,14 +1537,15 @@ class Wallet extends EventEmitter {
   }
 
   /**
-   * Create and finalize a open MTX.
+   * Create and finalize an open
+   * MTX without a lock.
    * @param {String} name
    * @param {Boolean} force
    * @param {Object} options
    * @returns {MTX}
    */
 
-  async createOpen(name, force, options) {
+  async _createOpen(name, force, options) {
     const acct = options ? options.account || 0 : 0;
     const mtx = await this.makeOpen(name, force, acct);
     await this.fill(mtx, options);
@@ -1552,7 +1553,26 @@ class Wallet extends EventEmitter {
   }
 
   /**
-   * Create and send a open MTX.
+   * Create and finalize an open
+   * MTX with a lock.
+   * @param {String} name
+   * @param {Boolean} force
+   * @param {Object} options
+   * @returns {MTX}
+   */
+
+  async createOpen(name, force, options) {
+    const unlock = await this.fundLock.lock();
+    try {
+      return await this._createOpen(name, force, options);
+    } finally {
+      unlock();
+    }
+  }
+
+  /**
+   * Create and send an open
+   * MTX without a lock.
    * @param {String} name
    * @param {Boolean} force
    * @param {Object} options
@@ -1560,12 +1580,13 @@ class Wallet extends EventEmitter {
 
   async _sendOpen(name, force, options) {
     const passphrase = options ? options.passphrase : null;
-    const mtx = await this.createOpen(name, force, options);
+    const mtx = await this._createOpen(name, force, options);
     return this.sendMTX(mtx, passphrase);
   }
 
   /**
-   * Create and send a open MTX.
+   * Create and send an open
+   * MTX with a lock.
    * @param {String} name
    * @param {Boolean} force
    * @param {Object} options

--- a/lib/wallet/wallet.js
+++ b/lib/wallet/wallet.js
@@ -2057,32 +2057,52 @@ class Wallet extends EventEmitter {
   }
 
   /**
-   * Create and finalize a redeem MTX.
+   * Create and finalize a redeem
+   * MTX without a lock.
    * @param {String} name
    * @param {Object} options
    * @returns {MTX}
    */
 
-  async createRedeem(name, options) {
+  async _createRedeem(name, options) {
     const mtx = await this.makeRedeem(name);
     await this.fill(mtx, options);
     return this.finalize(mtx, options);
   }
 
   /**
-   * Create and send a redeem MTX.
+   * Create and finalize a redeem
+   * MTX with a lock.
+   * @param {String} name
+   * @param {Object} options
+   * @returns {MTX}
+   */
+
+  async createRedeem(name, options) {
+    const unlock = await this.fundLock.lock();
+    try {
+      return await this._createRedeem(name, options);
+    } finally {
+      unlock();
+    }
+  }
+
+  /**
+   * Create and send a redeem
+   * MTX without a lock.
    * @param {String} name
    * @param {Object} options
    */
 
   async _sendRedeem(name, options) {
     const passphrase = options ? options.passphrase : null;
-    const mtx = await this.createRedeem(name, options);
+    const mtx = await this._createRedeem(name, options);
     return this.sendMTX(mtx, passphrase);
   }
 
   /**
-   * Create and send a redeem MTX.
+   * Create and send a redeem
+   * MTX with a lock.
    * @param {String} name
    * @param {Object} options
    */

--- a/lib/wallet/wallet.js
+++ b/lib/wallet/wallet.js
@@ -3018,32 +3018,52 @@ class Wallet extends EventEmitter {
   }
 
   /**
-   * Create and finalize an update MTX.
+   * Create and finalize a revoke
+   * MTX without a lock.
    * @param {String} name
    * @param {Object} options
    * @returns {MTX}
    */
 
-  async createRevoke(name, options) {
+  async _createRevoke(name, options) {
     const mtx = await this.makeRevoke(name);
     await this.fill(mtx, options);
     return this.finalize(mtx, options);
   }
 
   /**
-   * Create and send an update MTX.
+   * Create and finalize a revoke
+   * MTX with a lock.
+   * @param {String} name
+   * @param {Object} options
+   * @returns {MTX}
+   */
+
+  async createRevoke(name, options) {
+    const unlock = await this.fundLock.lock();
+    try {
+      return await this._createRevoke(name, options);
+    } finally {
+      unlock();
+    }
+  }
+
+  /**
+   * Create and send a revoke
+   * MTX without a lock.
    * @param {String} name
    * @param {Object} options
    */
 
   async _sendRevoke(name, options) {
     const passphrase = options ? options.passphrase : null;
-    const mtx = await this.createRevoke(name);
+    const mtx = await this._createRevoke(name);
     return this.sendMTX(mtx, passphrase);
   }
 
   /**
-   * Create and send an update MTX.
+   * Create and send a revoke
+   * MTX with a lock.
    * @param {String} name
    * @param {Object} options
    */

--- a/lib/wallet/wallet.js
+++ b/lib/wallet/wallet.js
@@ -1934,25 +1934,42 @@ class Wallet extends EventEmitter {
   }
 
   /**
-   * Create and finalize a bid MTX.
+   * Create and finalize a reveal all
+   * MTX without a lock.
    * @param {Object} options
    * @returns {MTX}
    */
 
-  async createRevealAll(options) {
+  async _createRevealAll(options) {
     const mtx = await this.makeRevealAll();
     await this.fill(mtx, options);
     return this.finalize(mtx, options);
   }
 
   /**
-   * Create and send a bid MTX.
+   * Create and finalize a reveal all
+   * MTX with a lock.
+   * @param {Object} options
+   * @returns {MTX}
+   */
+
+  async createRevealAll(options) {
+    const unlock = await this.fundLock.lock();
+    try {
+      return await this._createRevealAll(options);
+    } finally {
+      unlock();
+    }
+  }
+
+  /**
+   * Create and send a reveal all MTX.
    * @param {Object} options
    */
 
   async _sendRevealAll(options) {
     const passphrase = options ? options.passphrase : null;
-    const mtx = await this.createRevealAll(options);
+    const mtx = await this._createRevealAll(options);
     return this.sendMTX(mtx, passphrase);
   }
 

--- a/lib/wallet/wallet.js
+++ b/lib/wallet/wallet.js
@@ -1668,7 +1668,25 @@ class Wallet extends EventEmitter {
   }
 
   /**
-   * Create and finalize a bid MTX.
+   * Create and finalize a bid
+   * MTX without a lock.
+   * @param {String} name
+   * @param {Number} value
+   * @param {Number} lockup
+   * @param {Object} options
+   * @returns {MTX}
+   */
+
+  async _createBid(name, value, lockup, options) {
+    const acct = options ? options.account || 0 : 0;
+    const mtx = await this.makeBid(name, value, lockup, acct);
+    await this.fill(mtx, options);
+    return this.finalize(mtx, options);
+  }
+
+  /**
+   * Create and finalize a bid
+   * MTX with a lock.
    * @param {String} name
    * @param {Number} value
    * @param {Number} lockup
@@ -1677,10 +1695,12 @@ class Wallet extends EventEmitter {
    */
 
   async createBid(name, value, lockup, options) {
-    const acct = options ? options.account || 0 : 0;
-    const mtx = await this.makeBid(name, value, lockup, acct);
-    await this.fill(mtx, options);
-    return this.finalize(mtx, options);
+    const unlock = await this.fundLock.lock();
+    try {
+      return await this._createBid(name, value, lockup, options);
+    } finally {
+      unlock();
+    }
   }
 
   /**
@@ -1693,7 +1713,7 @@ class Wallet extends EventEmitter {
 
   async _sendBid(name, value, lockup, options) {
     const passphrase = options ? options.passphrase : null;
-    const mtx = await this.createBid(name, value, lockup, options);
+    const mtx = await this._createBid(name, value, lockup, options);
     return this.sendMTX(mtx, passphrase);
   }
 

--- a/lib/wallet/wallet.js
+++ b/lib/wallet/wallet.js
@@ -2178,30 +2178,49 @@ class Wallet extends EventEmitter {
   }
 
   /**
-   * Create and finalize a redeem MTX.
+   * Create and finalize a redeem
+   * all MTX without a lock.
    * @param {Object} options
    * @returns {MTX}
    */
 
-  async createRedeemAll(options) {
+  async _createRedeemAll(options) {
     const mtx = await this.makeRedeemAll();
     await this.fill(mtx, options);
     return this.finalize(mtx, options);
   }
 
   /**
-   * Create and send a redeem MTX.
+   * Create and finalize a redeem
+   * all MTX with a lock.
+   * @param {Object} options
+   * @returns {MTX}
+   */
+
+  async createRedeemAll(options) {
+    const unlock = await this.fundLock.lock();
+    try {
+      return await this._createRedeemAll(options);
+    } finally {
+      unlock();
+    }
+  }
+
+  /**
+   * Create and send a redeem all
+   * MTX without a lock.
    * @param {Object} options
    */
 
   async _sendRedeemAll(options) {
     const passphrase = options ? options.passphrase : null;
-    const mtx = await this.createRedeemAll(options);
+    const mtx = await this._createRedeemAll(options);
     return this.sendMTX(mtx, passphrase);
   }
 
   /**
-   * Create and send a redeem MTX.
+   * Create and send a redeem all
+   * MTX with a lock.
    * @param {Object} options
    */
 

--- a/lib/wallet/wallet.js
+++ b/lib/wallet/wallet.js
@@ -1810,27 +1810,45 @@ class Wallet extends EventEmitter {
   }
 
   /**
-   * Create and finalize a bid MTX.
+   * Create and finalize a reveal
+   * MTX without a lock.
    * @param {String} name
    * @param {Object} options
    * @returns {MTX}
    */
 
-  async createReveal(name, options) {
+  async _createReveal(name, options) {
     const mtx = await this.makeReveal(name);
     await this.fill(mtx, options);
     return this.finalize(mtx, options);
   }
 
   /**
-   * Create and send a bid MTX.
+   * Create and finalize a reveal
+   * MTX with a lock.
+   * @param {String} name
+   * @param {Object} options
+   * @returns {MTX}
+   */
+
+  async createReveal(name, options) {
+    const unlock = await this.fundLock.lock();
+    try {
+      return await this._createReveal(name, options);
+    } finally {
+      unlock();
+    }
+  }
+
+  /**
+   * Create and send a reveal MTX.
    * @param {String} name
    * @param {Object} options
    */
 
   async _sendReveal(name, options) {
     const passphrase = options ? options.passphrase : null;
-    const mtx = await this.createReveal(name, options);
+    const mtx = await this._createReveal(name, options);
     return this.sendMTX(mtx, passphrase);
   }
 

--- a/lib/wallet/wallet.js
+++ b/lib/wallet/wallet.js
@@ -2637,7 +2637,23 @@ class Wallet extends EventEmitter {
   }
 
   /**
-   * Create and finalize an update MTX.
+   * Create and finalize a transfer
+   * MTX without a lock.
+   * @param {String} name
+   * @param {Address} address
+   * @param {Object} options
+   * @returns {MTX}
+   */
+
+  async _createTransfer(name, address, options) {
+    const mtx = await this.makeTransfer(name, address);
+    await this.fill(mtx, options);
+    return this.finalize(mtx, options);
+  }
+
+  /**
+   * Create and finalize a transfer
+   * MTX with a lock.
    * @param {String} name
    * @param {Address} address
    * @param {Object} options
@@ -2645,13 +2661,17 @@ class Wallet extends EventEmitter {
    */
 
   async createTransfer(name, address, options) {
-    const mtx = await this.makeTransfer(name, address);
-    await this.fill(mtx, options);
-    return this.finalize(mtx, options);
+    const unlock = await this.fundLock.lock();
+    try {
+      return await this._createTransfer(name, address, options);
+    } finally {
+      unlock();
+    }
   }
 
   /**
-   * Create and send an update MTX.
+   * Create and send a transfer
+   * MTX without a lock.
    * @param {String} name
    * @param {Address} address
    * @param {Object} options
@@ -2659,7 +2679,7 @@ class Wallet extends EventEmitter {
 
   async _sendTransfer(name, address, options) {
     const passphrase = options ? options.passphrase : null;
-    const mtx = await this.createTransfer(
+    const mtx = await this._createTransfer(
       name,
       address,
       options
@@ -2668,7 +2688,8 @@ class Wallet extends EventEmitter {
   }
 
   /**
-   * Create and send an update MTX.
+   * Create and send a transfer
+   * MTX with a lock.
    * @param {String} name
    * @param {Address} address
    * @param {Object} options

--- a/lib/wallet/wallet.js
+++ b/lib/wallet/wallet.js
@@ -2513,32 +2513,52 @@ class Wallet extends EventEmitter {
   }
 
   /**
-   * Create and finalize a renewal MTX.
+   * Create and finalize a renewal
+   * MTX without a lock.
    * @param {String} name
    * @param {Object} options
    * @returns {MTX}
    */
 
-  async createRenewal(name, options) {
+  async _createRenewal(name, options) {
     const mtx = await this.makeRenewal(name);
     await this.fill(mtx, options);
     return this.finalize(mtx, options);
   }
 
   /**
-   * Create and send a renewal MTX.
+   * Create and finalize a renewal
+   * MTX with a lock.
+   * @param {String} name
+   * @param {Object} options
+   * @returns {MTX}
+   */
+
+  async createRenewal(name, options) {
+    const unlock = await this.fundLock.lock();
+    try {
+      return await this._createRenewal(name, options);
+    } finally {
+      unlock();
+    }
+  }
+
+  /**
+   * Create and send a renewal
+   * MTX without a lock.
    * @param {String} name
    * @param {Object} options
    */
 
   async _sendRenewal(name, options) {
     const passphrase = options ? options.passphrase : null;
-    const mtx = await this.createRenewal(name, options);
+    const mtx = await this._createRenewal(name, options);
     return this.sendMTX(mtx, passphrase);
   }
 
   /**
-   * Create and send an renewal MTX.
+   * Create and send a renewal
+   * MTX with a lock.
    * @param {String} name
    * @param {Object} options
    */


### PR DESCRIPTION
There are many different types of transactions regarding the auction system. Each covenant type has its own explicit code path for creation. Currently, only the `send` functionality has a lock around it which means that there is *no* lock being used for code that wants to create the transaction but not sign and/or broadcast it. This pull request adds a new method for each create transaction type method that wraps the actual method with a lock.

Since there is no enforced concept of private methods in Javascript, this makes each of the create transaction methods safe for external consumption. These functions were only being called from within the wallet before, but in an attempt to better support watch only wallets, the create transaction methods would like to be consumed from outside of the wallet itself.

An example:

```javascript

// original createBid functionality here
_createBid() {}


createBid() {
  // create lock
  // call _createBid
  // unlock
}
```

The above pattern was followed for each of the create methods. The send methods call the create methods and there is already a lock around the send methods (they follow a similar pattern as above), they were updated to directly use the methods with the underscores.

There are currently two pull requests that could use this functionality
- https://github.com/handshake-org/hsd/pull/163
- https://github.com/handshake-org/hsd/pull/145
