### PR TITLE
wallet: remove dead option

### DIFF
--- a/lib/wallet/node.js
+++ b/lib/wallet/node.js
@@ -49,7 +49,6 @@ class WalletNode extends Node {
       memory: this.config.bool('memory'),
       maxFiles: this.config.uint('max-files'),
       cacheSize: this.config.mb('cache-size'),
-      witness: this.config.bool('witness'),
       checkpoints: this.config.bool('checkpoints'),
       wipeNoReally: this.config.bool('wipe-no-really'),
       spv: this.config.bool('spv')


### PR DESCRIPTION
The `witness` option in `lib/wallet/node.js` is left over from bcoin. This pull request deletes it because it is not used in the `walletdb`.