### PR TITLE
readme: add blurb about node-gyp

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,22 @@ $ npm install --production
 $ ./bin/hsd
 ```
 
+`node-gyp` is used to compile native code and requires
+Python 2.7. If your machine natively supports Python 3,
+configure `npm` using the command:
+
+```
+$ npm config set python /path/to/executable/python2.7
+```
+
+You can determine the native version of Python using:
+
+```
+$ python --version
+```
+
+See the [node-gyp](https://github.com/nodejs/node-gyp) documentation for more information.
+
 ## Documentation
 
 - Documentation Site: [https://handshake-org.github.io](https://handshake-org.github.io)


### PR DESCRIPTION
People have been experiencing issues with the native code automatically compiling after running `npm install`. Adding a section about `node-gyp` will help to give people a path forwards when it doesn't compile correctly. An incorrect version of python was the most common issue that I have experienced when talking to people that want to run `hsd`, especially because newer distros have `python3` as the default `python`.