### PR TITLE
net/netaddress: add getKey method

### DIFF
--- a/lib/net/netaddress.js
+++ b/lib/net/netaddress.js
@@ -9,6 +9,7 @@
 const assert = require('bsert');
 const bio = require('bufio');
 const IP = require('binet');
+const base32 = require('bs32');
 const Network = require('../protocol/network');
 const util = require('../utils/util');
 const common = require('./common');
@@ -250,6 +251,22 @@ class NetAddress extends bio.Struct {
 
     assert(Buffer.isBuffer(key) && key.length === 33);
     this.key = key;
+  }
+
+  /**
+   * Get key.
+   * @param {String} enc
+   * @returns {String|Buffer}
+   */
+
+  getKey(enc) {
+    if (enc === 'base32')
+      return base32.encode(this.key);
+
+    if (enc === 'hex')
+      return this.key.toString('hex');
+
+    return this.key;
   }
 
   /**


### PR DESCRIPTION
Add a `getKey` method to the `NetAddress`. The method accepts an optional string that determines the serialization of the return value. The serialization can be base32 string, hex string or will otherwise return a buffer.

This change is very simple and will allow for more progress on https://github.com/handshake-org/hsd/issues/141