### PR TITLE
net: jsdoc fixes for constants

### DIFF
--- a/lib/net/common.js
+++ b/lib/net/common.js
@@ -59,7 +59,7 @@ exports.LOCAL_SERVICES = 0
   | exports.services.NETWORK;
 
 /**
- * Required services (network and segwit).
+ * Required services (network).
  * @const {Number}
  * @default
  */
@@ -76,7 +76,7 @@ exports.REQUIRED_SERVICES = 0
 exports.USER_AGENT = `/${pkg.name}:${pkg.version}/`;
 
 /**
- * Max message size (~4mb with segwit, formerly 2mb)
+ * Max message size (~8mb)
  * @const {Number}
  * @default
  */


### PR DESCRIPTION
This commit updates the documenation on two constants in the net common
file. The first is the required services which are now only NETWORK and
not NETWORK and SEGWIT. The second is an update to the maximum message
size. The max message size was updated from 4mb to 8mb in commit: 4c5668994162053be6c02d3af5c7959b6a572b47