### PR TITLE
rpc and http expose identity key

### DIFF
--- a/lib/net/netaddress.js
+++ b/lib/net/netaddress.js
@@ -9,6 +9,7 @@
 const assert = require('bsert');
 const bio = require('bufio');
 const IP = require('binet');
+const base32 = require('bs32');
 const Network = require('../protocol/network');
 const util = require('../utils/util');
 const common = require('./common');
@@ -250,6 +251,22 @@ class NetAddress extends bio.Struct {
 
     assert(Buffer.isBuffer(key) && key.length === 33);
     this.key = key;
+  }
+
+  /**
+   * Get key.
+   * @param {String} enc
+   * @returns {String|Buffer}
+   */
+
+  getKey(enc) {
+    if (enc === 'base32')
+      return base32.encode(this.key);
+
+    if (enc === 'hex')
+      return this.key.toString('hex');
+
+    return this.key;
   }
 
   /**

--- a/lib/net/peer.js
+++ b/lib/net/peer.js
@@ -204,6 +204,15 @@ class Peer extends EventEmitter {
   }
 
   /**
+   * Getter to retrieve fullname.
+   * @returns {String}
+   */
+
+  fullname() {
+    return this.address.fullname();
+  }
+
+  /**
    * Frame a payload with a header.
    * @param {String} cmd - Packet type.
    * @param {Buffer} payload

--- a/lib/net/peer.js
+++ b/lib/net/peer.js
@@ -1514,6 +1514,8 @@ class Peer extends EventEmitter {
     this.agent = packet.agent;
     this.noRelay = packet.noRelay;
     this.local = packet.remote;
+    // set the peer's key on their local address
+    this.local.setKey(this.address.getKey());
 
     if (!this.network.selfConnect) {
       if (this.options.hasNonce(packet.nonce))

--- a/lib/node/http.js
+++ b/lib/node/http.js
@@ -136,6 +136,7 @@ class HTTP extends Server {
         pool: {
           host: addr.host,
           port: addr.port,
+          identitykey: addr.getKey('base32'),
           agent: this.pool.options.agent,
           services: this.pool.options.services.toString(2),
           outbound: this.pool.peers.outbound,

--- a/lib/node/rpc.js
+++ b/lib/node/rpc.js
@@ -325,6 +325,7 @@ class RPC extends RPCBase {
       version: pkg.version,
       subversion: this.pool.options.agent,
       protocolversion: this.pool.options.version,
+      identitykey: this.pool.hosts.address.getKey('base32'),
       localservices: hex32(this.pool.options.services),
       localrelay: !this.pool.options.noRelay,
       timeoffset: this.network.time.offset,
@@ -485,9 +486,9 @@ class RPC extends RPCBase {
 
       peers.push({
         id: peer.id,
-        addr: peer.hostname(),
+        addr: peer.fullname(),
         addrlocal: !peer.local.isNull()
-          ? peer.local.hostname
+          ? peer.local.fullname()
           : undefined,
         name: peer.name || undefined,
         services: hex32(peer.services),


### PR DESCRIPTION
This PR implements the plumbing required to expose the identity key for both the node itself and its peers.

Changes:

- Add a `getKey` method to the `NetAddress`
- Add a `fullname` method to the `Peer`
- Add `.pool.identitykey` to  Node `GET /`
- Add `identitykey` to the response of Node `getnetworkinfo` RPC
- Return fullnames (key@ip:host) for Node `getpeerinfo` RPC
- Set the key on `Peer.local` so that it can be easily returned with `Peer.local.fullname()`, before it was not being set at all
