### PR TITLE
node/http: coin amount for value/burned

### DIFF
--- a/lib/node/http.js
+++ b/lib/node/http.js
@@ -20,6 +20,7 @@ const TX = require('../primitives/tx');
 const Claim = require('../primitives/claim');
 const Address = require('../primitives/address');
 const Network = require('../protocol/network');
+const Amount = require('../ui/amount');
 const pkg = require('../pkg');
 
 /**
@@ -129,8 +130,8 @@ class HTTP extends Server {
           state: {
             tx: this.chain.db.state.tx,
             coin: this.chain.db.state.coin,
-            value: this.chain.db.state.value,
-            burned: this.chain.db.state.burned
+            value: Amount.coin(this.chain.db.state.value, true),
+            burned: Amount.coin(this.chain.db.state.burned, true)
           }
         },
         pool: {


### PR DESCRIPTION
Other parts of the API return full coin amounts,
this switches the API for `GET /` to return
full coin amounts for the chain state at
`.chain.state.{value,burned}`.

The logger uses Amount.coin for both of these
values in the `chaindb.js` file.

```
this.logger.info(
  'Chain State: hash=%x tx=%d coin=%d value=%s burned=%s.',
  this.state.tip,
  this.state.tx,
  this.state.coin,
  Amount.coin(this.state.value),
  Amount.coin(this.state.burned));
```