### PR TITLE
mempool: expose mempool rejection filter to api

### DIFF
--- a/lib/node/http.js
+++ b/lib/node/http.js
@@ -336,6 +336,39 @@ class HTTP extends Server {
       res.json(200, result);
     });
 
+    // Mempool Rejection Filter
+    this.get('/mempool/invalid', async (req, res) => {
+      enforce(this.mempool, 'No mempool available.');
+
+      const valid = Validator.fromRequest(req);
+      const verbose = valid.bool('verbose', false);
+
+      const rejects = this.mempool.rejects;
+      res.json(200, {
+        items: rejects.items,
+        filter: verbose ? rejects.filter.toString('hex') : undefined,
+        size: rejects.size,
+        entries: rejects.entries,
+        n: rejects.n,
+        limit: rejects.limit,
+        tweak: rejects.tweak
+      });
+    });
+
+    // Mempool Rejection Test
+    this.get('/mempool/invalid/:hash', async (req, res) => {
+      enforce(this.mempool, 'No mempool available.');
+
+      const valid = Validator.fromRequest(req);
+      const hash = valid.bhash('hash');
+
+      assert(hash, 'Must pass hash.');
+
+      const invalid = this.mempool.rejects.test(hash, 'hex');
+
+      res.json(200, { invalid });
+    });
+
     // Broadcast TX
     this.post('/broadcast', async (req, res) => {
       const valid = Validator.fromRequest(req);

--- a/test/http-test.js
+++ b/test/http-test.js
@@ -316,6 +316,34 @@ describe('HTTP', function() {
     });
   });
 
+  it('should get mempool rejection filter', async () => {
+    const filterInfo = await nclient.get('/mempool/invalid', { verbose: true });
+
+    assert.ok('items' in filterInfo);
+    assert.ok('filter' in filterInfo);
+    assert.ok('size' in filterInfo);
+    assert.ok('entries' in filterInfo);
+    assert.ok('n' in filterInfo);
+    assert.ok('limit' in filterInfo);
+    assert.ok('tweak' in filterInfo);
+
+    assert.equal(filterInfo.entries, 0);
+  });
+
+  it('should add an entry to the mempool rejection filter', async () => {
+    const mtx = new MTX();
+    mtx.addOutpoint(new Outpoint(consensus.ZERO_HASH, 0));
+
+    const raw = mtx.toHex();
+    const txid = await nclient.execute('sendrawtransaction', [raw]);
+
+    const json = await nclient.get(`/mempool/invalid/${txid}`);
+    assert.equal(json.invalid, true);
+
+    const filterInfo = await nclient.get('/mempool/invalid');
+    assert.equal(filterInfo.entries, 1);
+  });
+
   it('should cleanup', async () => {
     await wallet.close();
     await wclient.close();


### PR DESCRIPTION
This Pull Request adds 2 additional HTTP endpoints on the Node.

- `GET /mempool/invalid`
Returns the parameters of the mempool rejections bloom filter and the bloom filter itself if the query param `verbose` is sent. The bloom filter itself is very large.

- `GET /mempool/invalid/:hash`
Tests the hash for inclusion in the bloom filter.
