### PR TITLE
Log Identity Keys in net Module

### DIFF
--- a/lib/net/peer.js
+++ b/lib/net/peer.js
@@ -204,6 +204,15 @@ class Peer extends EventEmitter {
   }
 
   /**
+   * Getter to retrieve fullname.
+   * @returns {String}
+   */
+
+  fullname() {
+    return this.address.fullname();
+  }
+
+  /**
    * Frame a payload with a header.
    * @param {String} cmd - Packet type.
    * @param {Buffer} payload

--- a/lib/net/peer.js
+++ b/lib/net/peer.js
@@ -462,7 +462,7 @@ class Peer extends EventEmitter {
     if (this.version === -1) {
       this.logger.debug(
         'Peer sent a verack without a version (%s).',
-        this.hostname());
+        this.fullname());
 
       await this.wait(packetTypes.VERSION, 10000);
 
@@ -474,7 +474,7 @@ class Peer extends EventEmitter {
 
     this.handshake = true;
 
-    this.logger.debug('Version handshake complete (%s).', this.hostname());
+    this.logger.debug('Version handshake complete (%s).', this.fullname());
   }
 
   /**
@@ -711,7 +711,7 @@ class Peer extends EventEmitter {
     this.invQueue = [];
 
     this.logger.spam('Serving %d inv items to %s.',
-      queue.length, this.hostname());
+      queue.length, this.fullname());
 
     const items = [];
 
@@ -750,7 +750,7 @@ class Peer extends EventEmitter {
       return;
 
     this.logger.spam('Serving %d inv items to %s.',
-      items.length, this.hostname());
+      items.length, this.fullname());
 
     for (let i = 0; i < items.length; i += 1000) {
       const chunk = items.slice(i, i + 1000);
@@ -780,7 +780,7 @@ class Peer extends EventEmitter {
       return;
 
     this.logger.spam('Serving %d headers to %s.',
-      items.length, this.hostname());
+      items.length, this.fullname());
 
     for (let i = 0; i < items.length; i += 2000) {
       const chunk = items.slice(i, i + 2000);
@@ -845,7 +845,7 @@ class Peer extends EventEmitter {
     if (this.challenge) {
       this.logger.debug(
         'Peer has not responded to ping (%s).',
-        this.hostname());
+        this.fullname());
       return;
     }
 
@@ -1025,7 +1025,7 @@ class Peer extends EventEmitter {
       this.logger.warning(
         'Peer is not reading: %dmb buffered (%s).',
         this.drainSize / (1 << 20),
-        this.hostname());
+        this.fullname());
       this.error('Peer stalled (drain).');
       this.destroy();
     }
@@ -1297,7 +1297,7 @@ class Peer extends EventEmitter {
       err.message = `Socket Error: ${msg}`;
     }
 
-    err.message += ` (${this.hostname()})`;
+    err.message += ` (${this.fullname()})`;
 
     this.emit('error', err);
   }
@@ -1545,12 +1545,12 @@ class Peer extends EventEmitter {
 
   async handleVerack(packet) {
     if (this.ack) {
-      this.logger.debug('Peer sent duplicate ack (%s).', this.hostname());
+      this.logger.debug('Peer sent duplicate ack (%s).', this.fullname());
       return;
     }
 
     this.ack = true;
-    this.logger.debug('Received verack (%s).', this.hostname());
+    this.logger.debug('Received verack (%s).', this.fullname());
   }
 
   /**
@@ -1579,17 +1579,17 @@ class Peer extends EventEmitter {
     const now = Date.now();
 
     if (!this.challenge) {
-      this.logger.debug('Peer sent an unsolicited pong (%s).', this.hostname());
+      this.logger.debug('Peer sent an unsolicited pong (%s).', this.fullname());
       return;
     }
 
     if (!nonce.equals(this.challenge)) {
       if (nonce.equals(common.ZERO_NONCE)) {
-        this.logger.debug('Peer sent a zero nonce (%s).', this.hostname());
+        this.logger.debug('Peer sent a zero nonce (%s).', this.fullname());
         this.challenge = null;
         return;
       }
-      this.logger.debug('Peer sent the wrong nonce (%s).', this.hostname());
+      this.logger.debug('Peer sent the wrong nonce (%s).', this.fullname());
       return;
     }
 
@@ -1599,7 +1599,7 @@ class Peer extends EventEmitter {
         this.minPing = now - this.lastPing;
       this.minPing = Math.min(this.minPing, now - this.lastPing);
     } else {
-      this.logger.debug('Timing mismatch (what?) (%s).', this.hostname());
+      this.logger.debug('Timing mismatch (what?) (%s).', this.fullname());
     }
 
     this.challenge = null;
@@ -1616,7 +1616,7 @@ class Peer extends EventEmitter {
     if (this.preferHeaders) {
       this.logger.debug(
         'Peer sent a duplicate sendheaders (%s).',
-        this.hostname());
+        this.fullname());
       return;
     }
 
@@ -1704,7 +1704,7 @@ class Peer extends EventEmitter {
     if (this.compactMode !== -1) {
       this.logger.debug(
         'Peer sent a duplicate sendcmpct (%s).',
-        this.hostname());
+        this.fullname());
       return;
     }
 
@@ -1712,20 +1712,20 @@ class Peer extends EventEmitter {
       // Ignore
       this.logger.info(
         'Peer request compact blocks version %d (%s).',
-        packet.version, this.hostname());
+        packet.version, this.fullname());
       return;
     }
 
     if (packet.mode > 1) {
       this.logger.info(
         'Peer request compact blocks mode %d (%s).',
-        packet.mode, this.hostname());
+        packet.mode, this.fullname());
       return;
     }
 
     this.logger.info(
       'Peer initialized compact blocks (mode=%d, version=%d) (%s).',
-      packet.mode, packet.version, this.hostname());
+      packet.mode, packet.version, this.fullname());
 
     this.compactMode = packet.mode;
   }
@@ -1747,7 +1747,7 @@ class Peer extends EventEmitter {
 
     this.logger.debug(
       'Requesting headers packet from peer with getheaders (%s).',
-      this.hostname());
+      this.fullname());
 
     this.logger.debug(
       'Sending getheaders (hash=%x, stop=%x).',
@@ -1778,7 +1778,7 @@ class Peer extends EventEmitter {
 
     this.logger.debug(
       'Requesting inv packet from peer with getblocks (%s).',
-      this.hostname());
+      this.fullname());
 
     this.logger.debug(
       'Sending getblocks (hash=%x, stop=%x).',
@@ -1798,13 +1798,13 @@ class Peer extends EventEmitter {
     if (!(this.services & services.BLOOM)) {
       this.logger.debug(
         'Cannot request mempool for non-bloom peer (%s).',
-        this.hostname());
+        this.fullname());
       return;
     }
 
     this.logger.debug(
       'Requesting inv packet from peer with mempool (%s).',
-      this.hostname());
+      this.fullname());
 
     this.send(new packets.MempoolPacket());
   }
@@ -1823,15 +1823,15 @@ class Peer extends EventEmitter {
     if (msg != null) {
       this.logger.debug('Rejecting %s %x (%s): code=%s reason=%s.',
         packets.typesByVal[msg] || 'UNKNOWN',
-        hash, this.hostname(), code, reason);
+        hash, this.fullname(), code, reason);
     } else {
       this.logger.debug('Rejecting packet from %s: code=%s reason=%s.',
-        this.hostname(), code, reason);
+        this.fullname(), code, reason);
     }
 
     this.logger.debug(
       'Sending reject packet to peer (%s).',
-      this.hostname());
+      this.fullname());
 
     this.send(reject);
   }
@@ -1844,7 +1844,7 @@ class Peer extends EventEmitter {
   sendCompact(mode) {
     this.logger.info(
       'Initializing normal compact blocks (%s).',
-      this.hostname());
+      this.fullname());
 
     this.send(new packets.SendCmpctPacket(mode, 1));
   }
@@ -1859,7 +1859,7 @@ class Peer extends EventEmitter {
     this.logger.info(
       'Sending proof request for %x (%s).',
       key,
-      this.hostname());
+      this.fullname());
 
     this.send(new packets.GetProofPacket(root, key));
   }
@@ -1875,7 +1875,7 @@ class Peer extends EventEmitter {
   sendProof(root, key, proof) {
     this.logger.info(
       'Sending proof (%s).',
-      this.hostname());
+      this.fullname());
 
     this.send(new packets.ProofPacket(root, key, proof));
   }
@@ -1890,7 +1890,7 @@ class Peer extends EventEmitter {
     this.banScore += score;
 
     if (this.banScore >= this.options.banScore) {
-      this.logger.debug('Ban threshold exceeded (%s).', this.hostname());
+      this.logger.debug('Ban threshold exceeded (%s).', this.fullname());
       this.ban();
       return true;
     }
@@ -1949,7 +1949,7 @@ class Peer extends EventEmitter {
   inspect() {
     return '<Peer:'
       + ` handshake=${this.handshake}`
-      + ` host=${this.hostname()}`
+      + ` host=${this.fullname()}`
       + ` outbound=${this.outbound}`
       + ` ping=${this.minPing}`
       + '>';

--- a/lib/net/pool.js
+++ b/lib/net/pool.js
@@ -620,7 +620,7 @@ class Pool extends EventEmitter {
 
       this.logger.info(
         'Repurposing peer for loader (%s).',
-        peer.hostname());
+        peer.fullname());
 
       this.setLoader(peer);
 
@@ -640,7 +640,7 @@ class Pool extends EventEmitter {
 
     const peer = this.createOutbound(addr);
 
-    this.logger.info('Adding loader peer (%s).', peer.hostname());
+    this.logger.info('Adding loader peer (%s).', peer.fullname());
 
     this.peers.add(peer);
 
@@ -1010,7 +1010,7 @@ class Pool extends EventEmitter {
     if (type !== entry.type) {
       this.logger.debug(
         'Peer requested item with the wrong type (%s).',
-        peer.hostname());
+        peer.fullname());
       return null;
     }
 
@@ -1018,7 +1018,7 @@ class Pool extends EventEmitter {
       'Peer requested %s %x (%s).',
       name,
       item.hash,
-      peer.hostname());
+      peer.fullname());
 
     entry.handleAck(peer);
 
@@ -1115,7 +1115,7 @@ class Pool extends EventEmitter {
 
     this.bindPeer(peer);
 
-    this.logger.debug('Connecting to %s.', peer.hostname());
+    this.logger.debug('Connecting to %s.', peer.fullname());
 
     peer.tryOpen();
 
@@ -1316,7 +1316,7 @@ class Pool extends EventEmitter {
    */
 
   async handleConnect(peer) {
-    this.logger.info('Connected to %s.', peer.hostname());
+    this.logger.info('Connected to %s.', peer.fullname());
 
     if (peer.outbound)
       this.hosts.markSuccess(peer.hostname());
@@ -1400,7 +1400,7 @@ class Pool extends EventEmitter {
     this.removePeer(peer);
 
     if (loader) {
-      this.logger.info('Removed loader peer (%s).', peer.hostname());
+      this.logger.info('Removed loader peer (%s).', peer.fullname());
       if (this.checkpoints)
         this.resetChain();
     }
@@ -1450,7 +1450,7 @@ class Pool extends EventEmitter {
   async handleVersion(peer, packet) {
     this.logger.info(
       'Received version (%s): version=%d height=%d services=%s agent=%s',
-      peer.hostname(),
+      peer.fullname(),
       packet.version,
       packet.height,
       packet.services.toString(2),
@@ -1514,7 +1514,7 @@ class Pool extends EventEmitter {
     if (peer.sentAddr) {
       this.logger.debug(
         'Ignoring repeated getaddr (%s).',
-        peer.hostname());
+        peer.fullname());
       return;
     }
 
@@ -1539,7 +1539,7 @@ class Pool extends EventEmitter {
     this.logger.debug(
       'Sending %d addrs to peer (%s)',
       items.length,
-      peer.hostname());
+      peer.fullname());
 
     peer.send(new packets.AddrPacket(items));
   }
@@ -1583,7 +1583,7 @@ class Pool extends EventEmitter {
       addrs.length,
       this.hosts.size(),
       this.peers.size(),
-      peer.hostname());
+      peer.fullname());
 
     this.fillOutbound();
   }
@@ -1651,12 +1651,12 @@ class Pool extends EventEmitter {
 
     this.logger.spam(
       'Received inv packet with %d items: blocks=%d txs=%d claims=%d (%s).',
-      items.length, blocks.length, txs.length, claims.length, peer.hostname());
+      items.length, blocks.length, txs.length, claims.length, peer.fullname());
 
     if (unknown !== -1) {
       this.logger.warning(
         'Peer sent an unknown inv type: %d (%s).',
-        unknown, peer.hostname());
+        unknown, peer.fullname());
     }
 
     if (blocks.length > 0)
@@ -1704,7 +1704,7 @@ class Pool extends EventEmitter {
     this.logger.debug(
       'Received %d block hashes from peer (%s).',
       hashes.length,
-      peer.hostname());
+      peer.fullname());
 
     const items = [];
 
@@ -1715,7 +1715,7 @@ class Pool extends EventEmitter {
 
       // Resolve orphan chain.
       if (this.chain.hasOrphan(hash)) {
-        this.logger.debug('Received known orphan hash (%s).', peer.hostname());
+        this.logger.debug('Received known orphan hash (%s).', peer.fullname());
         await this.resolveOrphan(peer, hash);
         continue;
       }
@@ -1735,7 +1735,7 @@ class Pool extends EventEmitter {
       // continue the sync, or do a getblocks
       // from the last hash.
       if (i === hashes.length - 1) {
-        this.logger.debug('Received existing hash (%s).', peer.hostname());
+        this.logger.debug('Received existing hash (%s).', peer.fullname());
         await this.getBlocks(peer, hash, consensus.ZERO_HASH);
       }
     }
@@ -1816,7 +1816,7 @@ class Pool extends EventEmitter {
     if (items.length > common.MAX_INV) {
       this.logger.warning(
         'Peer sent inv with >50k items (%s).',
-        peer.hostname());
+        peer.fullname());
       peer.increaseBan(100);
       peer.destroy();
       return;
@@ -1901,7 +1901,7 @@ class Pool extends EventEmitter {
           if (!this.options.bip37) {
             this.logger.debug(
               'Peer requested a merkleblock without bip37 enabled (%s).',
-              peer.hostname());
+              peer.fullname());
             peer.destroy();
             return;
           }
@@ -1986,31 +1986,31 @@ class Pool extends EventEmitter {
     if (txs > 0) {
       this.logger.debug(
         'Served %d txs with getdata (notfound=%d) (%s).',
-        txs, notFound.length, peer.hostname());
+        txs, notFound.length, peer.fullname());
     }
 
     if (blocks > 0) {
       this.logger.debug(
         'Served %d blocks with getdata (notfound=%d, cmpct=%d) (%s).',
-        blocks, notFound.length, compact, peer.hostname());
+        blocks, notFound.length, compact, peer.fullname());
     }
 
     if (claims > 0) {
       this.logger.debug(
         'Served %d claims with getdata (notfound=%d) (%s).',
-        claims, notFound.length, peer.hostname());
+        claims, notFound.length, peer.fullname());
     }
 
     if (proofs > 0) {
       this.logger.debug(
         'Served %d airdrops with getdata (notfound=%d) (%s).',
-        proofs, notFound.length, peer.hostname());
+        proofs, notFound.length, peer.fullname());
     }
 
     if (unknown !== -1) {
       this.logger.warning(
         'Peer sent an unknown getdata type: %d (%d).',
-        unknown, peer.hostname());
+        unknown, peer.fullname());
     }
   }
 
@@ -2029,7 +2029,7 @@ class Pool extends EventEmitter {
       if (!this.resolveItem(peer, item)) {
         this.logger.warning(
           'Peer sent notfound for unrequested item: %x (%s).',
-          item.hash, peer.hostname());
+          item.hash, peer.fullname());
         peer.destroy();
         return;
       }
@@ -2193,7 +2193,7 @@ class Pool extends EventEmitter {
       if (!header.verify()) {
         this.logger.warning(
           'Peer sent an invalid header (%s).',
-          peer.hostname());
+          peer.fullname());
         peer.increaseBan(100);
         peer.destroy();
         return;
@@ -2202,7 +2202,7 @@ class Pool extends EventEmitter {
       if (!header.prevBlock.equals(last.hash)) {
         this.logger.warning(
           'Peer sent a bad header chain (%s).',
-          peer.hostname());
+          peer.fullname());
         peer.destroy();
         return;
       }
@@ -2213,7 +2213,7 @@ class Pool extends EventEmitter {
         if (!node.hash.equals(this.headerTip.hash)) {
           this.logger.warning(
             'Peer sent an invalid checkpoint (%s).',
-            peer.hostname());
+            peer.fullname());
           peer.destroy();
           return;
         }
@@ -2229,7 +2229,7 @@ class Pool extends EventEmitter {
     this.logger.debug(
       'Received %d headers from peer (%s).',
       headers.length,
-      peer.hostname());
+      peer.fullname());
 
     // If we received a valid header
     // chain, consider this a "block".
@@ -2274,7 +2274,7 @@ class Pool extends EventEmitter {
     if (this.options.spv) {
       this.logger.warning(
         'Peer sent unsolicited block (%s).',
-        peer.hostname());
+        peer.fullname());
       return;
     }
 
@@ -2318,7 +2318,7 @@ class Pool extends EventEmitter {
     if (!this.resolveBlock(peer, hash)) {
       this.logger.warning(
         'Received unrequested block: %x (%s).',
-        block.hash(), peer.hostname());
+        block.hash(), peer.fullname());
       peer.destroy();
       return;
     }
@@ -2342,7 +2342,7 @@ class Pool extends EventEmitter {
       if (this.checkpoints) {
         this.logger.warning(
           'Peer sent orphan block with getheaders (%s).',
-          peer.hostname());
+          peer.fullname());
         return;
       }
 
@@ -2403,7 +2403,7 @@ class Pool extends EventEmitter {
         'Header hash mismatch %x != %x (%s).',
         hash,
         node.hash,
-        peer.hostname());
+        peer.fullname());
 
       peer.destroy();
 
@@ -2431,7 +2431,7 @@ class Pool extends EventEmitter {
 
     this.logger.info(
       'Switching to getblocks (%s).',
-      peer.hostname());
+      peer.fullname());
 
     await this.switchSync(peer, hash);
   }
@@ -2477,7 +2477,7 @@ class Pool extends EventEmitter {
 
     this.logger.debug(
       'Punishing peer for sending a bad orphan (%s).',
-      peer.hostname());
+      peer.fullname());
 
     // Punish the original peer who sent this.
     peer.reject(msg, err);
@@ -2556,7 +2556,7 @@ class Pool extends EventEmitter {
         if (peer.merkleMap.has(whash)) {
           this.logger.warning(
             'Peer sent duplicate merkle tx: %x (%s).',
-            hash, peer.hostname());
+            hash, peer.fullname());
           peer.increaseBan(100);
           return;
         }
@@ -2580,7 +2580,7 @@ class Pool extends EventEmitter {
     if (!this.resolveTX(peer, hash)) {
       this.logger.warning(
         'Peer sent unrequested tx: %x (%s).',
-        hash, peer.hostname());
+        hash, peer.fullname());
       peer.destroy();
       return;
     }
@@ -2605,7 +2605,7 @@ class Pool extends EventEmitter {
     if (missing && missing.length > 0) {
       this.logger.debug(
         'Requesting %d missing transactions (%s).',
-        missing.length, peer.hostname());
+        missing.length, peer.fullname());
 
       this.ensureTX(peer, missing);
     }
@@ -2646,7 +2646,7 @@ class Pool extends EventEmitter {
     if (!this.resolveClaim(peer, hash)) {
       this.logger.warning(
         'Peer sent unrequested claim: %x (%s).',
-        claim.hash(), peer.hostname());
+        claim.hash(), peer.fullname());
       peer.destroy();
       return;
     }
@@ -2703,7 +2703,7 @@ class Pool extends EventEmitter {
     if (!this.resolveAirdrop(peer, hash)) {
       this.logger.warning(
         'Peer sent unrequested airdrop proof: %x (%s).',
-        proof.hash(), peer.hostname());
+        proof.hash(), peer.fullname());
       peer.destroy();
       return;
     }
@@ -2736,7 +2736,7 @@ class Pool extends EventEmitter {
   async handleReject(peer, packet) {
     this.logger.warning(
       'Received reject (%s): msg=%s code=%s reason=%s hash=%x.',
-      peer.hostname(),
+      peer.fullname(),
       packets.typesByVal[packet.message] || 'UNKNOWN',
       packet.getCode(),
       packet.reason,
@@ -2774,7 +2774,7 @@ class Pool extends EventEmitter {
     if (!this.options.bip37) {
       this.logger.debug(
         'Peer requested mempool without bip37 enabled (%s).',
-        peer.hostname());
+        peer.fullname());
       peer.destroy();
       return;
     }
@@ -2786,7 +2786,7 @@ class Pool extends EventEmitter {
 
     this.logger.debug(
       'Sending mempool snapshot (%s).',
-      peer.hostname());
+      peer.fullname());
 
     peer.queueInv(items);
   }
@@ -2861,7 +2861,7 @@ class Pool extends EventEmitter {
     if (!this.options.spv) {
       this.logger.warning(
         'Peer sent unsolicited merkleblock (%s).',
-        peer.hostname());
+        peer.fullname());
       peer.increaseBan(100);
       return;
     }
@@ -2872,7 +2872,7 @@ class Pool extends EventEmitter {
     if (!peer.blockMap.has(hash)) {
       this.logger.warning(
         'Peer sent an unrequested merkleblock (%s).',
-        peer.hostname());
+        peer.fullname());
       peer.destroy();
       return;
     }
@@ -2880,7 +2880,7 @@ class Pool extends EventEmitter {
     if (peer.merkleBlock) {
       this.logger.warning(
         'Peer sent a merkleblock prematurely (%s).',
-        peer.hostname());
+        peer.fullname());
       peer.increaseBan(100);
       return;
     }
@@ -2888,7 +2888,7 @@ class Pool extends EventEmitter {
     if (!block.verify()) {
       this.logger.warning(
         'Peer sent an invalid merkleblock (%s).',
-        peer.hostname());
+        peer.fullname());
       peer.increaseBan(100);
       return;
     }
@@ -2949,7 +2949,7 @@ class Pool extends EventEmitter {
     if (!this.options.compact) {
       this.logger.info(
         'Peer sent unsolicited cmpctblock (%s).',
-        peer.hostname());
+        peer.fullname());
       this.destroy();
       return;
     }
@@ -2957,7 +2957,7 @@ class Pool extends EventEmitter {
     if (!peer.hasCompact()) {
       this.logger.info(
         'Peer sent unsolicited cmpctblock (%s).',
-        peer.hostname());
+        peer.fullname());
       this.destroy();
       return;
     }
@@ -2965,14 +2965,14 @@ class Pool extends EventEmitter {
     if (peer.compactBlocks.has(hash)) {
       this.logger.debug(
         'Peer sent us a duplicate compact block (%s).',
-        peer.hostname());
+        peer.fullname());
       return;
     }
 
     if (this.compactBlocks.has(hash)) {
       this.logger.debug(
         'Already waiting for compact block %x (%s).',
-        hash, peer.hostname());
+        hash, peer.fullname());
       return;
     }
 
@@ -2980,7 +2980,7 @@ class Pool extends EventEmitter {
       if (this.options.blockMode !== 1) {
         this.logger.warning(
           'Peer sent us an unrequested compact block (%s).',
-          peer.hostname());
+          peer.fullname());
         peer.destroy();
         return;
       }
@@ -2997,7 +2997,7 @@ class Pool extends EventEmitter {
     if (!block.verify()) {
       this.logger.debug(
         'Peer sent an invalid compact block (%s).',
-        peer.hostname());
+        peer.fullname());
       peer.increaseBan(100);
       return;
     }
@@ -3008,7 +3008,7 @@ class Pool extends EventEmitter {
     } catch (e) {
       this.logger.debug(
         'Peer sent an invalid compact block (%s).',
-        peer.hostname());
+        peer.fullname());
       peer.increaseBan(100);
       return;
     }
@@ -3016,7 +3016,7 @@ class Pool extends EventEmitter {
     if (!result) {
       this.logger.warning(
         'Siphash collision for %x. Requesting full block (%s).',
-        block.hash(), peer.hostname());
+        block.hash(), peer.fullname());
       peer.getFullBlock(hash);
       peer.increaseBan(10);
       return;
@@ -3027,14 +3027,14 @@ class Pool extends EventEmitter {
     if (full) {
       this.logger.debug(
         'Received full compact block %x (%s).',
-        block.hash(), peer.hostname());
+        block.hash(), peer.fullname());
       const flags = chainCommon.flags.VERIFY_BODY;
       await this.addBlock(peer, block.toBlock(), flags);
       return;
     }
 
     if (peer.compactBlocks.size >= 15) {
-      this.logger.warning('Compact block DoS attempt (%s).', peer.hostname());
+      this.logger.warning('Compact block DoS attempt (%s).', peer.fullname());
       peer.destroy();
       return;
     }
@@ -3048,7 +3048,7 @@ class Pool extends EventEmitter {
 
     this.logger.debug(
       'Received non-full compact block %x tx=%d/%d (%s).',
-      block.hash(), block.count, block.totalTX, peer.hostname());
+      block.hash(), block.count, block.totalTX, peer.fullname());
 
     peer.send(new packets.GetBlockTxnPacket(block.toRequest()));
   }
@@ -3080,7 +3080,7 @@ class Pool extends EventEmitter {
     if (!block) {
       this.logger.debug(
         'Peer sent getblocktxn for non-existent block (%s).',
-        peer.hostname());
+        peer.fullname());
       peer.increaseBan(100);
       return;
     }
@@ -3090,14 +3090,14 @@ class Pool extends EventEmitter {
     if (height < this.chain.tip.height - 15) {
       this.logger.debug(
         'Peer sent a getblocktxn for a block > 15 deep (%s)',
-        peer.hostname());
+        peer.fullname());
       return;
     }
 
     this.logger.debug(
       'Sending blocktxn for %x to peer (%s).',
       block.hash(),
-      peer.hostname());
+      peer.fullname());
 
     const res = BIP152.TXResponse.fromBlock(block, req);
 
@@ -3120,7 +3120,7 @@ class Pool extends EventEmitter {
     if (!block) {
       this.logger.debug(
         'Peer sent unsolicited blocktxn (%s).',
-        peer.hostname());
+        peer.fullname());
       return;
     }
 
@@ -3133,7 +3133,7 @@ class Pool extends EventEmitter {
       this.logger.warning(
         'Peer sent non-full blocktxn for %x. Requesting full block (%s).',
         block.hash(),
-        peer.hostname());
+        peer.fullname());
       peer.getFullBlock(res.hash);
       peer.increaseBan(10);
       return;
@@ -3141,7 +3141,7 @@ class Pool extends EventEmitter {
 
     this.logger.debug(
       'Filled compact block %x (%s).',
-      block.hash(), peer.hostname());
+      block.hash(), peer.fullname());
 
     await this.addBlock(peer, block.toBlock(), flags);
   }
@@ -3176,7 +3176,7 @@ class Pool extends EventEmitter {
         'Peer sent us an unsolicited proof: %x/%x (%s)!',
         key,
         root,
-        peer.hostname());
+        peer.fullname());
       peer.increaseBan(100);
       return;
     }
@@ -3189,7 +3189,7 @@ class Pool extends EventEmitter {
         'Peer sent us an unsolicited proof: %x/%x (%s)!',
         key,
         root,
-        peer.hostname());
+        peer.fullname());
       peer.increaseBan(100);
       return;
     }
@@ -3199,7 +3199,7 @@ class Pool extends EventEmitter {
         'Peer sent us an invalid data length: %x/%x (%s)!',
         key,
         root,
-        peer.hostname());
+        peer.fullname());
       peer.increaseBan(100);
       return;
     }
@@ -3212,7 +3212,7 @@ class Pool extends EventEmitter {
         key,
         root,
         code,
-        peer.hostname());
+        peer.fullname());
       peer.increaseBan(100);
       return;
     }
@@ -3235,7 +3235,7 @@ class Pool extends EventEmitter {
   async handleUnknown(peer, packet) {
     this.logger.warning(
       'Unknown packet: %d (%s).',
-      packet.type, peer.hostname());
+      packet.type, peer.fullname());
   }
 
   /**
@@ -3252,7 +3252,7 @@ class Pool extends EventEmitter {
 
     const peer = this.createInbound(socket);
 
-    this.logger.info('Added inbound peer (%s).', peer.hostname());
+    this.logger.info('Added inbound peer (%s).', peer.fullname());
 
     this.peers.add(peer);
   }
@@ -3614,7 +3614,7 @@ class Pool extends EventEmitter {
     if (peer.blockMap.size >= common.MAX_BLOCK_REQUEST) {
       this.logger.warning(
         'Peer advertised too many blocks (%s).',
-        peer.hostname());
+        peer.fullname());
       peer.destroy();
       return;
     }
@@ -3623,7 +3623,7 @@ class Pool extends EventEmitter {
       'Requesting %d/%d blocks from peer with getdata (%s).',
       items.length,
       this.blockMap.size,
-      peer.hostname());
+      peer.fullname());
 
     peer.getBlock(items);
   }
@@ -3666,7 +3666,7 @@ class Pool extends EventEmitter {
     if (peer.txMap.size >= common.MAX_TX_REQUEST) {
       this.logger.warning(
         'Peer advertised too many txs (%s).',
-        peer.hostname());
+        peer.fullname());
       peer.destroy();
       return;
     }
@@ -3675,7 +3675,7 @@ class Pool extends EventEmitter {
       'Requesting %d/%d txs from peer with getdata (%s).',
       items.length,
       this.txMap.size,
-      peer.hostname());
+      peer.fullname());
 
     peer.getTX(items);
   }
@@ -3718,7 +3718,7 @@ class Pool extends EventEmitter {
     if (peer.claimMap.size >= common.MAX_CLAIM_REQUEST) {
       this.logger.warning(
         'Peer advertised too many txs (%s).',
-        peer.hostname());
+        peer.fullname());
       peer.destroy();
       return;
     }
@@ -3727,7 +3727,7 @@ class Pool extends EventEmitter {
       'Requesting %d/%d claims from peer with getdata (%s).',
       items.length,
       this.claimMap.size,
-      peer.hostname());
+      peer.fullname());
 
     peer.getClaim(items);
   }
@@ -3770,7 +3770,7 @@ class Pool extends EventEmitter {
     if (peer.airdropMap.size >= common.MAX_CLAIM_REQUEST) {
       this.logger.warning(
         'Peer advertised too many txs (%s).',
-        peer.hostname());
+        peer.fullname());
       peer.destroy();
       return;
     }
@@ -3779,7 +3779,7 @@ class Pool extends EventEmitter {
       'Requesting %d/%d airdrops from peer with getdata (%s).',
       items.length,
       this.airdropMap.size,
-      peer.hostname());
+      peer.fullname());
 
     peer.getAirdrop(items);
   }


### PR DESCRIPTION
This PR adds the identity key to all of the log messages that log IP:Port in the `net` module. It does this by adding a `fullname` method to the `Peer` class which wraps `netAddress.fullname` which returns the `identitykey@ip:port` whereas `netAddress.hostname` returns just `ip:port`. 