### PR TITLE
wallet: emit events for covenant types

### DIFF
--- a/lib/wallet/txdb.js
+++ b/lib/wallet/txdb.js
@@ -22,7 +22,7 @@ const rules = require('../covenants/rules');
 const NameState = require('../covenants/namestate');
 const NameUndo = require('../covenants/undo');
 const {TXRecord} = records;
-const {types} = rules;
+const {types, typesByVal} = rules;
 
 /*
  * Constants
@@ -1065,6 +1065,42 @@ class TXDB {
     this.emit('tx', tx, details);
     this.emit('balance', balance);
 
+    const {outputs} = tx;
+    for (const output of outputs) {
+      const {covenant} = output;
+      const {type} = covenant;
+      const action = typesByVal[type].toLowerCase();
+      switch (type) {
+        case types.CLAIM:
+        case types.OPEN:
+        case types.BID:
+        case types.FINALIZE: {
+          const name = covenant.get(2).toString();
+          this.emit(action, {name, output}, details);
+          break;
+        }
+        case types.REVEAL:
+        case types.REDEEM:
+        case types.REGISTER:
+        case types.UPDATE:
+        case types.RENEW:
+        case types.TRANSFER:
+        case types.REVOKE: {
+          const nameHash = covenant.get(0);
+          const nameState = await this.wallet.getNameState(nameHash);
+          let name = null;
+          if (nameState)
+            name = nameState.name.toString();
+
+          this.emit(action, {name, output}, details);
+          break;
+        }
+        case types.NONE:
+        default:
+          break;
+      }
+    }
+
     return details;
   }
 
@@ -1791,6 +1827,7 @@ class TXDB {
       const path = await this.getPath(output);
       const nameHash = covenant.getHash(0);
       const outpoint = tx.outpoint(i);
+
       const ns = await view.getNameState(this, nameHash);
 
       if (!ns.isNull())

--- a/test/util/common.js
+++ b/test/util/common.js
@@ -85,6 +85,12 @@ common.writeTX = function writeTX(name, tx, view) {
   common.writeFile(`${name}-undo.raw`, undoRaw);
 };
 
+common.event = async function event(obj, name) {
+  return new Promise((resolve) => {
+    obj.once(name, resolve);
+  });
+};
+
 function parseUndo(data) {
   const br = bio.read(data);
   const items = [];


### PR DESCRIPTION
Emit events for each output the wallet receives based on the covenant type.