### PR TITLE
jsdoc: update chain getDeployments

### DIFF
--- a/lib/blockchain/chain.js
+++ b/lib/blockchain/chain.js
@@ -602,7 +602,8 @@ class Chain extends AsyncEmitter {
   }
 
   /**
-   * Check all deployments on a chain, ranging from p2sh to segwit.
+   * Check all deployments on a chain, ranging from
+   * the hardening to the 2017 rollover.
    * @param {Number} time
    * @param {ChainEntry} prev
    * @returns {Promise} - Returns {@link DeploymentState}.


### PR DESCRIPTION
This is a quick PR to update the jsdoc to be specific to Handshake instead of leftovers from Bitcoin. The docstring mentions p2sh and segwit deployments, which are not relevant to Handshake. This changes the docstring to mention the hardening and the 2017 rollover instead.