### PR TITLE
framer: fix jsdoc parameters

### DIFF
--- a/lib/net/framer.js
+++ b/lib/net/framer.js
@@ -29,7 +29,6 @@ class Framer {
    * Frame a payload with a header.
    * @param {Number} cmd - Packet type.
    * @param {Buffer} payload
-   * @param {Buffer?} checksum - Precomputed checksum.
    * @returns {Buffer} Payload with header prepended.
    */
 


### PR DESCRIPTION
This commit fixes a small jsdoc param that is not longer used. 