### PR TITLE
pkg: link hs-client to bin

### DIFF
--- a/.eslintfiles
+++ b/.eslintfiles
@@ -6,6 +6,8 @@ bin/node
 bin/_seeder
 bin/spvnode
 bin/wallet
+bin/hsd-cli
+bin/hsw-cli
 etc/genesis
 lib/
 test/

--- a/README.md
+++ b/README.md
@@ -20,6 +20,13 @@ Note that `node-gyp` must be installed. See the
 [node-gyp](https://github.com/nodejs/node-gyp) documentation for more
 information.
 
+## CLI
+
+HSD comes with command-line interface tools `hsd-cli` (to interact with the node
+server) and `hsw-cli` (to interact with the wallet server). These applications
+are available in `./bin` (for example the command `./bin/hsd-cli info` returns
+basic node info). CLI usage in the API docs refers to these applications.
+
 ## Documentation
 
 - Documentation Site: [https://handshake-org.github.io](https://handshake-org.github.io)

--- a/README.md
+++ b/README.md
@@ -27,6 +27,19 @@ server) and `hsw-cli` (to interact with the wallet server). These applications
 are available in `./bin` (for example the command `./bin/hsd-cli info` returns
 basic node info). CLI usage in the API docs refers to these applications.
 
+When `hsd` is installed globally, CLI commands are available without the path:
+
+```
+$ hsd-cli info
+```
+
+RPC commands are available with `hsd-cli rpc <command>` and `hsw-cli rpc <command>`.
+The shortcuts `hsd-rpc` and `hsw-rpc` are available if you install hs-client globally:
+
+```
+$ npm install -g hs-client
+```
+
 ## Documentation
 
 - Documentation Site: [https://handshake-org.github.io](https://handshake-org.github.io)

--- a/bin/hsd-cli
+++ b/bin/hsd-cli
@@ -1,0 +1,5 @@
+#!/usr/bin/env node
+
+ 'use strict';
+
+ require('hs-client/bin/hsd-cli');

--- a/bin/hsw-cli
+++ b/bin/hsw-cli
@@ -1,0 +1,5 @@
+#!/usr/bin/env node
+
+ 'use strict';
+
+ require('hs-client/bin/hsw-cli');

--- a/package.json
+++ b/package.json
@@ -57,7 +57,9 @@
     "hsd-node": "./bin/node",
     "hsd-spvnode": "./bin/spvnode",
     "hs-seeder": "./bin/hs-seeder",
-    "hs-wallet": "./bin/hsw"
+    "hs-wallet": "./bin/hsw",
+    "hsd-cli": "./bin/hsd-cli",
+    "hsw-cli": "./bin/hsw-cli"
   },
   "scripts": {
     "lint": "eslint $(cat .eslintfiles) || exit 0",


### PR DESCRIPTION
This is a port of https://github.com/bcoin-org/bcoin/pull/707

After installation, links hsd-cli and hsw-cli directly to hs-client bin, already installed. 

Adds full deprecation message to `cli`.
- [x] Should we just remove `cli` all together? Seems funny to have a deprecation warning on unreleased software.
- [ ] `hsd-rpc` and `hsw-rpc` are a little trickier since those commands are actually bash scripts that hotwire `hsd-cli rpc ...`, etc. Leaving them out for now.

This need was brought to my attention by a community post: https://handshake.community/t/help-chain-is-loading-mac-hsd/100

User seemed a little confused about CLI usage and I realized there is no explicit docs for CLI usage in HSD. (And actually in bcoin, it is a little [buried](https://github.com/bcoin-org/bcoin/blob/master/docs/cli.md) )
