### PR TITLE
node/http: get header by hash/height

### DIFF
--- a/lib/node/http.js
+++ b/lib/node/http.js
@@ -336,7 +336,7 @@ class HTTP extends Server {
     // Block Header by hash/height
     this.get('/header/:block', async (req, res) => {
       const valid = Validator.fromRequest(req);
-      const hash = valid.uintbrhash('block');
+      const hash = valid.uintbhash('block');
 
       enforce(hash != null, 'Hash or height required.');
 

--- a/lib/node/http.js
+++ b/lib/node/http.js
@@ -333,6 +333,23 @@ class HTTP extends Server {
       res.json(200, block.getJSON(this.network, view, height, depth));
     });
 
+    // Block Header by hash/height
+    this.get('/header/:block', async (req, res) => {
+      const valid = Validator.fromRequest(req);
+      const hash = valid.uintbrhash('block');
+
+      enforce(hash != null, 'Hash or height required.');
+
+      const entry = await this.chain.getEntry(hash);
+
+      if (!entry) {
+        res.json(404);
+        return;
+      }
+
+      res.json(200, entry.toJSON());
+    });
+
     // Mempool snapshot
     this.get('/mempool', async (req, res) => {
       enforce(this.mempool, 'No mempool available.');

--- a/test/http-test.js
+++ b/test/http-test.js
@@ -344,6 +344,65 @@ describe('HTTP', function() {
     assert.equal(filterInfo.entries, 1);
   });
 
+  it('should generate 10 blocks from RPC call', async () => {
+    const blocks = await nclient.execute('generatetoaddress', [10, addr.toString(network)]);
+    assert.strictEqual(blocks.length, 10);
+  });
+
+  // depends on the previous test to generate blocks
+  it('should fetch block header by height', async () => {
+    // fetch corresponding header and block
+    const height = 7;
+    const header = await nclient.get(`/header/${height}`);
+    assert.equal(header.height, height);
+
+    const properties = [
+      'hash', 'version', 'prevBlock',
+      'merkleRoot', 'time', 'bits',
+      'nonce', 'height', 'chainwork'
+    ];
+
+    for (const property of properties)
+      assert(property in header);
+
+    const block = await nclient.getBlock(height);
+
+    assert.equal(block.hash, header.hash);
+    assert.equal(block.height, header.height);
+    assert.equal(block.version, header.version);
+    assert.equal(block.prevBlock, header.prevBlock);
+    assert.equal(block.merkleRoot, header.merkleRoot);
+    assert.equal(block.time, header.time);
+    assert.equal(block.bits, header.bits);
+    assert.equal(block.nonce, header.nonce);
+  });
+
+  it('should fetch null for block header that does not exist', async () => {
+    // many blocks in the future
+    const header = await nclient.get(`/header/${40000}`);
+    assert.equal(header, null);
+  });
+
+  it('should have valid header chain', async () => {
+    // starting at the genesis block
+    let prevBlock = '0000000000000000000000000000000000000000000000000000000000000000';
+    for (let i = 0; i < 10; i++) {
+      const header = await nclient.get(`/header/${i}`);
+
+      assert.equal(prevBlock, header.prevBlock);
+      prevBlock = header.hash;
+    }
+  });
+
+  it('should fetch block header by hash', async () => {
+    const info = await nclient.getInfo();
+
+    const headerByHash = await nclient.get(`/header/${info.chain.tip}`);
+    const headerByHeight = await nclient.get(`/header/${info.chain.height}`);
+
+    assert.deepEqual(headerByHash, headerByHeight);
+  });
+
   it('should cleanup', async () => {
     await wallet.close();
     await wclient.close();


### PR DESCRIPTION
It can be useful to query for block headers directly without needing to query for full blocks.
Less disk i/o and less bandwidth would be needed when querying for just the block header.
It will also work for nodes in SPV mode.

This is a port of a PR to bcoin here https://github.com/bcoin-org/bcoin/pull/808/files