### PR TITLE
net: remove discoverExternal() from the pool

### DIFF
--- a/lib/net/pool.js
+++ b/lib/net/pool.js
@@ -277,7 +277,6 @@ class Pool extends EventEmitter {
     await this.hosts.open();
 
     await this.discoverGateway();
-    await this.discoverExternal();
     await this.discoverSeeds();
 
     this.fillOutbound();
@@ -520,52 +519,6 @@ class Pool extends EventEmitter {
 
       this.refill();
     }
-  }
-
-  /**
-   * Attempt to discover external IP via DNS.
-   * @returns {Promise}
-   */
-
-  async discoverExternal() {
-    const port = this.options.publicPort;
-
-    // Pointless if we're not listening.
-    if (!this.options.listen)
-      return;
-
-    // Never hit a DNS server if
-    // we're using an outbound proxy.
-    if (this.options.proxy)
-      return;
-
-    // Try not to hit this if we can avoid it.
-    if (this.hosts.local.size > 0)
-      return;
-
-    let host4 = null;
-
-    try {
-      host4 = await dns.getIPv4(2000);
-    } catch (e) {
-      this.logger.debug('Could not find external IPv4 (dns).');
-      this.logger.debug(e);
-    }
-
-    if (host4 && this.hosts.addLocal(host4, port, scores.DNS))
-      this.logger.info('External IPv4 found (dns): %s.', host4);
-
-    let host6 = null;
-
-    try {
-      host6 = await dns.getIPv6(2000);
-    } catch (e) {
-      this.logger.debug('Could not find external IPv6 (dns).');
-      this.logger.debug(e);
-    }
-
-    if (host6 && this.hosts.addLocal(host6, port, scores.DNS))
-      this.logger.info('External IPv6 found (dns): %s.', host6);
   }
 
   /**


### PR DESCRIPTION
This commit removes the discover external check in the pool. Currently
we already store all local addresses that are sent to us from peers in
the hostlist, so there is no reason to rely on an external service to
check for our local/external address. This was removed from bitcoin in
commit 845c86d.

EDIT: This is blocked by implementing the saving of local addresses via the remote property in the version packet. 