### PR TITLE
config: add discover option for peer discovery

### DIFF
--- a/lib/net/pool.js
+++ b/lib/net/pool.js
@@ -1333,7 +1333,7 @@ class Pool extends EventEmitter {
 
   async handleOpen(peer) {
     // Advertise our address.
-    if (!this.options.selfish && this.options.listen) {
+    if (!this.options.selfish && this.options.listen && this.options.discover) {
       const addr = this.hosts.getLocal(peer.address);
       if (addr)
         peer.send(new packets.AddrPacket([addr]));
@@ -4302,6 +4302,11 @@ class PoolOptions {
     if (options.listen != null) {
       assert(typeof options.listen === 'boolean');
       this.listen = options.listen;
+    }
+
+    if (options.discover != null) {
+      assert(typeof options.discover === 'boolean');
+      this.discover = options.discover;
     }
 
     if (options.compact != null) {

--- a/lib/node/fullnode.js
+++ b/lib/node/fullnode.js
@@ -80,6 +80,8 @@ class FullNode extends Node {
       indexAddress: this.config.bool('index-address')
     });
 
+    this.listen = this.config.bool('listen');
+
     // Pool needs access to the chain and mempool.
     this.pool = new Pool({
       network: this.network,
@@ -104,8 +106,9 @@ class FullNode extends Node {
       publicPort: this.config.uint('public-port'),
       host: this.config.str('host'),
       port: this.config.uint('port'),
-      listen: this.config.bool('listen'),
-      memory: this.config.bool('memory')
+      listen: this.listen,
+      memory: this.config.bool('memory'),
+      discover: this.config.bool('discover', this.listen )
     });
 
     // Miner needs access to the chain and mempool.

--- a/lib/node/spvnode.js
+++ b/lib/node/spvnode.js
@@ -73,7 +73,8 @@ class SPVNode extends Node {
       createSocket: this.config.func('create-socket'),
       memory: this.config.bool('memory'),
       selfish: true,
-      listen: false
+      listen: false,
+      discover: false
     });
 
     this.rpc = new RPC(this);


### PR DESCRIPTION
This commit adds a configuration boolean named discover. It mimics the
behavior provided in commit 845c86d. Discover allows the user to
configure their node to *not* share their own peer address with other
peers. This allows for a node to listen, but choose not to share their
local address.