### PR TITLE
sighash: `singlepresignfinalize`

### DIFF
--- a/lib/primitives/tx.js
+++ b/lib/primitives/tx.js
@@ -297,6 +297,7 @@ class TX extends bio.Struct {
 
     if (!(type & hashType.ANYONECANPAY)
         && (type & 0x1f) !== hashType.SINGLE
+        && (type & 0x1f) !== hashType.SINGLEPRESIGNFINALIZE
         && (type & 0x1f) !== hashType.NONE) {
       if (this._hashSequence) {
         sequences = this._hashSequence;
@@ -314,6 +315,7 @@ class TX extends bio.Struct {
     }
 
     if ((type & 0x1f) !== hashType.SINGLE
+        && (type & 0x1f) !== hashType.SINGLEPRESIGNFINALIZE
         && (type & 0x1f) !== hashType.NONE) {
       if (this._hashOutputs) {
         outputs = this._hashOutputs;
@@ -337,6 +339,18 @@ class TX extends bio.Struct {
       if (index < this.outputs.length) {
         const output = this.outputs[index];
         outputs = blake2b.digest(output.encode());
+      }
+    } else if ((type & 0x1f) === hashType.SINGLEPRESIGNFINALIZE) {
+      if (index < this.outputs.length) {
+        const output = this.outputs[index];
+        if (output.covenant.type === rules.types.FINALIZE) {
+          const clone = new Output();
+          clone.inject(output);
+          clone.covenant.set(6, consensus.ZERO_HASH);
+          outputs = blake2b.digest(clone.encode());
+        } else {
+          outputs = blake2b.digest(output.encode());
+        }
       }
     }
 

--- a/lib/script/common.js
+++ b/lib/script/common.js
@@ -415,6 +415,14 @@ exports.hashType = {
   SINGLE: 3,
 
   /*
+   * Sign output at the same index but do not
+   * sign the covenant data at index 6 iff the
+   * covenant type is FINALIZE (zero sequences).
+   */
+
+  SINGLEPRESIGNFINALIZE: 5,
+
+  /*
    * Sign no inputs.
    */
 
@@ -436,6 +444,7 @@ exports.hashTypeByVal = {
   1: 'ALL',
   2: 'NONE',
   3: 'SINGLE',
+  5: 'SINGLEPRESIGNFINALIZE',
   0x40: 'NOINPUT',
   0x80: 'ANYONECANPAY'
 };

--- a/test/sighash-test.js
+++ b/test/sighash-test.js
@@ -1,0 +1,158 @@
+/*!
+ * sighash-test.js - test sighash types
+ * Copyright (c) 2019, Mark Tyneway (MIT License).
+ * https://github.com/handshake-org/hsd
+ */
+
+'use strict';
+
+const assert = require('bsert');
+const KeyRing = require('../lib/primitives/keyring');
+const MTX = require('../lib/primitives/mtx');
+const Script = require('../lib/script/script');
+const Mnemonic = require('../lib/hd/mnemonic');
+const HDPrivateKey = require('../lib/hd/private');
+const Coin = require('../lib/primitives/coin');
+const Network = require('../lib/protocol/network');
+const common = require('../lib/script/common');
+const {HARDENED} = require('../lib/hd/common');
+const random = require('bcrypto/lib/random');
+
+const mnemonics = require('./data/mnemonic-english.json');
+const phrase = mnemonics[0][1];
+const mnemonic = Mnemonic.fromPhrase(phrase);
+
+const rules = require('../lib/covenants/rules');
+const {types} = rules;
+
+Network.set('regtest');
+const network = Network.get('regtest');
+
+// sighash types
+const SINGLEPRESIGNFINALIZE = common.hashType.SINGLEPRESIGNFINALIZE;
+
+const ONE_HASH = Buffer.alloc(32, 0x00);
+ONE_HASH[0] = 0x01;
+const COIN_TYPE= network.keyPrefix.coinType;
+
+describe('Signature Hashes', function () {
+  describe('SINGLEPRESIGNFINALIZE', function () {
+    let path, keyring, addr, receives;
+
+    before(() => {
+      path = [harden(44), harden(5353), harden(0), 0, 0];
+      keyring = newKeyRing(path);
+      addr = keyring.getAddress();
+
+      // generate receive addresses
+      receives = [
+        newAddress([harden(44), harden(COIN_TYPE), harden(1), 0, 0]),
+        newAddress([harden(44), harden(COIN_TYPE), harden(2), 0, 0]),
+        newAddress([harden(44), harden(COIN_TYPE), harden(3), 0, 0])
+      ];
+    });
+
+    after(() => {
+      path = null;
+      keyring = null;
+      addr = null;
+      receives = null;
+    });
+
+    it('should exist in common', () => {
+      assert('SINGLEPRESIGNFINALIZE' in common.hashType);
+      assert(common.hashTypeByVal[SINGLEPRESIGNFINALIZE] === 'SINGLEPRESIGNFINALIZE');
+    });
+
+    it('should calculate the correct sighash for FINALIZE transaction', () => {
+      const name = 'foo';
+      const rawName = Buffer.from(name, 'ascii');
+      const nameHash = rules.hashName(rawName);
+
+      const mtx = new MTX();
+
+      mtx.addOutput({
+        value: 0,
+        address: receives[0],
+        covenant: {
+          type: types.FINALIZE,
+          items: [
+            nameHash,
+            b('0000dead'),         // height
+            rawName,
+            b('00'),               // flags
+            b('dead0000'),         // claim height
+            b('00dead00'),         // renewal count
+            random.randomBytes(32) // block hash
+          ]
+        }
+      });
+
+      const coin = new Coin({
+        height: 0,
+        value: 0,
+        address: addr,
+        hash: ONE_HASH,
+        index: 0,
+        covenant: {
+          type: types.TRANSFER,
+          items: [
+            nameHash,
+            b('0000dead'), // height
+            rawName
+          ]
+        }
+      });
+
+      mtx.addCoin(coin);
+
+      const script = Script.fromPubkeyhash(keyring.getHash());
+      const sighash = mtx.signatureHash(0, script, 0, SINGLEPRESIGNFINALIZE);
+
+      // malleate transaction
+      mtx.covenant(0).set(6, random.randomBytes(32));
+      const malleated = mtx.signatureHash(0, script, 0, SINGLEPRESIGNFINALIZE);
+
+      assert.bufferEqual(sighash, malleated);
+
+      // malleate in unintended way
+      mtx.covenant(0).set(0, random.randomBytes(32));
+      const fail = mtx.signatureHash(0, script, 0, SINGLEPRESIGNFINALIZE);
+      assert.notBufferEqual(sighash, fail);
+    });
+  });
+});
+
+// deterministically generate keys from a path
+function newKeyRing(path) {
+  let key = HDPrivateKey.fromMnemonic(mnemonic);
+
+  assert(Array.isArray(path));
+  assert(path.every(index => Number.isSafeInteger(index)));
+
+  for (let index of path) {
+    let hardened = false;
+    if (index & HARDENED) {
+      index ^= HARDENED;
+      hardened = true;
+    }
+    key = key.derive(index, hardened);
+  }
+
+  return KeyRing.fromPrivate(key.privateKey);
+}
+
+// create an address from a path
+function newAddress(path) {
+  return newKeyRing(path).getAddress();
+}
+
+function harden(uint) {
+  assert(Number.isSafeInteger(uint) && uint >= 0);
+  return (uint | HARDENED) >>> 0;
+}
+
+function b(str) {
+  assert(typeof str === 'string');
+  return Buffer.from(str, 'hex');
+}


### PR DESCRIPTION
```
  HIP: xxx
  Title: Sighash SINGLEPRESIGNFINALIZE
  Author: Mark Tyneway <mark@purse.io>
          Boyma Fahnbulleh <boymanjor@protonmail.com>
  Comments-Summary: No comments yet.
  Comments-URI: No uri yet.
  Status: Draft
  Type: Standards
  Created: 2019-07-01
```

## Abstract

Standard cryptocurrency transactions use public key cryptography to authorize the movement
of value in the system. UTXOs are encumbered with a "locking script" and have a value,
it generally requires a proof of ownership of a private key using a digital signature
algorithm that is also able to authenitcate the transaction data before it is considered
a valid spend. Bitcoin introduced the concept of a Sighash type, which alters which data
is committed to in the signature hashing algorithm. Any data that is not committed to
is considered malleable and can be altered after the digital signature has been created
and still allow for valid signature verification. Sighashes allow for more interesting
transaction schemes to be created, but they also come with a downside of complexity and
potential loss of security.

Sometimes it is desired to have certain fields in the transaction be malleable because
their values are unknown at the time of signing. For example, a user may sign a transaction
and then pass the transaction to a counterparty who may alter the transaction in different
ways before broadcasting it to the network. It is very important that only particular fields
are malleable as the counterparty may be able to modify the transaction in unintended ways
if the wrong fields are malleable.

Handshake uses a UTXO based model similar to Bitcoin, but UTXOs have an additional field
called `covenant`, which has an `action` and an array of `arguments`. 

```
struct output_s {
  int64_t value;
  uint8_t script[];
  struct covenant_s {
    uint8_t action;
    uint8_t arguments[][];
  } covenant;
} output;
```

Covenants are a way to restrict all future spends of any UTXOs that derive from the
current UTXO. In Handshake, certain types of covenants can be spent to other types
of covenants. To prevent a major hack hurting the network, two transactions are
necessary to move a UTXO that represents a name to another address. The first valid
transaction must spend the name UTXO to a new UTXO with the same address but with
a covenant of action `TRANSFER`. This covenant must commit to the address that the
name will be transferred to. Another transaction must be submitted that spends
the `TRANSFER` to a `FINALIZE`. Consensus rules dictate that the address in the
UTXO with the `FINALIZE` covenant is the same as the address that was comitted to
in the `TRANSFER` output.

Many of the `arguments` are critical for the auction mechanism to function properly,
but some can only have specific values based on consensus rules. This means that blocks
that contain incorrect covenant data will be rejected by the network. A new sighash
type called `SINGLEPRESIGNFINALIZE` is proposed to allow the signer to not commit to a
specific field in the `arguments` array for only the `FINALIZE` covenant. A previous
version of this sighash type defined a different behavior for each covenant type, but
that idea was dropped in favor of a very specific sighash type that is easier to
reason about.

## Motivation

Sighash `SINGLEPRESIGNFINALIZE` will allow for more flexible smart contracts involving the
covenant system. In particular, this sighash type can be used to build a secondary market
on chain for names in a non-interactive fashion. Since names require two transactions to
be moved to another address, the `TRANSFER` transaction can be signed with sighash
`SINGLEREVERSE` and can be posted along with a `FINALIZE` transaction signed with sighash
`SINGLEPRESIGNFINALIZE|NO_INPUT`. Note that this scheme can only be trustless if the name
is held in a script that uses `OP_TYPE` along with `OP_RETURN` to only allow the covenant
state transition from `TRANSFER` to `FINALIZE`. Without such a policy, it would also be
a valid state transition to go from `TRANSFER` to `UPDATE`, which is how name transfers
are cancelled, or from `TRANSFER` to `REVOKE`, which would result in the name state
being nullified and the name going back up for auction in the future.

## Specification

Sighash `SINGLEPRESIGNFINALIZE` is assigned the sighash number `0x05`. Implementation can be found
at https://github.com/tynes/hsd/tree/sighash-singlepresignfinalize.

Consensus dictactes the size of the `arguments` array along with the shape of the data that
is included in it. The `FINALIZE` covenant `arguments` array must have 7 items in this shape:

```
[name hash, height, name, flags, claim height, renewal count, block hash]
```

The element at index 6 is a `block hash`. When signing with `SINGLEPRESIGNFINALIZE`,
the `block hash` is replaced with 32 null bytes so that it is a malleable value.
Consensus rules still dictate that it must be a block hash one lockup period's worth
of blocks into the future after the `TRANSFER` transaciton was included in a block.

The new `signatureHash` implementation is as follows:

```js
  /**
   * Get the signature hash of the transaction for signing verifying.
   * @param {Number} index - Index of input being signed/verified.
   * @param {Script} prev - Previous output script or redeem script
   * (in the case of witnesspubkeyhash, this should be the generated
   * p2pkh script).
   * @param {Amount} value - Previous output value.
   * @param {SighashType} type - Sighash type.
   * @returns {Buffer} Signature hash.
   */

  signatureHash(index, prev, value, type) {
    assert(index >= 0 && index < this.inputs.length);
    assert(prev instanceof Script);
    assert(typeof value === 'number');
    assert(typeof type === 'number');

    let input = this.inputs[index];
    let prevouts = consensus.ZERO_HASH;
    let sequences = consensus.ZERO_HASH;
    let outputs = consensus.ZERO_HASH;

    if (type & hashType.NOINPUT)
      input = new Input();

    if (!(type & hashType.ANYONECANPAY)) {
      if (this._hashPrevouts) {
        prevouts = this._hashPrevouts;
      } else {
        const bw = bio.pool(this.inputs.length * 36);

        for (const input of this.inputs)
          input.prevout.write(bw);

        prevouts = blake2b.digest(bw.render());

        if (!this.mutable)
          this._hashPrevouts = prevouts;
      }
    }

    if (!(type & hashType.ANYONECANPAY)
        && (type & 0x1f) !== hashType.SINGLE
        && (type & 0x1f) !== hashType.SINGLEPRESIGNFINALIZE
        && (type & 0x1f) !== hashType.NONE) {
      if (this._hashSequence) {
        sequences = this._hashSequence;
      } else {
        const bw = bio.pool(this.inputs.length * 4);

        for (const input of this.inputs)
          bw.writeU32(input.sequence);

        sequences = blake2b.digest(bw.render());

        if (!this.mutable)
          this._hashSequence = sequences;
      }
    }

    if ((type & 0x1f) !== hashType.SINGLE
        && (type & 0x1f) !== hashType.SINGLEPRESIGNFINALIZE
        && (type & 0x1f) !== hashType.NONE) {
      if (this._hashOutputs) {
        outputs = this._hashOutputs;
      } else {
        let size = 0;

        for (const output of this.outputs)
          size += output.getSize();

        const bw = bio.pool(size);

        for (const output of this.outputs)
          output.write(bw);

        outputs = blake2b.digest(bw.render());

        if (!this.mutable)
          this._hashOutputs = outputs;
      }
    } else if ((type & 0x1f) === hashType.SINGLE) {
      if (index < this.outputs.length) {
        const output = this.outputs[index];
        outputs = blake2b.digest(output.encode());
      }
    } else if ((type & 0x1f) === hashType.SINGLEPRESIGNFINALIZE) {
      if (index < this.outputs.length) {
        const output = this.outputs[index];
        if (output.covenant.type === rules.types.FINALIZE) {
          const clone = new Output();
          clone.inject(output);
          clone.covenant.set(6, consensus.ZERO_HASH);
          outputs = blake2b.digest(clone.encode());
        } else {
          outputs = blake2b.digest(output.encode());
        }
      }
    }

    const size = 156 + prev.getVarSize();
    const bw = bio.pool(size);

    bw.writeU32(this.version);
    bw.writeBytes(prevouts);
    bw.writeBytes(sequences);
    bw.writeHash(input.prevout.hash);
    bw.writeU32(input.prevout.index);
    bw.writeVarBytes(prev.encode());
    bw.writeU64(value);
    bw.writeU32(input.sequence);
    bw.writeBytes(outputs);
    bw.writeU32(this.locktime);
    bw.writeU32(type);

    return blake2b.digest(bw.render());
  }
```

## Discussion

This block hash must be at least one lockup period's
interval worth of blocks ahead of the block in which the initial `TRANSFER` covenant was
included in a block. This prevents the `TRANSFER` to `FINALIZE` period from being gamed -
to brute force a future valid block hash would be better spent finding an actual block.
Additionally, the full node would not be able to locate the fake block in its chain database, so
it would be unable to validate that there was enough time between the `TRANSFER` and `FINALIZE`.

This time period was created to allow the name holder to react in the case when their
keys are stolen by an adversary. It is possible to spend a `TRANSFER` to an `UPDATE` which
effectively cancels the name transfer. In the worst case, the attacker has copied the key
and has permanent access to it. It is now a race to submit `TRANSFER`s, `UPDATE`s and
`FINALIZE`s between the two parties. In this case, the only move is to submit a `REVOKE`
which burns the UTXO that represents the name and the name will go back up for auction
in the future. 

The addition of the sighash type `SINGLEPRESIGNFINALIZE` adds additional security considerations.
An adversary that has access to the key for a name will want to sign two transactions, one
to `TRANSFER` and then sign the `FINALIZE` but not commit to the block height by using
`SINGLEPRESIGNFINALIZE` so that they can hold on to the signed transaction until enough
blocks pass and be able to substitute in a valid block hash and submit a valid transaction.

In the case of when a key is stolen, the counterparty must be online to prevent the `FINALIZE`
from going through. Even with this sighash type, the same case applies. The counterparty
has time to react to spend the `TRANSFER` to a `UPDATE`. The main difference in the security
of the protocol is about when the attacker has access to the key locking a name. Before this
sighash type, the attacker must have the key at both the time of sending the `TRANSFER` and
when sending the `FINALIZE`. If the attacker steals the key, then they could obviously have
the key during both times. If the key is on a hardware device and cannot be extracted and
the attacker only has access to the hardware device for a short period of time, then the
attacker will be able to sign two consecutive transactions and have them both be valid
eventually if the name holder does not intervene.
