### PR TITLE
wallet: cannot send another OPEN after auction closes

### DIFF
--- a/test/auction-rpc-test.js
+++ b/test/auction-rpc-test.js
@@ -138,7 +138,7 @@ class TestUtil {
   }
 }
 
-describe.only('Auction RPCs', function() {
+describe('Auction RPCs', function() {
   this.timeout(60000);
 
   const util = new TestUtil();


### PR DESCRIPTION
## Problem

We've run into this a bunch on this testnet / previous testnets. There are (2) reasons you may want to OPEN an auction on a name twice from the same wallet:

1) The winner of the initial auction failed to RENEW their name. You want to OPEN a new auction to try to win the name again. (takes a long time)
2) Nobody submit any bids, so the name immediately re-enters the pool of available names when the initial auction closes. (happens quickly)

This PR adds a test case that currently fails with the "Error: Already sent an open for: ${name}". I haven't started fixing this yet, but figured I'd share the failing test case first.