### PR TITLE
pool: Use a shorter loop to get hosts for refilling peers

### DIFF
--- a/lib/net/pool.js
+++ b/lib/net/pool.js
@@ -3276,13 +3276,11 @@ class Pool extends EventEmitter {
     // Calculate maximum number of hosts we can get.
     let max = this.hosts.totalFresh + this.hosts.totalUsed;
 
-    // Limit by number of max outbound connections.
     // We don't want to loop a lot here as it's expensive on CPU.
     // If this gets high, such as 100, it could cause a local DoS
     // for incoming RPC calls.
-    // XXX tie this to a different config option?
-    if (max > this.options.maxOutbound)
-      max = this.options.maxOutbound;
+    if (max > 10)
+      max = 10;
 
     // Work out a percentage based hit rate outside of the
     // loop to save CPU.

--- a/lib/net/pool.js
+++ b/lib/net/pool.js
@@ -3273,12 +3273,24 @@ class Pool extends EventEmitter {
     const services = this.options.getRequiredServices();
     const now = this.network.now();
 
-    for (let i = 0; i < 100; i++) {
+    // Calculate maximum number of hosts we can get.
+    let max = this.hosts.totalFresh + this.hosts.totalUsed;
+    if (max > 100)
+      max = 100;
+
+    // Work out a percentage based hit rate outside of the
+    // loop to save CPU.
+    // Subtract 1 because we're zero based.
+    let pc1 =  max / 100;
+    let pc30 = (pc1 * 30) - 1;
+    let pc50 = (pc1 * 50) - 1;
+    let pc95 = (pc1 * 95) - 1;
+
+    for (let i = 0; i < max; i++) {
       const entry = this.hosts.getHost();
 
       if (!entry)
         break;
-
       const addr = entry.addr;
 
       if (this.peers.has(addr.hostname))
@@ -3293,13 +3305,13 @@ class Pool extends EventEmitter {
       if (!this.options.onion && addr.isOnion())
         continue;
 
-      if (i < 30 && now - entry.lastAttempt < 600)
+      if (i < pc30 && now - entry.lastAttempt < 600)
         continue;
 
-      if (i < 50 && addr.port !== this.network.port)
+      if (i < pc50 && addr.port !== this.network.port)
         continue;
 
-      if (i < 95 && this.hosts.isBanned(addr.host))
+      if (i < pc95 && this.hosts.isBanned(addr.host))
         continue;
 
       return entry.addr;

--- a/lib/net/pool.js
+++ b/lib/net/pool.js
@@ -3275,13 +3275,19 @@ class Pool extends EventEmitter {
 
     // Calculate maximum number of hosts we can get.
     let max = this.hosts.totalFresh + this.hosts.totalUsed;
-    if (max > 100)
-      max = 100;
+
+    // Limit by number of max outbound connections.
+    // We don't want to loop a lot here as it's expensive on CPU.
+    // If this gets high, such as 100, it could cause a local DoS
+    // for incoming RPC calls.
+    // XXX tie this to a different config option?
+    if (max > this.options.maxOutbound)
+      max = this.options.maxOutbound;
 
     // Work out a percentage based hit rate outside of the
     // loop to save CPU.
     // Subtract 1 because we're zero based.
-    const pc1 =  max / 100;
+    const pc1  = max / 100;
     const pc30 = (pc1 * 30) - 1;
     const pc50 = (pc1 * 50) - 1;
     const pc95 = (pc1 * 95) - 1;

--- a/lib/net/pool.js
+++ b/lib/net/pool.js
@@ -3281,10 +3281,10 @@ class Pool extends EventEmitter {
     // Work out a percentage based hit rate outside of the
     // loop to save CPU.
     // Subtract 1 because we're zero based.
-    let pc1 =  max / 100;
-    let pc30 = (pc1 * 30) - 1;
-    let pc50 = (pc1 * 50) - 1;
-    let pc95 = (pc1 * 95) - 1;
+    const pc1 =  max / 100;
+    const pc30 = (pc1 * 30) - 1;
+    const pc50 = (pc1 * 50) - 1;
+    const pc95 = (pc1 * 95) - 1;
 
     for (let i = 0; i < max; i++) {
       const entry = this.hosts.getHost();


### PR DESCRIPTION
Currently, pool::getHost() uses a fixed loop of 0-99 regardless
of how many hosts it has in it's lists so it can use a percentage
to factor in whether it should use an entry or not.
Using network regtest and a single host of 127.0.0.1:14038, hsd
burns a lot of CPU when refilling peers and this blocks incoming
requests so much it times out.

This is less noticeable the more hosts you have.

Instead, calculate how many hosts we have in our list and then
the percentage of each index for it. We can then iterate a much
smmaller list using the same percentage calculations.

This brings CPU utlisation on my NetBSD Xen DOMU on regtest with
one host from 100% to 6% and connecting 4 to peers on testnet
from 85% to 8%, allowing RPC commands to now work.

Fixes #220.