### PR TITLE
peer: set key if inbound and brontide succeeds

### DIFF
--- a/lib/net/peer.js
+++ b/lib/net/peer.js
@@ -409,6 +409,8 @@ class Peer extends EventEmitter {
       this.brontide.once('connect', () => {
         this.time = Date.now();
         this.connected = true;
+        if (!this.outbound)
+          this.address.setKey(this.brontide.remoteStatic);
         this.emit('connect');
 
         cleanup();


### PR DESCRIPTION
Currently on hnscan we noticed that no inbound peers show their identity key when printed using "getpeerinfo". This change sets the key on the net address, inside of an inbound peer if the brontide Handshake is successful. 