### PR TITLE
[Consensus] Script: require output index for OP_CHECKOUTPUT 

### DIFF
--- a/lib/script/script.js
+++ b/lib/script/script.js
@@ -586,6 +586,7 @@ class Script extends bio.Struct {
           if (stack.length < 3)
             throw new ScriptError('INVALID_STACK_OPERATION', op, ip);
 
+          const outputIndex = stack.getInt(-4, minimal, 4);
           const version = stack.getInt(-3, minimal, 4);
           const hash = stack.get(-2);
           const num = stack.getNum(-1, minimal, 8);
@@ -600,8 +601,9 @@ class Script extends bio.Struct {
             throw new ScriptError('INVALID_VALUE', op, ip);
 
           const val = num.isZero() ? value : num.toDouble();
-          const res = checkOutput(tx, index, val, version, hash);
+          const res = checkOutput(tx, outputIndex, val, version, hash);
 
+          stack.pop();
           stack.pop();
           stack.pop();
           stack.pop();

--- a/test/atomic-name-sale-checkoutput-test.js
+++ b/test/atomic-name-sale-checkoutput-test.js
@@ -1,0 +1,272 @@
+/* eslint-env mocha */
+/* eslint prefer-arrow-callback: "off" */
+
+'use strict';
+
+const assert = require('bsert');
+const Network = require('../lib/protocol/network');
+const Script = require('../lib/script/script');
+const Opcode = require('../lib/script/opcode');
+const FullNode = require('../lib/node/fullnode');
+const MTX = require('../lib/primitives/mtx');
+const Output = require('../lib/primitives/output');
+const Input = require('../lib/primitives/input');
+const Address = require('../lib/primitives/address');
+const rules = require('../lib/covenants/rules');
+const Resource = require('../lib/dns/resource');
+
+const network = Network.get('regtest');
+
+const node = new FullNode({
+  memory: true,
+  network: 'regtest',
+  plugins: [require('../lib/wallet/plugin')]
+});
+
+const {wdb} = node.require('walletdb');
+const name = rules.grindName(10, 20, network);
+const salePrice = 123456789;
+let owner, buyer, ownerAddr, buyerAddr;
+let paymentAddr, transferAddr, saleAddr, script;
+
+async function mineBlocks(n, addr) {
+  addr = addr ? addr : new Address().toString('regtest');
+  for (let i = 0; i < n; i++) {
+    const block = await node.miner.mineBlock(null, addr);
+    await node.chain.add(block);
+  }
+}
+
+describe('Atomic name sale with CHECKOUTPUT', function() {
+  before(async () => {
+    await node.open();
+
+    owner = await wdb.create();
+    ownerAddr = await owner.createReceive();
+    owner.createAccount({name: 'payment'});
+    paymentAddr = await owner.createReceive('payment');
+    ownerAddr = ownerAddr.getKeyAddress().toString('regtest');
+    paymentAddr = paymentAddr.getKeyAddress();
+
+    buyer = await wdb.create();
+    buyerAddr = await buyer.createReceive();
+    transferAddr = await buyer.createReceive();
+    buyerAddr = buyerAddr.getKeyAddress().toString('regtest');
+    transferAddr = transferAddr.getKeyAddress();
+  });
+
+  after(async () => {
+    await node.close();
+  });
+
+  it('should fund both wallets', async () => {
+    await mineBlocks(10, ownerAddr);
+    await mineBlocks(10, buyerAddr);
+
+    // Wallet rescan is an effective way to ensure that
+    // wallet and chain are synced before proceeding.
+    await wdb.rescan(0);
+
+    const ownerBal = await owner.getBalance();
+    const buyerBal = await owner.getBalance();
+    assert(ownerBal.confirmed === 2000 * 10 * 1e6);
+    assert(buyerBal.confirmed === 2000 * 10 * 1e6);
+  });
+
+  it('should run an entire auction until a name is owned', async () => {
+    await owner.sendOpen(name, false);
+    await mineBlocks(network.names.treeInterval + 2);
+    let ns = await node.chain.db.getNameStateByName(name);
+    assert(ns.isBidding(node.chain.height, network));
+
+    await wdb.rescan(0);
+
+    await owner.sendBid(name, 100000, 200000);
+    await mineBlocks(network.names.biddingPeriod);
+    ns = await node.chain.db.getNameStateByName(name);
+    assert(ns.isReveal(node.chain.height, network));
+
+    await wdb.rescan(0);
+
+    await owner.sendReveal(name);
+    await mineBlocks(network.names.revealPeriod);
+    ns = await node.chain.db.getNameStateByName(name);
+    assert(ns.isClosed(node.chain.height, network));
+
+    await wdb.rescan(0);
+
+    const resource = Resource.fromJSON({
+      text: ['Delicious Handhsake name for sale!']
+    });
+
+    await owner.sendUpdate(name, resource);
+    await mineBlocks(network.names.treeInterval);
+
+    await wdb.rescan(0);
+
+    ns = await node.chain.db.getNameStateByName(name);
+
+    // Owner owns the name.
+    let coin = await owner.getCoin(ns.owner.hash, ns.owner.index);
+    assert(coin);
+
+    coin = await buyer.getCoin(ns.owner.hash, ns.owner.index);
+    assert(!coin);
+  });
+
+  it('should transfer name to sale script', async () => {
+    script = new Script([
+      Opcode.fromSymbol('OP_TYPE'),
+      Opcode.fromInt(rules.types.TRANSFER),
+      Opcode.fromSymbol('OP_EQUAL'),
+      Opcode.fromSymbol('OP_IF'),
+        Opcode.fromInt(1),  // Output index to check
+        Opcode.fromInt(paymentAddr.version),
+        Opcode.fromData(paymentAddr.hash),
+        Opcode.fromInt(salePrice),
+        Opcode.fromSymbol('OP_CHECKOUTPUT'),
+      Opcode.fromSymbol('OP_ELSE'),
+        Opcode.fromSymbol('OP_TYPE'),
+        Opcode.fromInt(rules.types.FINALIZE),
+        Opcode.fromSymbol('OP_EQUAL'),
+      Opcode.fromSymbol('OP_ENDIF')
+    ]);
+
+    saleAddr = Address.fromScript(script);
+
+    await owner.sendTransfer(name, saleAddr);
+    await mineBlocks(network.names.transferLockup);
+
+    await wdb.rescan(0);
+
+    const finalize = await owner.sendFinalize(name);
+    await mineBlocks(network.names.treeInterval);
+
+    await wdb.rescan(0);
+
+    // Name is now controlled by above script in a FINALIZE.
+    const ns = await node.chain.db.getNameStateByName(name);
+    assert.bufferEqual(finalize.hash(), ns.owner.hash);
+  });
+
+  it('should transfer money to owner and name to buyer', async () => {
+    /*
+     * If the above script format is accepted as a standard and globally known,
+     * then at this point the name owner only needs to announce (in plain text):
+     *  1. The name for sale
+     *  2. The payment address
+     *  3. The sale price
+     *
+     * (and actually if the buyer has --index-address turned on,
+     * they could even figure out which name is for sale on their own!)
+     *
+     * The buyer can recreate the redeem script from the owner's offer data
+     * and verify that the name is owned by that script, including the
+     * impossibility of the transfer being REVOKE'd.
+     */
+
+    // Buyer retrieves namestate to get owner outpoint
+    let ns = await node.chain.db.getNameStateByName(name);
+    const coin = await node.chain.getCoin(ns.owner.hash, ns.owner.index);
+
+    // Output 0: the TRANSFER, sends to same address and value as current owner.
+    const output0 = new Output();
+    output0.address = coin.address;
+    output0.value = coin.value;
+
+    // Buyer adds their own receive address to covenant.
+    output0.covenant.type = rules.types.TRANSFER;
+    output0.covenant.pushHash(ns.nameHash);
+    output0.covenant.pushU32(ns.height);
+    output0.covenant.pushU8(transferAddr.version);
+    output0.covenant.push(transferAddr.hash);
+
+    // Output 1: the payout. Money goes to owner, satisfying OP_CHECKOUTPUT.
+    const output1 = new Output();
+    output1.address = paymentAddr;
+    output1.value = salePrice;
+
+    // First add the money stuff so wallet can fund and create change output.
+    // wallet.fund() doesn't work if mtx already has inputs...
+    const mtx = new MTX();
+    mtx.outputs.push(output1);
+    // Preemptively double the fee because half the tx is still missing
+    await buyer.fund(mtx, {rate: network.feeRate * 2});
+
+    // Insert the name covenants as input 0 and output 0
+    mtx.outputs.unshift(output0);
+    mtx.inputs.unshift(Input.fromCoin(coin));
+
+    // Insert seralized script into witness of input 0 -- no signature needed!
+    mtx.inputs[0].witness.push(script.toRaw());
+    mtx.view.addCoin(coin);
+
+    // Sign (the payment input) & send
+    await buyer.sign(mtx);
+    assert(mtx.verify());
+    const tx = mtx.toTX();
+    await node.sendTX(tx);
+
+    // Confirm
+    await mineBlocks(network.names.transferLockup);
+    await wdb.rescan(0);
+
+    // Owner is paid
+    const paymentBalance = await owner.getBalance('payment');
+    assert.strictEqual(paymentBalance.confirmed, salePrice);
+
+    // Name is owned by TRANSFER tx
+    ns = await node.chain.db.getNameStateByName(name);
+    assert.bufferEqual(ns.owner.hash, tx.hash());
+  });
+
+  it('should finalize the transfer', async () => {
+    // Buyer retrieves namestate to get owner outpoint
+    let ns = await node.chain.db.getNameStateByName(name);
+    let coin = await node.chain.getCoin(ns.owner.hash, ns.owner.index);
+
+    // Output 0: the FINALIZE
+    const output0 = new Output();
+    output0.address = transferAddr;
+    output0.value = coin.value;
+    output0.covenant.type = rules.types.FINALIZE;
+    output0.covenant.pushHash(ns.nameHash);
+    output0.covenant.pushU32(ns.height);
+    output0.covenant.push(Buffer.from(name, 'ascii'));
+    output0.covenant.pushU8(0);
+    output0.covenant.pushU32(ns.claimed);
+    output0.covenant.pushU32(ns.renewals);
+    output0.covenant.pushHash(await wdb.getRenewalBlock());
+
+    // Fund a no-value MTX. Yep, just a miner fee (make it a double).
+    const mtx = new MTX();
+    await buyer.fund(mtx, {rate: network.feeRate * 2});
+
+    // Insert the name covenants as input 0 and output 0
+    mtx.outputs.unshift(output0);
+    mtx.inputs.unshift(Input.fromCoin(coin));
+
+    // Insert seralized script into witness of input 0 -- no signature needed!
+    mtx.inputs[0].witness.push(script.toRaw());
+    mtx.view.addCoin(coin);
+
+    // Sign (the payment input) & send
+    await buyer.sign(mtx);
+    assert(mtx.verify());
+    const tx = mtx.toTX();
+    await node.sendTX(tx);
+
+    // Confirm
+    await mineBlocks(1);
+    await wdb.rescan(0);
+
+    // Name is owned by BUYER
+    ns = await node.chain.db.getNameStateByName(name);
+    const buyerCoin = await buyer.getCoin(ns.owner.hash, ns.owner.index);
+    assert(buyerCoin);
+
+    coin = await node.chain.getCoin(ns.owner.hash, ns.owner.index);
+    const buyerKey = await buyer.getKey(coin.address);
+    assert(buyerKey);
+  });
+});

--- a/test/script-introspection-test.js
+++ b/test/script-introspection-test.js
@@ -1,0 +1,262 @@
+/* eslint-env mocha */
+/* eslint prefer-arrow-callback: "off" */
+
+'use strict';
+
+const assert = require('bsert');
+const Address = require('../lib/primitives/address');
+const Script = require('../lib/script/script');
+const Witness = require('../lib/script/witness');
+const Opcode = require('../lib/script/opcode');
+const MTX = require('../lib/primitives/mtx');
+const Coin = require('../lib/primitives/coin');
+const Output = require('../lib/primitives/output');
+const Covenant = require('../lib/primitives/covenant');
+
+describe('Script transaction introspection', function() {
+  describe('OP_TYPE', function() {
+    it('should verify covenant type from TX output', async () => {
+      for (let t = 0; t < 10; t++) {
+        const script = new Script([
+          Opcode.fromSymbol('OP_TYPE'),
+          Opcode.fromInt(t),
+          Opcode.fromSymbol('OP_EQUAL')
+        ]);
+
+        const coin = Coin.fromOptions({
+          value: 1000,
+          address: Address.fromScript(script)
+        });
+
+        const witness = new Witness([script.encode()]);
+
+        const output = new Output();
+        output.covenant = new Covenant(t, []);
+
+        const mtx = new MTX();
+        mtx.addCoin(coin);
+        mtx.inputs[0].witness.fromStack(witness);
+        mtx.outputs[0] = output;
+
+        assert(mtx.verify());
+      }
+    });
+
+    it('should reject wrong covenant type from TX output', async () => {
+      for (let t = 0; t < 10; t++) {
+        const script = new Script([
+          Opcode.fromSymbol('OP_TYPE'),
+          Opcode.fromInt(t),
+          Opcode.fromSymbol('OP_EQUAL')
+        ]);
+
+        const coin = Coin.fromOptions({
+          value: 1000,
+          address: Address.fromScript(script)
+        });
+
+        const witness = new Witness([script.encode()]);
+
+        const output = new Output();
+        output.covenant = new Covenant(t + 1, []);
+
+        const mtx = new MTX();
+        mtx.addCoin(coin);
+        mtx.inputs[0].witness.fromStack(witness);
+        mtx.outputs[0] = output;
+
+        assert(!mtx.verify());
+      }
+    });
+  });
+
+  describe('OP_CHECKOUTPUT', function() {
+    it('should verify TX output with specified value', async () => {
+      for (let v = 1; v < 10; v++) {
+        const value = 1000 * v;
+        const version = v;
+        const hash = Buffer.alloc(20, v);
+
+        const address = new Address({
+          version,
+          hash
+        });
+
+        const script = new Script([
+          Opcode.fromInt(version),
+          Opcode.fromData(hash),
+          Opcode.fromInt(value),
+          Opcode.fromSymbol('OP_CHECKOUTPUT')
+        ]);
+
+        const coin = Coin.fromOptions({
+          value: value + 10000,
+          address: Address.fromScript(script)
+        });
+
+        const witness = new Witness([script.encode()]);
+
+        const output = new Output({
+          value,
+          address
+        });
+
+        const mtx = new MTX();
+        mtx.addCoin(coin);
+        mtx.inputs[0].witness.fromStack(witness);
+        mtx.outputs[0] = output;
+
+        assert(mtx.verify());
+      }
+    });
+
+    it('should verify TX output with same-as-input value', async () => {
+      const value = 123456789;
+      const version = 0;
+      const hash = Buffer.alloc(20, 1);
+
+      const address = new Address({
+        version,
+        hash
+      });
+
+      const script = new Script([
+        Opcode.fromInt(version),
+        Opcode.fromData(hash),
+        Opcode.fromInt(0),
+        Opcode.fromSymbol('OP_CHECKOUTPUT')
+      ]);
+
+      const coin = Coin.fromOptions({
+        value: value,
+        address: Address.fromScript(script)
+      });
+
+      const witness = new Witness([script.encode()]);
+
+      const output = new Output({
+        value,
+        address
+      });
+
+      const mtx = new MTX();
+      mtx.addCoin(coin);
+      mtx.inputs[0].witness.fromStack(witness);
+      mtx.outputs[0] = output;
+
+      assert(mtx.verify());
+    });
+
+    it('should reject TX output mismatch: value', async () => {
+      const value = 123456789;
+      const version = 0;
+      const hash = Buffer.alloc(20, 1);
+
+      const address = new Address({
+        version,
+        hash
+      });
+
+      const script = new Script([
+        Opcode.fromInt(version),
+        Opcode.fromData(hash),
+        Opcode.fromInt(value + 1),
+        Opcode.fromSymbol('OP_CHECKOUTPUT')
+      ]);
+
+      const coin = Coin.fromOptions({
+        value: value - 1,
+        address: Address.fromScript(script)
+      });
+
+      const witness = new Witness([script.encode()]);
+
+      const output = new Output({
+        value,
+        address
+      });
+
+      const mtx = new MTX();
+      mtx.addCoin(coin);
+      mtx.inputs[0].witness.fromStack(witness);
+      mtx.outputs[0] = output;
+
+      assert(!mtx.verify());
+    });
+
+    it('should reject TX output mismatch: address', async () => {
+      const value = 123456789;
+      const version = 0;
+      const hash = Buffer.alloc(20, 1);
+      const badhash = Buffer.alloc(20, 2);
+
+      const address = new Address({
+        version,
+        hash
+      });
+
+      const script = new Script([
+        Opcode.fromInt(version),
+        Opcode.fromData(badhash),
+        Opcode.fromInt(value),
+        Opcode.fromSymbol('OP_CHECKOUTPUT')
+      ]);
+
+      const coin = Coin.fromOptions({
+        value: value,
+        address: Address.fromScript(script)
+      });
+
+      const witness = new Witness([script.encode()]);
+
+      const output = new Output({
+        value,
+        address
+      });
+
+      const mtx = new MTX();
+      mtx.addCoin(coin);
+      mtx.inputs[0].witness.fromStack(witness);
+      mtx.outputs[0] = output;
+
+      assert(!mtx.verify());
+    });
+
+    it('should reject TX output mismatch: version', async () => {
+      const value = 123456789;
+      const version = 0;
+      const hash = Buffer.alloc(20, 1);
+
+      const address = new Address({
+        version,
+        hash
+      });
+
+      const script = new Script([
+        Opcode.fromInt(version + 1),
+        Opcode.fromData(hash),
+        Opcode.fromInt(value),
+        Opcode.fromSymbol('OP_CHECKOUTPUT')
+      ]);
+
+      const coin = Coin.fromOptions({
+        value: value,
+        address: Address.fromScript(script)
+      });
+
+      const witness = new Witness([script.encode()]);
+
+      const output = new Output({
+        value,
+        address
+      });
+
+      const mtx = new MTX();
+      mtx.addCoin(coin);
+      mtx.inputs[0].witness.fromStack(witness);
+      mtx.outputs[0] = output;
+
+      assert(!mtx.verify());
+    });
+  });
+});


### PR DESCRIPTION
Implementation of the proposal at https://github.com/handshake-org/hsd/issues/224.
Tests built off of https://github.com/handshake-org/hsd/pull/226

### Modified consensus rule

OP_CHECKOUTPUT and OP_CHECKOUTPUTVERIFY consume one extra value from the stack that indicates _which output_ of the spending transaction to check (for value, address hash and address version).

### Motivation

Handshake has two types of covenants: The literal primitive object that is associated with every transaction output and restricts name updates and transfers, and the more conceptual scheme that restricts payments of the hns coin. The latter has been proposed in other cryptocurrency systems including opcodes like OP_CHECKOUTPUT. The former is more specifically integrated in handshake, and these native covenants _require that input and output indexes be identical_. That rule is enforced in multiple places like `rules.js` and `chain.js`.

Unfortunately, the native covenant index-rule prevents combining both types of covenants in the same transaction. In other words, OP_CHECKOUT can not be used effectively in a native name-related covenant because the output at that index is already restricted by the native covenant rules.

Allowing the sender to define _which output_ should be checked by the opcode makes it way more flexible, and allows simple on-chain name-for-money atomic swaps (as outlined in issue #224)

### References

[Bitcoin Covenants by: Malte Moser, Ittay Eyal, and Emin Gun Sirer](https://maltemoeser.de/paper/covenants.pdf) describes OP_CHECKOUTPUTVERIFY:
> The opcode expects the index as the first parameter, allowing to place it in the input of the spending transaction. The creator of the spending transaction can therefore determine the output’s position.

[Chain also implemented OP_CHECKOUTPUT](https://chain.com/docs/1.2/protocol/specifications/vm1#introspection-instructions). Step 1 in the algorithm is:
> 1. Pops 6 items from the data stack: index, data, amount, assetid, version, prog.

### SINGLEREVERSE

This consensus change doesn't conflict with #198 and has different trade-offs in the on-chain atomic-swap application. We could have both features in Handshake. (TODO: exemplify both protocols and compare TX sizes and other trade-offs)

### Note to reviewers

I want to make sure that the `getInt()` line below is correct especially regarding the size (4 bytes) - is there such thing as an hsd transaction with more outputs than that? 
`const outputIndex = stack.getInt(-4, minimal, 4);`