### PR TITLE
[consensus] Script: remove OP_CHECKOUTPUT and OP_CHECKOUTPUTVERIFY

### DIFF
--- a/lib/script/common.js
+++ b/lib/script/common.js
@@ -159,8 +159,6 @@ exports.opcodes = {
 
   // More Ops
   OP_TYPE: 0xd0,
-  OP_CHECKOUTPUT: 0xd1,
-  OP_CHECKOUTPUTVERIFY: 0xd2,
 
   // Custom
   OP_INVALIDOPCODE: 0xff
@@ -311,8 +309,6 @@ exports.opcodesByVal = {
 
   // More Ops
   0xd0: 'OP_TYPE',
-  0xd1: 'OP_CHECKOUTPUT',
-  0xd2: 'OP_CHECKOUTPUTVERIFY',
 
   // Custom
   0xff: 'OP_INVALIDOPCODE'

--- a/lib/script/script.js
+++ b/lib/script/script.js
@@ -578,44 +578,6 @@ class Script extends bio.Struct {
 
           break;
         }
-        case opcodes.OP_CHECKOUTPUT:
-        case opcodes.OP_CHECKOUTPUTVERIFY: {
-          if (!tx)
-            throw new ScriptError('UNKNOWN_ERROR', 'No TX passed in.');
-
-          if (stack.length < 3)
-            throw new ScriptError('INVALID_STACK_OPERATION', op, ip);
-
-          const version = stack.getInt(-3, minimal, 4);
-          const hash = stack.get(-2);
-          const num = stack.getNum(-1, minimal, 8);
-
-          if (version < 0 || version > 31)
-            throw new ScriptError('INVALID_VERSION', op, ip);
-
-          if (hash.length < 2 || hash.length > 40)
-            throw new ScriptError('INVALID_HASH', op, ip);
-
-          if (num.isNeg() || !num.isSafe())
-            throw new ScriptError('INVALID_VALUE', op, ip);
-
-          const val = num.isZero() ? value : num.toDouble();
-          const res = checkOutput(tx, index, val, version, hash);
-
-          stack.pop();
-          stack.pop();
-          stack.pop();
-
-          stack.pushBool(res);
-
-          if (op.value === opcodes.OP_CHECKOUTPUTVERIFY) {
-            if (!res)
-              throw new ScriptError('OUTPUTVERIFY', op, ip);
-            stack.pop();
-          }
-
-          break;
-        }
         case opcodes.OP_CHECKLOCKTIMEVERIFY: {
           if (!tx)
             throw new ScriptError('UNKNOWN_ERROR', 'No TX passed in.');
@@ -2493,34 +2455,6 @@ function validateSignature(sig, flags) {
 
 function checksig(msg, sig, key) {
   return secp256k1.verify(msg, sig.slice(0, -1), key);
-}
-
-/**
- * Check output against predicate parameters.
- * @param {TX} tx
- * @param {Number} index
- * @param {Amount} value
- * @param {Number} version
- * @param {Buffer} hash
- * @returns {Boolean}
- */
-
-function checkOutput(tx, index, value, version, hash) {
-  if (index >= tx.outputs.length)
-    return false;
-
-  const output = tx.outputs[index];
-
-  if (output.value !== value)
-    return false;
-
-  if (output.address.version !== version)
-    return false;
-
-  if (!output.address.hash.equals(hash))
-    return false;
-
-  return true;
 }
 
 /*

--- a/test/data/script-tests.json
+++ b/test/data/script-tests.json
@@ -7225,7 +7225,7 @@
     "locktime": 0,
     "sequence": 4294967295,
     "flags": [],
-    "result": "INVALID_STACK_OPERATION"
+    "result": "BAD_OPCODE"
   },
   {
     "comments": null,
@@ -7237,7 +7237,7 @@
     "locktime": 0,
     "sequence": 4294967295,
     "flags": [],
-    "result": "INVALID_STACK_OPERATION"
+    "result": "BAD_OPCODE"
   },
   {
     "comments": null,


### PR DESCRIPTION
Closes https://github.com/handshake-org/hsd/issues/224
Replaces https://github.com/handshake-org/hsd/pull/227

- [x] : Update https://github.com/handshake-org/hsd/pull/226

It seems this opcode may be more trouble than it is worth for Handshake. We already have a native covenant system, and a proposed consensus update to enable on-chain atomic name sales (https://github.com/handshake-org/hsd/pull/198).

This PR removes the opcode from the scripting system and adjusts tests that called it to throw the appropriate error (`BAD_OPCODE`)