### PR TITLE
hsd: expose covenants and dns in global hsd.js object

### DIFF
--- a/lib/covenants/index.js
+++ b/lib/covenants/index.js
@@ -1,0 +1,15 @@
+/*!
+ * covenants/index.js - covenants for hsd
+ * Copyright (c) 2019, handshake-org developers (MIT License).
+ * https://github.com/handshake-org/hsd
+ */
+
+'use strict';
+
+/**
+ * @module covenants
+ */
+
+exports.Namestate = require('./namestate');
+exports.Ownership = require('./ownership');
+exports.Rules = require('./rules');

--- a/lib/hsd-browser.js
+++ b/lib/hsd-browser.js
@@ -43,6 +43,16 @@ hsd.Coins = require('./coins/coins');
 hsd.CoinEntry = require('./coins/coinentry');
 hsd.CoinView = require('./coins/coinview');
 
+// Covenants
+hsd.covenants = require('./covenants');
+hsd.Namestate = require('./covenants/namestate');
+hsd.Ownership = require('./covenants/ownership');
+hsd.Rules = require('./covenants/rules');
+
+// DNS
+hsd.dns = require('./dns/server');
+hsd.Resource = require('./dns/resource');
+
 // HD
 hsd.hd = require('./hd');
 hsd.HDPrivateKey = require('./hd/private');

--- a/lib/hsd.js
+++ b/lib/hsd.js
@@ -62,6 +62,16 @@ hsd.define('Coins', './coins/coins');
 hsd.define('CoinEntry', './coins/coinentry');
 hsd.define('CoinView', './coins/coinview');
 
+// Covenants
+hsd.define('covenants', './covenants');
+hsd.define('Namestate', './covenants/namestate');
+hsd.define('Ownership', './covenants/ownership');
+hsd.define('Rules', './covenants/rules');
+
+// DNS
+hsd.define('dns', './dns/server');
+hsd.define('Resource', './dns/resource');
+
 // HD
 hsd.define('hd', './hd');
 hsd.define('HDPrivateKey', './hd/private');


### PR DESCRIPTION
This is an update I needed to bundle `hsd` for the browser in my experimental hsd SPV browser node: https://github.com/pinheadmz/mobilehsd

From the global `hsd` object, for example, there is otherwise no method to get a namehash (sha3 digest of a rules-verified string). There's also no way to decode a `Resource` obtained via SPV `getProof` messaging.

I didn't think all the submodules were necessary, this is what is now exposed:

```
// Covenants
hsd.covenants = require('./covenants');
hsd.Namestate = require('./covenants/namestate');
hsd.Ownership = require('./covenants/ownership');
hsd.Rules = require('./covenants/rules');

 // DNS
hsd.dns = require('./dns/server');
hsd.Resource = require('./dns/resource');
```

Note that `dns/server` exports two objects: 
```
exports.RootServer = RootServer;
exports.RecursiveServer = RecursiveServer;
```