### PR TITLE
wallet: accept account argument for all covenant makers and verify account ownership during coin selection

### DIFF
--- a/lib/wallet/txdb.js
+++ b/lib/wallet/txdb.js
@@ -2251,6 +2251,20 @@ class TXDB {
   }
 
   /**
+   * Test whether an account owns a coin.
+   * @param {Number} acct
+   * @param {Hash} hash
+   * @param {Index} number
+   * @returns {Promise} - Returns Boolean.
+   */
+
+  hasCoinByAccount(acct, hash, index) {
+    assert(typeof acct === 'number');
+
+    return this.bucket.has(layout.C.encode(acct, hash, index));
+  }
+
+  /**
    * Get hashes of all transactions in the database.
    * @param {Number} acct
    * @returns {Promise} - Returns {@link Hash}[].

--- a/lib/wallet/wallet.js
+++ b/lib/wallet/wallet.js
@@ -2626,15 +2626,21 @@ class Wallet extends EventEmitter {
    * Make a transfer MTX.
    * @param {String} name
    * @param {Address} address
+   * @param {String|Number} acct
    * @returns {MTX}
    */
 
-  async makeTransfer(name, address) {
+  async makeTransfer(name, address, acct) {
     assert(typeof name === 'string');
     assert(address instanceof Address);
 
     if (!rules.verifyName(name))
       throw new Error('Invalid name.');
+
+    if (acct != null) {
+      assert((acct >>> 0) === acct || typeof acct === 'string');
+      acct = await this.getAccountIndex(acct);
+    }
 
     const rawName = Buffer.from(name, 'ascii');
     const nameHash = rules.hashName(rawName);
@@ -2657,6 +2663,9 @@ class Wallet extends EventEmitter {
     // Is local?
     if (coin.height < ns.height)
       throw new Error(`Wallet does not own: "${name}".`);
+
+    if (acct != null && !await this.txdb.hasCoinByAccount(acct, hash, index))
+      throw new Error(`Account does not own: "${name}".`);
 
     const state = ns.state(height, network);
 
@@ -2696,7 +2705,8 @@ class Wallet extends EventEmitter {
    */
 
   async _createTransfer(name, address, options) {
-    const mtx = await this.makeTransfer(name, address);
+    const acct = options ? options.account : null;
+    const mtx = await this.makeTransfer(name, address, acct);
     await this.fill(mtx, options);
     return this.finalize(mtx, options);
   }
@@ -2876,14 +2886,20 @@ class Wallet extends EventEmitter {
    * Make a transfer-finalizing MTX.
    * @private
    * @param {String} name
+   * @param {String|Number} acct
    * @returns {MTX}
    */
 
-  async makeFinalize(name) {
+  async makeFinalize(name, acct) {
     assert(typeof name === 'string');
 
     if (!rules.verifyName(name))
       throw new Error('Invalid name.');
+
+    if (acct != null) {
+      assert((acct >>> 0) === acct || typeof acct === 'string');
+      acct = await this.getAccountIndex(acct);
+    }
 
     const rawName = Buffer.from(name, 'ascii');
     const nameHash = rules.hashName(rawName);
@@ -2906,6 +2922,9 @@ class Wallet extends EventEmitter {
     // Is local?
     if (coin.height < ns.height)
       throw new Error(`Wallet does not own: "${name}".`);
+
+    if (acct != null && !await this.txdb.hasCoinByAccount(acct, hash, index))
+      throw new Error(`Account does not own: "${name}".`);
 
     const state = ns.state(height, network);
 
@@ -2955,7 +2974,8 @@ class Wallet extends EventEmitter {
    */
 
   async _createFinalize(name, options) {
-    const mtx = await this.makeFinalize(name);
+    const acct = options ? options.account : null;
+    const mtx = await this.makeFinalize(name, acct);
     await this.fill(mtx, options);
     return this.finalize(mtx, options);
   }

--- a/lib/wallet/wallet.js
+++ b/lib/wallet/wallet.js
@@ -2768,14 +2768,20 @@ class Wallet extends EventEmitter {
    * Make a transfer-cancelling MTX.
    * @private
    * @param {String} name
+   * @param {String|Number} acct
    * @returns {MTX}
    */
 
-  async makeCancel(name) {
+  async makeCancel(name, acct) {
     assert(typeof name === 'string');
 
     if (!rules.verifyName(name))
       throw new Error('Invalid name.');
+
+    if (acct != null) {
+      assert((acct >>> 0) === acct || typeof acct === 'string');
+      acct = await this.getAccountIndex(acct);
+    }
 
     const rawName = Buffer.from(name, 'ascii');
     const nameHash = rules.hashName(rawName);
@@ -2798,6 +2804,9 @@ class Wallet extends EventEmitter {
     // Is local?
     if (coin.height < ns.height)
       throw new Error(`Wallet does not own: "${name}".`);
+
+    if (acct != null && !await this.txdb.hasCoinByAccount(acct, hash, index))
+      throw new Error(`Account does not own: "${name}".`);
 
     const state = ns.state(height, network);
 
@@ -2831,7 +2840,8 @@ class Wallet extends EventEmitter {
    */
 
   async _createCancel(name, options) {
-    const mtx = await this.makeCancel(name);
+    const acct = options ? options.account : null;
+    const mtx = await this.makeCancel(name, acct);
     await this.fill(mtx, options);
     return this.finalize(mtx, options);
   }

--- a/lib/wallet/wallet.js
+++ b/lib/wallet/wallet.js
@@ -3039,14 +3039,20 @@ class Wallet extends EventEmitter {
   /**
    * Make a revoke MTX.
    * @param {String} name
+   * @param {String|Number} acct
    * @returns {MTX}
    */
 
-  async makeRevoke(name) {
+  async makeRevoke(name, acct) {
     assert(typeof name === 'string');
 
     if (!rules.verifyName(name))
       throw new Error('Invalid name.');
+
+    if (acct != null) {
+      assert((acct >>> 0) === acct || typeof acct === 'string');
+      acct = await this.getAccountIndex(acct);
+    }
 
     const rawName = Buffer.from(name, 'ascii');
     const nameHash = rules.hashName(rawName);
@@ -3062,6 +3068,9 @@ class Wallet extends EventEmitter {
 
     if (!coin)
       throw new Error(`Wallet does not own: "${name}".`);
+
+    if (acct != null && !await this.txdb.hasCoinByAccount(acct, hash, index))
+      throw new Error(`Account does not own: "${name}".`);
 
     // Is local?
     if (coin.height < ns.height)
@@ -3106,7 +3115,8 @@ class Wallet extends EventEmitter {
    */
 
   async _createRevoke(name, options) {
-    const mtx = await this.makeRevoke(name);
+    const acct = options ? options.account : null;
+    const mtx = await this.makeRevoke(name, acct);
     await this.fill(mtx, options);
     return this.finalize(mtx, options);
   }
@@ -3137,7 +3147,7 @@ class Wallet extends EventEmitter {
 
   async _sendRevoke(name, options) {
     const passphrase = options ? options.passphrase : null;
-    const mtx = await this._createRevoke(name);
+    const mtx = await this._createRevoke(name, options);
     return this.sendMTX(mtx, passphrase);
   }
 

--- a/lib/wallet/wallet.js
+++ b/lib/wallet/wallet.js
@@ -1747,11 +1747,17 @@ class Wallet extends EventEmitter {
   /**
    * Make a reveal MTX.
    * @param {String} name
+   * @param {String|Number} acct
    * @returns {MTX}
    */
 
-  async makeReveal(name) {
+  async makeReveal(name, acct) {
     assert(typeof name === 'string');
+
+    if (acct != null) {
+      assert((acct >>> 0) === acct || typeof acct === 'string');
+      acct = await this.getAccountIndex(acct);
+    }
 
     if (!rules.verifyName(name))
       throw new Error('Invalid name.');
@@ -1787,6 +1793,9 @@ class Wallet extends EventEmitter {
       const coin = await this.getCoin(hash, index);
 
       if (!coin)
+        continue;
+
+      if (acct != null && !await this.txdb.hasCoinByAccount(acct, hash, index))
         continue;
 
       // Is local?
@@ -1828,7 +1837,8 @@ class Wallet extends EventEmitter {
    */
 
   async _createReveal(name, options) {
-    const mtx = await this.makeReveal(name);
+    const acct = options ? options.account : null;
+    const mtx = await this.makeReveal(name, acct);
     await this.fill(mtx, options);
     return this.finalize(mtx, options);
   }

--- a/lib/wallet/wallet.js
+++ b/lib/wallet/wallet.js
@@ -1747,7 +1747,7 @@ class Wallet extends EventEmitter {
   /**
    * Make a reveal MTX.
    * @param {String} name
-   * @param {String|Number} acct
+   * @param {(Number|String)?} acct
    * @returns {MTX}
    */
 
@@ -2010,7 +2010,7 @@ class Wallet extends EventEmitter {
   /**
    * Make a redeem MTX.
    * @param {String} name
-   * @param {String|Number} acct
+   * @param {(Number|String)?} acct
    * @returns {MTX}
    */
 
@@ -2346,7 +2346,7 @@ class Wallet extends EventEmitter {
    * Make an update MTX.
    * @param {String} name
    * @param {Resource} resource
-   * @param {String|Number} acct
+   * @param {(Number|String)?} acct
    * @returns {MTX}
    */
 
@@ -2491,7 +2491,7 @@ class Wallet extends EventEmitter {
    * Make a renewal MTX.
    * @private
    * @param {String} name
-   * @param {String|Number} acct
+   * @param {(Number|String)?} acct
    * @returns {MTX}
    */
 
@@ -2626,7 +2626,7 @@ class Wallet extends EventEmitter {
    * Make a transfer MTX.
    * @param {String} name
    * @param {Address} address
-   * @param {String|Number} acct
+   * @param {(Number|String)?} acct
    * @returns {MTX}
    */
 
@@ -2768,7 +2768,7 @@ class Wallet extends EventEmitter {
    * Make a transfer-cancelling MTX.
    * @private
    * @param {String} name
-   * @param {String|Number} acct
+   * @param {(Number|String)?} acct
    * @returns {MTX}
    */
 
@@ -2896,7 +2896,7 @@ class Wallet extends EventEmitter {
    * Make a transfer-finalizing MTX.
    * @private
    * @param {String} name
-   * @param {String|Number} acct
+   * @param {(Number|String)?} acct
    * @returns {MTX}
    */
 
@@ -3039,7 +3039,7 @@ class Wallet extends EventEmitter {
   /**
    * Make a revoke MTX.
    * @param {String} name
-   * @param {String|Number} acct
+   * @param {(Number|String)?} acct
    * @returns {MTX}
    */
 

--- a/lib/wallet/wallet.js
+++ b/lib/wallet/wallet.js
@@ -2010,14 +2010,20 @@ class Wallet extends EventEmitter {
   /**
    * Make a redeem MTX.
    * @param {String} name
+   * @param {String|Number} acct
    * @returns {MTX}
    */
 
-  async makeRedeem(name) {
+  async makeRedeem(name, acct) {
     assert(typeof name === 'string');
 
     if (!rules.verifyName(name))
       throw new Error('Invalid name.');
+
+    if (acct != null) {
+      assert((acct >>> 0) === acct || typeof acct === 'string');
+      acct = await this.getAccountIndex(acct);
+    }
 
     const rawName = Buffer.from(name, 'ascii');
     const nameHash = rules.hashName(rawName);
@@ -2046,12 +2052,16 @@ class Wallet extends EventEmitter {
       if (!own)
         continue;
 
+      // Winner can not redeem
       if (prevout.equals(ns.owner))
         continue;
 
       const coin = await this.getCoin(hash, index);
 
       if (!coin)
+        continue;
+
+      if (acct != null && !await this.txdb.hasCoinByAccount(acct, hash, index))
         continue;
 
       // Is local?
@@ -2085,7 +2095,8 @@ class Wallet extends EventEmitter {
    */
 
   async _createRedeem(name, options) {
-    const mtx = await this.makeRedeem(name);
+    const acct = options ? options.account : null;
+    const mtx = await this.makeRedeem(name, acct);
     await this.fill(mtx, options);
     return this.finalize(mtx, options);
   }
@@ -2335,15 +2346,21 @@ class Wallet extends EventEmitter {
    * Make an update MTX.
    * @param {String} name
    * @param {Resource} resource
+   * @param {String|Number} acct
    * @returns {MTX}
    */
 
-  async makeUpdate(name, resource) {
+  async makeUpdate(name, resource, acct) {
     assert(typeof name === 'string');
     assert(resource instanceof Resource);
 
     if (!rules.verifyName(name))
       throw new Error('Invalid name.');
+
+    if (acct != null) {
+      assert((acct >>> 0) === acct || typeof acct === 'string');
+      acct = await this.getAccountIndex(acct);
+    }
 
     const rawName = Buffer.from(name, 'ascii');
     const nameHash = rules.hashName(rawName);
@@ -2359,6 +2376,9 @@ class Wallet extends EventEmitter {
 
     if (!coin)
       throw new Error(`Wallet does not own: "${name}".`);
+
+    if (acct != null && !await this.txdb.hasCoinByAccount(acct, hash, index))
+      throw new Error(`Account does not own: "${name}".`);
 
     if (coin.covenant.isReveal() || coin.covenant.isClaim())
       return this._makeRegister(name, resource);
@@ -2412,7 +2432,8 @@ class Wallet extends EventEmitter {
    */
 
   async _createUpdate(name, resource, options) {
-    const mtx = await this.makeUpdate(name, resource);
+    const acct = options ? options.account : null;
+    const mtx = await this.makeUpdate(name, resource, acct);
     await this.fill(mtx, options);
     return this.finalize(mtx, options);
   }
@@ -2470,15 +2491,20 @@ class Wallet extends EventEmitter {
    * Make a renewal MTX.
    * @private
    * @param {String} name
-   * @param {Resource?} resource
+   * @param {String|Number} acct
    * @returns {MTX}
    */
 
-  async makeRenewal(name) {
+  async makeRenewal(name, acct) {
     assert(typeof name === 'string');
 
     if (!rules.verifyName(name))
       throw new Error('Invalid name.');
+
+    if (acct != null) {
+      assert((acct >>> 0) === acct || typeof acct === 'string');
+      acct = await this.getAccountIndex(acct);
+    }
 
     const rawName = Buffer.from(name, 'ascii');
     const nameHash = rules.hashName(rawName);
@@ -2501,6 +2527,9 @@ class Wallet extends EventEmitter {
     // Is local?
     if (coin.height < ns.height)
       throw new Error(`Wallet does not own: "${name}".`);
+
+    if (acct != null && !await this.txdb.hasCoinByAccount(acct, hash, index))
+      throw new Error(`Account does not own: "${name}".`);
 
     const state = ns.state(height, network);
 
@@ -2541,7 +2570,8 @@ class Wallet extends EventEmitter {
    */
 
   async _createRenewal(name, options) {
-    const mtx = await this.makeRenewal(name);
+    const acct = options ? options.account : null;
+    const mtx = await this.makeRenewal(name, acct);
     await this.fill(mtx, options);
     return this.finalize(mtx, options);
   }

--- a/test/wallet-accounts-auction-test.js
+++ b/test/wallet-accounts-auction-test.js
@@ -256,4 +256,81 @@ describe('Multiple accounts participating in same auction', function() {
       assert.strictEqual(node.mempool.map.size, 0);
     });
   });
+
+  describe('TRANSFER', function() {
+    // Alice will transfer to Bob
+    let toAddr;
+
+    before(async () => {
+      toAddr = await bob.receiveAddress();
+    });
+
+    it('should reject TRANSFER from wrong account', async () => {
+      await assert.rejects(async () => {
+        await wallet.sendTransfer(name, toAddr, {account: 'bob'});
+      }, {
+        name: 'Error',
+        message: `Account does not own: "${name}".`
+      });
+    });
+
+    it('should send TRANSFER from correct account', async () => {
+      const tx = await wallet.sendTransfer(name, toAddr, {account: 0});
+      assert(tx);
+
+      await wallet.abandon(tx.hash());
+
+      assert.strictEqual(node.mempool.map.size, 1);
+      await node.mempool.reset();
+      assert.strictEqual(node.mempool.map.size, 0);
+    });
+
+    it('should send TRANSFER from correct account automatically', async () => {
+      const tx = await wallet.sendTransfer(name, toAddr);
+      assert(tx);
+
+      await mineBlocks(1);
+    });
+  });
+
+  describe('FINALIZE', function() {
+    it('should advance chain until FINALIZE is allowed', async () => {
+      await mineBlocks(network.names.transferLockup);
+      const ns = await node.chain.db.getNameStateByName(name);
+      assert(ns.isClosed(node.chain.height, network));
+
+      await wdb.rescan(0);
+    });
+
+    it('should reject FINALIZE from wrong account', async () => {
+      await assert.rejects(async () => {
+        await wallet.sendFinalize(name, {account: 'bob'});
+      }, {
+        name: 'Error',
+        message: `Account does not own: "${name}".`
+      });
+    });
+
+    it('should send FINALIZE from correct account', async () => {
+      const tx = await wallet.sendFinalize(name, {account: 0});
+      assert(tx);
+
+      await wallet.abandon(tx.hash());
+
+      assert.strictEqual(node.mempool.map.size, 1);
+      await node.mempool.reset();
+      assert.strictEqual(node.mempool.map.size, 0);
+    });
+
+    it('should send FINALIZE from correct account automatically', async () => {
+      const tx = await wallet.sendFinalize(name);
+      assert(tx);
+
+      await wallet.abandon(tx.hash());
+
+      assert.strictEqual(node.mempool.map.size, 1);
+      await node.mempool.reset();
+      assert.strictEqual(node.mempool.map.size, 0);
+    });
+  });
 });

--- a/test/wallet-accounts-auction-test.js
+++ b/test/wallet-accounts-auction-test.js
@@ -1,0 +1,259 @@
+/* eslint-env mocha */
+/* eslint prefer-arrow-callback: "off" */
+
+'use strict';
+
+const assert = require('bsert');
+const Network = require('../lib/protocol/network');
+const FullNode = require('../lib/node/fullnode');
+const Address = require('../lib/primitives/address');
+const rules = require('../lib/covenants/rules');
+const Resource = require('../lib/dns/resource');
+const {WalletClient} = require('hs-client');
+
+const network = Network.get('regtest');
+
+const node = new FullNode({
+  memory: true,
+  network: 'regtest',
+  plugins: [require('../lib/wallet/plugin')]
+});
+
+// Prevent mempool from sending duplicate TXs back to the walletDB and txdb.
+// This will prevent a race condition when we need to remove spent (but
+// unconfirmed) outputs from the wallet so they can be reused in other tests.
+node.mempool.emit = () => {};
+
+const wclient = new WalletClient({
+  port: network.walletPort
+});
+
+const {wdb} = node.require('walletdb');
+
+const name = rules.grindName(5, 1, network);
+let wallet, alice, bob, aliceReceive, bobReceive;
+
+async function mineBlocks(n, addr) {
+  addr = addr ? addr : new Address().toString('regtest');
+  for (let i = 0; i < n; i++) {
+    const block = await node.miner.mineBlock(null, addr);
+    await node.chain.add(block);
+  }
+}
+
+describe('Multiple accounts participating in same auction', function() {
+  before(async () => {
+    await node.open();
+    await wclient.open();
+
+    wallet = await wdb.create();
+
+    // We'll use an account number for alice and a string for bob
+    // to ensure that both types work as options.
+    alice = await wallet.getAccount(0);
+    bob = await wallet.createAccount({name: 'bob'});
+
+    aliceReceive = await alice.receiveAddress();
+    bobReceive = await bob.receiveAddress();
+  });
+
+  after(async () => {
+    await wclient.close();
+    await node.close();
+  });
+
+  it('should fund both accounts', async () => {
+    await mineBlocks(2, aliceReceive);
+    await mineBlocks(2, bobReceive);
+
+    // Wallet rescan is an effective way to ensure that
+    // wallet and chain are synced before proceeding.
+    await wdb.rescan(0);
+
+    const aliceBal = await wallet.getBalance(0);
+    const bobBal = await wallet.getBalance('bob');
+    assert(aliceBal.confirmed === 2000 * 2 * 1e6);
+    assert(bobBal.confirmed === 2000 * 2 * 1e6);
+  });
+
+  it('should open an auction and proceed to REVEAL phase', async () => {
+    await wallet.sendOpen(name, false, {account: 0});
+    await mineBlocks(network.names.treeInterval + 2);
+    let ns = await node.chain.db.getNameStateByName(name);
+    assert(ns.isBidding(node.chain.height, network));
+
+    await wdb.rescan(0);
+
+    await wallet.sendBid(name, 100000, 200000, {account: 0});
+    await wallet.sendBid(name, 50000, 200000, {account: 'bob'});
+    await mineBlocks(network.names.biddingPeriod);
+    ns = await node.chain.db.getNameStateByName(name);
+    assert(ns.isReveal(node.chain.height, network));
+
+    await wdb.rescan(0);
+
+    const walletBids = await wallet.getBidsByName(name);
+    assert.strictEqual(walletBids.length, 2);
+
+    for (const bid of walletBids)
+      assert(bid.own);
+
+    assert.strictEqual(node.mempool.map.size, 0);
+  });
+
+  describe('REVEAL', function() {
+    it('should send one REVEAL per account', async () => {
+      const tx1 = await wallet.sendReveal(name, {account: 0});
+      assert(tx1);
+
+      const tx2 = await wallet.sendReveal(name, {account: 'bob'});
+      assert(tx2);
+
+      // Reset for next test
+      await wallet.abandon(tx1.hash());
+      await wallet.abandon(tx2.hash());
+
+      assert.strictEqual(node.mempool.map.size, 2);
+      await node.mempool.reset();
+      assert.strictEqual(node.mempool.map.size, 0);
+    });
+
+    it('should send one REVEAL for all accounts in one tx', async () => {
+      const tx = await wallet.sendRevealAll();
+      assert(tx);
+
+      // Reset for next test
+      await wallet.abandon(tx.hash());
+
+      assert.strictEqual(node.mempool.map.size, 1);
+      await mineBlocks(1);
+      assert.strictEqual(node.mempool.map.size, 0);
+    });
+  });
+
+  describe('UPDATE', function() {
+    const aliceResource = Resource.Resource.fromJSON({
+      records: [
+        {
+          type: 'TXT',
+          txt: ['ALICE']
+        }
+      ]});
+    const bobResource = Resource.Resource.fromJSON({
+      records: [
+        {
+          type: 'TXT',
+          txt: ['BOB']
+        }
+      ]});
+
+    it('should advance auction to REGISTER phase', async () => {
+      await mineBlocks(network.names.revealPeriod);
+      const ns = await node.chain.db.getNameStateByName(name);
+      assert(ns.isClosed(node.chain.height, network));
+
+      await wdb.rescan(0);
+
+      // Alice is the winner
+      const {hash, index} = ns.owner;
+      assert(await wallet.txdb.hasCoinByAccount(0, hash, index));
+
+      // ...not Bob (sanity check)
+      assert(!await wallet.txdb.hasCoinByAccount(1, hash, index));
+    });
+
+    it('should reject REGISTER given wrong account', async () => {
+      await assert.rejects(async () => {
+        await wallet.sendUpdate(name, bobResource, {account: 'bob'});
+      }, {
+        name: 'Error',
+        message: `Account does not own: "${name}".`
+      });
+    });
+
+    it('should send REGISTER given correct account', async () => {
+      const tx = await wallet.sendUpdate(name, aliceResource, {account: 0});
+      assert(tx);
+
+      await wallet.abandon(tx.hash());
+
+      assert.strictEqual(node.mempool.map.size, 1);
+      await node.mempool.reset();
+      assert.strictEqual(node.mempool.map.size, 0);
+    });
+
+    it('should send REGISTER from correct account automatically', async () => {
+      const tx = await wallet.sendUpdate(name, aliceResource);
+      assert(tx);
+
+      await mineBlocks(1);
+    });
+  });
+
+  describe('REDEEM', function() {
+    it('should reject REDEEM given wrong account', async () => {
+      await assert.rejects(async () => {
+        await wallet.sendRedeem(name, {account: 0});
+      }, {
+        name: 'Error',
+        message: 'No reveals to redeem.'
+      });
+    });
+
+    it('should send REDEEM from correct account', async () => {
+      const tx = await wallet.sendRedeem(name, {account: 'bob'});
+      assert(tx);
+
+      await wallet.abandon(tx.hash());
+
+      assert.strictEqual(node.mempool.map.size, 1);
+      await node.mempool.reset();
+      assert.strictEqual(node.mempool.map.size, 0);
+    });
+
+    it('should send REDEEM from correct account automatically', async () => {
+      const tx = await wallet.sendRedeem(name);
+      assert(tx);
+
+      await mineBlocks(1);
+    });
+  });
+
+  describe('RENEW', function() {
+    it('should advance chain to allow renewal', async () => {
+      await mineBlocks(network.names.treeInterval);
+      await wdb.rescan(0);
+    });
+
+    it('should reject RENEW from wrong account', async () => {
+      await assert.rejects(async () => {
+        await wallet.sendRenewal(name, {account: 'bob'});
+      }, {
+        name: 'Error',
+        message: `Account does not own: "${name}".`
+      });
+    });
+
+    it('should send RENEW from correct account', async () => {
+      const tx = await wallet.sendRenewal(name, {account: 0});
+      assert(tx);
+
+      await wallet.abandon(tx.hash());
+
+      assert.strictEqual(node.mempool.map.size, 1);
+      await node.mempool.reset();
+      assert.strictEqual(node.mempool.map.size, 0);
+    });
+
+    it('should send RENEW from correct account automatically', async () => {
+      const tx = await wallet.sendRenewal(name);
+      assert(tx);
+
+      await wallet.abandon(tx.hash());
+
+      assert.strictEqual(node.mempool.map.size, 1);
+      await node.mempool.reset();
+      assert.strictEqual(node.mempool.map.size, 0);
+    });
+  });
+});

--- a/test/wallet-accounts-auction-test.js
+++ b/test/wallet-accounts-auction-test.js
@@ -366,4 +366,37 @@ describe('Multiple accounts participating in same auction', function() {
       assert.strictEqual(node.mempool.map.size, 0);
     });
   });
+
+  describe('REVOKE', function() {
+    it('should reject REVOKE from wrong account', async () => {
+      await assert.rejects(async () => {
+        await wallet.sendRevoke(name, {account: 'bob'});
+      }, {
+        name: 'Error',
+        message: `Account does not own: "${name}".`
+      });
+    });
+
+    it('should send REVOKE from correct account', async () => {
+      const tx = await wallet.sendRevoke(name, {account: 0});
+      assert(tx);
+
+      await wallet.abandon(tx.hash());
+
+      assert.strictEqual(node.mempool.map.size, 1);
+      await node.mempool.reset();
+      assert.strictEqual(node.mempool.map.size, 0);
+    });
+
+    it('should send REVOKE from correct account automatically', async () => {
+      const tx = await wallet.sendRevoke(name);
+      assert(tx);
+
+      await wallet.abandon(tx.hash());
+
+      assert.strictEqual(node.mempool.map.size, 1);
+      await node.mempool.reset();
+      assert.strictEqual(node.mempool.map.size, 0);
+    });
+  });
 });

--- a/test/wallet-accounts-auction-test.js
+++ b/test/wallet-accounts-auction-test.js
@@ -333,4 +333,37 @@ describe('Multiple accounts participating in same auction', function() {
       assert.strictEqual(node.mempool.map.size, 0);
     });
   });
+
+  describe('CANCEL', function() {
+    it('should reject CANCEL from wrong account', async () => {
+      await assert.rejects(async () => {
+        await wallet.sendCancel(name, {account: 'bob'});
+      }, {
+        name: 'Error',
+        message: `Account does not own: "${name}".`
+      });
+    });
+
+    it('should send CANCEL from correct account', async () => {
+      const tx = await wallet.sendCancel(name, {account: 0});
+      assert(tx);
+
+      await wallet.abandon(tx.hash());
+
+      assert.strictEqual(node.mempool.map.size, 1);
+      await node.mempool.reset();
+      assert.strictEqual(node.mempool.map.size, 0);
+    });
+
+    it('should send CANCEL from correct account automatically', async () => {
+      const tx = await wallet.sendCancel(name);
+      assert(tx);
+
+      await wallet.abandon(tx.hash());
+
+      assert.strictEqual(node.mempool.map.size, 1);
+      await node.mempool.reset();
+      assert.strictEqual(node.mempool.map.size, 0);
+    });
+  });
 });


### PR DESCRIPTION
Closes https://github.com/handshake-org/hsd/issues/231

Adds new method hasCoinByAccount(acct, hash, index) to txdb which
returns true if the coin (hash, index) is owned by account (number).
Adds this check to wallet.makeReveal() to prevent BIDs from other
wallet accounts being included as inputs to a new REVEAL TX from a
specific account.

TODO:
- [x] Put the test `double-reveal-test.js` in a more appropriate place... (`auction-test`? `wallet-test`?)
- [x] Finish the auction process in the test, make sure the same bug doesn't throw during any other auction or name-ownership function like `UPDATE`, `REGISTER`. etc...
- [x] Ensure RPC and HTTP APIs pass `account` parameters