### PR TITLE
seeds: add hnscan/easyhandshake nodes to testnet seeds

### DIFF
--- a/lib/net/seeds/testnet.js
+++ b/lib/net/seeds/testnet.js
@@ -1,6 +1,17 @@
 'use strict';
 
 module.exports = [
+
+  // hnscan - Urkel Labs
+  'ak2hy7feae2o5pfzsdzw3cxkxsu3lxypykcl6iphnup4adf2ply6a@138.68.61.31',
+
+  // easyhandshake.com
+  'ajaqq7jwqrwixmvl64tzi3qfi7ynj3hmmtzmkyubtrljh4mwmh7ie@165.22.151.242',
+
+  // Mark Tyneway
+  'aovaq4vgqt6ttolmgyk4kmaybvpf66xni5xr2jjxjuvcwzda7clzi@45.79.33.75',
+
+  // Original Testnet Seeds
   'aoihqqagbhzz6wxg43itefqvmgda4uwtky362p22kbimcyg5fdp54@172.104.214.189',
   'ajdzrpoxsusaw4ixq4ttibxxsuh5fkkduc5qszyboidif2z25i362@173.255.209.126',
   'ajk57wutnhfdzvqwqrgab3wwh4wxoqgnkz4avbln54pgj5jwefcts@172.104.177.177',


### PR DESCRIPTION
Unfortunately looks like some people are having issues connecting to the network currently. This should be a quick fix to help the new potential users coming from hn get onto the network. 