### PR TITLE
dns/records: fix assertion in TLSA JSON parsing

### DIFF
--- a/lib/dns/records.js
+++ b/lib/dns/records.js
@@ -780,8 +780,8 @@ class TLS extends Struct {
     assert((json.usage & 0xff) === json.usage);
     assert((json.selector & 0xff) === json.selector);
     assert((json.matchingType & 0xff) === json.matchingType);
-    assert(typeof json.fingerprint === 'string');
-    assert((json.fingerprint.length >>> 1) <= 255);
+    assert(typeof json.certificate === 'string');
+    assert((json.certificate.length >>> 1) <= 255);
     assert(isSingle(json.protocol));
     this.protocol = util.fqdn(json.protocol);
     this.port = json.port;


### PR DESCRIPTION
It looks like no one has attempted to use TLSA records until now :)

`fingerprint` is actually a better name for the ["Certificate Association Data Field"](https://tools.ietf.org/html/rfc6698#section-2.1.4), because I don't think anyone is going to want to use this to store the full certificate. It will basically always be a hash of the public key or certificate.

But, `certificate` is the name that's already exposed, so *shrug*.

@chjj 