### PR TITLE
Wallet Name Alerts

### DIFF
--- a/lib/wallet/client.js
+++ b/lib/wallet/client.js
@@ -13,7 +13,7 @@ const NameState = require('../covenants/namestate');
 
 const parsers = {
   'block connect': (entry, txs) => parseBlock(entry, txs),
-  'block disconnect': entry => [parseEntry(entry)],
+  'block disconnect': (entry, txs) => [parseBlock(entry, txs)],
   'block rescan': (entry, txs) => parseBlock(entry, txs),
   'chain reset': entry => [parseEntry(entry)],
   'tx': tx => [TX.decode(tx)]

--- a/lib/wallet/http.js
+++ b/lib/wallet/http.js
@@ -1319,6 +1319,27 @@ class HTTP extends Server {
       handleTX('conflict', wallet, tx, details);
     });
 
+    const filtered = (channel, wallet, data, details) => {
+      const name = `w:${wallet.id}`;
+
+      if (!this.channel(name) && !this.channel('w:*'))
+        return;
+
+      const json = data.toJSON(this.network, this.wdb.height);
+      if (data.toStats)
+        json.stats = data.toStats(this.wdb.height, this.network);
+
+      if (this.channel(name))
+        this.to(name, channel, wallet.id, json, details);
+
+      if (this.channel('w:*'))
+        this.to('w:*', channel, wallet.id, json, details);
+    };
+
+    this.wdb.on('alert', (wallet, ns, details) => {
+      filtered('alert', wallet, ns, details);
+    });
+
     this.wdb.on('balance', (wallet, balance) => {
       const name = `w:${wallet.id}`;
 

--- a/lib/wallet/http.js
+++ b/lib/wallet/http.js
@@ -1325,9 +1325,7 @@ class HTTP extends Server {
       if (!this.channel(name) && !this.channel('w:*'))
         return;
 
-      const json = data.toJSON(this.network, this.wdb.height);
-      if (data.toStats)
-        json.stats = data.toStats(this.wdb.height, this.network);
+      const json = data.getJSON(this.wdb.height, this.network);
 
       if (this.channel(name))
         this.to(name, channel, wallet.id, json, details);

--- a/lib/wallet/layout.js
+++ b/lib/wallet/layout.js
@@ -101,5 +101,7 @@ exports.txdb = {
   // Blinds
   v: bdb.key('v', ['hash256']),
   // Opens
-  o: bdb.key('o', ['hash256'])
+  o: bdb.key('o', ['hash256']),
+  // Alerts
+  a: bdb.key('a', ['uint32'])
 };

--- a/lib/wallet/layout.js
+++ b/lib/wallet/layout.js
@@ -51,7 +51,9 @@ exports.wdb = {
   t: bdb.key('t', ['uint32']),
 
   // Name Map
-  N: bdb.key('N', ['hash256'])
+  N: bdb.key('N', ['hash256']),
+  // Alerts
+  e: bdb.key('e', ['uint32'])
 };
 
 /*
@@ -101,7 +103,5 @@ exports.txdb = {
   // Blinds
   v: bdb.key('v', ['hash256']),
   // Opens
-  o: bdb.key('o', ['hash256']),
-  // Alerts
-  a: bdb.key('a', ['uint32'])
+  o: bdb.key('o', ['hash256'])
 };

--- a/lib/wallet/nodeclient.js
+++ b/lib/wallet/nodeclient.js
@@ -47,7 +47,7 @@ class NodeClient extends AsyncEmitter {
       if (!this.opened)
         return;
 
-      this.emit('block disconnect', entry);
+      this.emit('block disconnect', entry, block.txs);
     });
 
     this.node.on('tx', (tx) => {

--- a/lib/wallet/records.js
+++ b/lib/wallet/records.js
@@ -12,6 +12,7 @@
 
 const assert = require('bsert');
 const bio = require('bufio');
+const {BufferSet} = require('buffer-map');
 const util = require('../utils/util');
 const TX = require('../primitives/tx');
 const consensus = require('../protocol/consensus');
@@ -446,6 +447,67 @@ class MapRecord extends bio.Struct {
   }
 }
 
+/**
+ * Alert Record
+ * Maintains a height at which name hashes
+ * progress to a new auction period. Used
+ * for sending websocket events to clients
+ * listening for changes in auction periods.
+ */
+
+class AlertRecord extends bio.Struct {
+  /**
+   * Create alert record.
+   * @constructor
+   */
+
+  constructor(height) {
+    super();
+    this.hashes = new BufferSet();
+    this.height = 0;
+
+    if (typeof height === 'number')
+      this.height = height;
+  }
+
+  add(hash) {
+    this.hashes.add(hash);
+  }
+
+  remove(hash) {
+    return this.hashes.delete(hash);
+  }
+
+  has(hash) {
+    return this.hashes.has(hash);
+  }
+
+  write(bw) {
+    bw.writeU32(this.hashes.size);
+
+    for (const hash of this.hashes)
+      bw.writeHash(hash);
+
+    return bw;
+  }
+
+  getSize() {
+    return 4 + this.hashes.size * 32;
+  }
+
+  read(br, height) {
+    const count = br.readU32();
+
+    for (let i = 0; i < count; i++)
+      this.hashes.add(br.readHash());
+
+    if (typeof height === 'number')
+      this.height = height;
+
+    return this;
+  }
+}
+
 /*
  * Expose
  */
@@ -454,5 +516,6 @@ exports.ChainState = ChainState;
 exports.BlockMeta = BlockMeta;
 exports.TXRecord = TXRecord;
 exports.MapRecord = MapRecord;
+exports.AlertRecord = AlertRecord;
 
 module.exports = exports;

--- a/lib/wallet/records.js
+++ b/lib/wallet/records.js
@@ -420,6 +420,10 @@ class MapRecord extends bio.Struct {
     return true;
   }
 
+  has(wid) {
+    return this.wids.has(wid);
+  }
+
   remove(wid) {
     return this.wids.delete(wid);
   }
@@ -505,6 +509,21 @@ class AlertRecord extends bio.Struct {
       this.height = height;
 
     return this;
+  }
+
+  values() {
+    return this.hashes.values();
+  }
+
+  getJSON() {
+    const hashes = [];
+    for (const hash of this.hashes)
+      hashes.push(hash.toString('hex'));
+
+    return {
+      height: this.height,
+      hashes: hashes
+    };
   }
 }
 

--- a/lib/wallet/txdb.js
+++ b/lib/wallet/txdb.js
@@ -21,7 +21,8 @@ const policy = require('../protocol/policy');
 const rules = require('../covenants/rules');
 const NameState = require('../covenants/namestate');
 const NameUndo = require('../covenants/undo');
-const {TXRecord} = records;
+const {TXRecord, AlertRecord} = records;
+const {states} = NameState;
 const {types} = rules;
 
 /*
@@ -1065,6 +1066,9 @@ class TXDB {
     this.emit('tx', tx, details);
     this.emit('balance', balance);
 
+    if (height !== -1)
+      await this.alert(height, details);
+
     return details;
   }
 
@@ -2052,10 +2056,12 @@ class TXDB {
 
       if (ns.isNull()) {
         b.del(layout.A.encode(nameHash));
+        await this.deleteAlert(b, height, nameHash);
         continue;
       }
 
       b.put(layout.A.encode(nameHash), ns.encode());
+      await this.putAlert(b, this.alertHeight(ns), nameHash);
     }
 
     if (updated) {
@@ -2114,6 +2120,8 @@ class TXDB {
 
       ns.applyState(delta);
 
+      // TODO: handle reorgs here
+
       if (ns.isNull()) {
         await this.removeNameMap(b, nameHash);
         b.del(layout.A.encode(nameHash));
@@ -2123,6 +2131,154 @@ class TXDB {
     }
 
     b.del(layout.U.encode(hash));
+  }
+
+  /**
+   * Get name alerts by height.
+   * @param {Number} height
+   * @returns {AlertRecord}
+   */
+
+  async getAlerts(height) {
+    const raw = await this.bucket.get(layout.a.encode(height));
+
+    if (!raw)
+      return null;
+
+    const record = AlertRecord.decode(raw, height);
+
+    return record;
+  }
+
+  /**
+   * Put name alert by height.
+   * @param {bdb.Batch} b
+   * @param {Number} height
+   * @param {Hash} hash
+   */
+
+  async putAlert(b, height, hash) {
+    const raw = await this.bucket.get(layout.a.encode(height));
+
+    if (!raw) {
+      const record = new AlertRecord();
+      record.add(hash);
+      b.put(layout.a.encode(height), record.encode());
+      return;
+    }
+
+    const record = AlertRecord.decode(raw, height);
+    record.add(hash);
+    b.put(layout.a.encode(height), record.encode());
+    return;
+  }
+
+  /**
+   * Test for alerts by height.
+   * @param {Number} height
+   * @returns {Boolean}
+   */
+
+  async hasAlerts(height) {
+    return this.bucket.has(layout.a.encode(height));
+  }
+
+  /**
+   * Test for alert by height and name hash.
+   * @param {Number} height
+   * @param {Hash} nameHash
+   * @returns {Boolean}
+   */
+
+  async hasAlert(height, nameHash) {
+    const raw = await this.bucket.get(layout.a.encode(height));
+
+    if (!raw)
+      return false;
+
+    const record = AlertRecord.decode(raw);
+    return record.has(nameHash);
+  }
+
+  /**
+   * Remove alert from data at height
+   * by name hash.
+   * @param {bdb.Batch} b
+   * @param {Number} height
+   * @param {Hash} nameHash
+   */
+
+  async deleteAlert(b, height, nameHash) {
+    const raw = await this.bucket.get(layout.a.encode(height));
+
+    if (!raw)
+      return;
+
+    const record = AlertRecord.decode(raw);
+    record.remove(nameHash);
+    b.put(layout.a.encode(height), record.encode());
+  }
+
+  /**
+   * Delete all alerts at a height.
+   * @param {bdb.Batch} b
+   * @param {Number} height
+   */
+
+  async deleteAlerts(b, height) {
+    b.del(layout.a.encode(height), null);
+  }
+
+  /**
+   * Calculate the height to issue an alert.
+   * This differs based on the current period
+   * of the auction.
+   * @param {NameState} ns
+   * @returns {Number}
+   */
+
+  alertHeight(ns) {
+    const network = this.wdb.network;
+    const height = this.wdb.height;
+    const stats = ns.toStats(height, network);
+
+    switch (ns.state(height, network)) {
+      case states.OPENING:
+        return stats.openPeriodEnd;
+      case states.BIDDING:
+        return stats.bidPeriodEnd;
+      case states.REVEAL:
+        return stats.revealPeriodEnd;
+      case states.CLOSED:
+        return stats.renewalPeriodEnd;
+      case states.REVOKED:
+        return stats.revokePeriodEnd;
+      case states.LOCKED:
+        return stats.lockupPeriodEnd;
+      default:
+        return 0;
+    }
+  }
+
+  /**
+   * Emit an alert for each name by height.
+   * @emits
+   * @param {Number} height
+   * @param {Details} details
+   */
+
+  async alert(height, details) {
+    const record = await this.getAlerts(height);
+
+    if (!record)
+      return;
+
+    for (const nameHash of record.hashes.values()) {
+      const ns = await this.getNameState(nameHash);
+      ns.nameHash = nameHash;
+
+      this.emit('alert', ns, details);
+    }
   }
 
   /**

--- a/lib/wallet/txdb.js
+++ b/lib/wallet/txdb.js
@@ -21,8 +21,7 @@ const policy = require('../protocol/policy');
 const rules = require('../covenants/rules');
 const NameState = require('../covenants/namestate');
 const NameUndo = require('../covenants/undo');
-const {TXRecord, AlertRecord} = records;
-const {states} = NameState;
+const {TXRecord} = records;
 const {types} = rules;
 
 /*
@@ -1066,9 +1065,6 @@ class TXDB {
     this.emit('tx', tx, details);
     this.emit('balance', balance);
 
-    if (height !== -1)
-      await this.alert(height, details);
-
     return details;
   }
 
@@ -2056,12 +2052,10 @@ class TXDB {
 
       if (ns.isNull()) {
         b.del(layout.A.encode(nameHash));
-        await this.deleteAlert(b, height, nameHash);
         continue;
       }
 
       b.put(layout.A.encode(nameHash), ns.encode());
-      await this.putAlert(b, this.alertHeight(ns), nameHash);
     }
 
     if (updated) {
@@ -2120,8 +2114,6 @@ class TXDB {
 
       ns.applyState(delta);
 
-      // TODO: handle reorgs here
-
       if (ns.isNull()) {
         await this.removeNameMap(b, nameHash);
         b.del(layout.A.encode(nameHash));
@@ -2131,154 +2123,6 @@ class TXDB {
     }
 
     b.del(layout.U.encode(hash));
-  }
-
-  /**
-   * Get name alerts by height.
-   * @param {Number} height
-   * @returns {AlertRecord}
-   */
-
-  async getAlerts(height) {
-    const raw = await this.bucket.get(layout.a.encode(height));
-
-    if (!raw)
-      return null;
-
-    const record = AlertRecord.decode(raw, height);
-
-    return record;
-  }
-
-  /**
-   * Put name alert by height.
-   * @param {bdb.Batch} b
-   * @param {Number} height
-   * @param {Hash} hash
-   */
-
-  async putAlert(b, height, hash) {
-    const raw = await this.bucket.get(layout.a.encode(height));
-
-    if (!raw) {
-      const record = new AlertRecord();
-      record.add(hash);
-      b.put(layout.a.encode(height), record.encode());
-      return;
-    }
-
-    const record = AlertRecord.decode(raw, height);
-    record.add(hash);
-    b.put(layout.a.encode(height), record.encode());
-    return;
-  }
-
-  /**
-   * Test for alerts by height.
-   * @param {Number} height
-   * @returns {Boolean}
-   */
-
-  async hasAlerts(height) {
-    return this.bucket.has(layout.a.encode(height));
-  }
-
-  /**
-   * Test for alert by height and name hash.
-   * @param {Number} height
-   * @param {Hash} nameHash
-   * @returns {Boolean}
-   */
-
-  async hasAlert(height, nameHash) {
-    const raw = await this.bucket.get(layout.a.encode(height));
-
-    if (!raw)
-      return false;
-
-    const record = AlertRecord.decode(raw);
-    return record.has(nameHash);
-  }
-
-  /**
-   * Remove alert from data at height
-   * by name hash.
-   * @param {bdb.Batch} b
-   * @param {Number} height
-   * @param {Hash} nameHash
-   */
-
-  async deleteAlert(b, height, nameHash) {
-    const raw = await this.bucket.get(layout.a.encode(height));
-
-    if (!raw)
-      return;
-
-    const record = AlertRecord.decode(raw);
-    record.remove(nameHash);
-    b.put(layout.a.encode(height), record.encode());
-  }
-
-  /**
-   * Delete all alerts at a height.
-   * @param {bdb.Batch} b
-   * @param {Number} height
-   */
-
-  async deleteAlerts(b, height) {
-    b.del(layout.a.encode(height), null);
-  }
-
-  /**
-   * Calculate the height to issue an alert.
-   * This differs based on the current period
-   * of the auction.
-   * @param {NameState} ns
-   * @returns {Number}
-   */
-
-  alertHeight(ns) {
-    const network = this.wdb.network;
-    const height = this.wdb.height;
-    const stats = ns.toStats(height, network);
-
-    switch (ns.state(height, network)) {
-      case states.OPENING:
-        return stats.openPeriodEnd;
-      case states.BIDDING:
-        return stats.bidPeriodEnd;
-      case states.REVEAL:
-        return stats.revealPeriodEnd;
-      case states.CLOSED:
-        return stats.renewalPeriodEnd;
-      case states.REVOKED:
-        return stats.revokePeriodEnd;
-      case states.LOCKED:
-        return stats.lockupPeriodEnd;
-      default:
-        return 0;
-    }
-  }
-
-  /**
-   * Emit an alert for each name by height.
-   * @emits
-   * @param {Number} height
-   * @param {Details} details
-   */
-
-  async alert(height, details) {
-    const record = await this.getAlerts(height);
-
-    if (!record)
-      return;
-
-    for (const nameHash of record.hashes.values()) {
-      const ns = await this.getNameState(nameHash);
-      ns.nameHash = nameHash;
-
-      this.emit('alert', ns, details);
-    }
   }
 
   /**

--- a/lib/wallet/wallet.js
+++ b/lib/wallet/wallet.js
@@ -33,6 +33,7 @@ const Resource = require('../dns/resource');
 const Claim = require('../primitives/claim');
 const reserved = require('../covenants/reserved');
 const ownership = require('../covenants/ownership');
+const {AlertRecord} = require('./records');
 const {states} = require('../covenants/namestate');
 const {types} = rules;
 const {Mnemonic} = HD;
@@ -3882,7 +3883,8 @@ class Wallet extends EventEmitter {
    */
 
   async hasAlerts(height) {
-    return this.txdb.hasAlerts(height);
+    const record = await this.getAlerts(height);
+    return record !== null;
   }
 
   /**
@@ -3892,17 +3894,55 @@ class Wallet extends EventEmitter {
    */
 
   async hasAlert(height, nameHash) {
-    return this.txdb.hasAlert(height, nameHash);
+    const record = await this.getAlerts(height);
+    return record.has(nameHash);
   }
 
   /**
-   * Get all alerts by height.
+   * Get wallet alerts by height.
    * @param {Number} height
    * @returns {AlertRecord}
    */
 
   async getAlerts(height) {
-    return this.txdb.getAlerts(height);
+    const all = await this.wdb.getAlerts(height);
+
+    if (!all)
+      return null;
+
+    const record = new AlertRecord();
+    record.height = height;
+
+    for (const nameHash of all.values()) {
+      const map = await this.wdb.getNameMap(nameHash);
+
+      if (map.has(this.wid))
+        record.add(nameHash);
+    }
+
+    return record;
+  }
+
+  /**
+   * Emit an alert for each name by height.
+   * @emits
+   * @param {Number} height
+   * @param {ChainEntry} entry
+   */
+
+  async alert(height, entry) {
+    const record = await this.getAlerts(height);
+
+    if (!record)
+      return;
+
+    for (const nameHash of record.values()) {
+      const ns = await this.getNameState(nameHash);
+      ns.nameHash = nameHash;
+
+      this.wdb.emit('alert', this, ns, entry);
+      this.emit('alert', ns, entry);
+    }
   }
 
   /**

--- a/lib/wallet/wallet.js
+++ b/lib/wallet/wallet.js
@@ -3876,6 +3876,36 @@ class Wallet extends EventEmitter {
   }
 
   /**
+   * Checks for alerts by height.
+   * @param {Number} height
+   * @returns {Boolean}
+   */
+
+  async hasAlerts(height) {
+    return this.txdb.hasAlerts(height);
+  }
+
+  /**
+   * Checks for alert by height and name hash.
+   * @param {Number} height
+   * @param {Hash} nameHash
+   */
+
+  async hasAlert(height, nameHash) {
+    return this.txdb.hasAlert(height, nameHash);
+  }
+
+  /**
+   * Get all alerts by height.
+   * @param {Number} height
+   * @returns {AlertRecord}
+   */
+
+  async getAlerts(height) {
+    return this.txdb.getAlerts(height);
+  }
+
+  /**
    * Add a transaction to the wallets TX history.
    * @param {TX} tx
    * @returns {Promise}

--- a/lib/wallet/walletdb.js
+++ b/lib/wallet/walletdb.js
@@ -2083,9 +2083,13 @@ class WalletDB extends EventEmitter {
       if (await this._addTX(tx, tip))
         total += 1;
 
-      for (const {covenant} of tx.outputs)
-        if (covenant.isName())
-          nameHashes.add(covenant.get(0));
+      for (const {covenant} of tx.outputs) {
+        if (covenant.isName()) {
+          const nameHash = covenant.get(0);
+          if (this.testFilter(nameHash))
+            nameHashes.add(nameHash);
+        }
+      }
     }
 
     const b = this.db.batch();

--- a/lib/wallet/walletdb.js
+++ b/lib/wallet/walletdb.js
@@ -11,6 +11,7 @@ const path = require('path');
 const EventEmitter = require('events');
 const bio = require('bufio');
 const {BloomFilter} = require('bfilter');
+const {BufferSet} = require('buffer-map');
 const {Lock, MapLock} = require('bmutex');
 const bdb = require('bdb');
 const Logger = require('blgr');
@@ -22,17 +23,20 @@ const common = require('./common');
 const Wallet = require('./wallet');
 const Account = require('./account');
 const Outpoint = require('../primitives/outpoint');
+const NameState = require('../covenants/namestate');
 const layouts = require('./layout');
 const records = require('./records');
 const NullClient = require('./nullclient');
 const layout = layouts.wdb;
 const tlayout = layouts.txdb;
+const {states} = NameState;
 
 const {
   ChainState,
   BlockMeta,
   TXRecord,
-  MapRecord
+  MapRecord,
+  AlertRecord
 } = records;
 
 /**
@@ -136,9 +140,9 @@ class WalletDB extends EventEmitter {
       }
     });
 
-    this.client.bind('block disconnect', async (entry) => {
+    this.client.bind('block disconnect', async (entry, txs) => {
       try {
-        await this.removeBlock(entry);
+        await this.removeBlock(entry, txs);
       } catch (e) {
         this.emit('error', e);
       }
@@ -629,7 +633,8 @@ class WalletDB extends EventEmitter {
   }
 
   /**
-   * Test the bloom filter against a tx or address hash.
+   * Test the bloom filter against a tx,
+   * address hash or name hash.
    * @private
    * @param {Hash} hash
    * @returns {Boolean}
@@ -2072,9 +2077,45 @@ class WalletDB extends EventEmitter {
 
     let total = 0;
 
+    const nameHashes = new BufferSet();
+
     for (const tx of txs) {
       if (await this._addTX(tx, tip))
         total += 1;
+
+      for (const {covenant} of tx.outputs)
+        if (covenant.isName())
+          nameHashes.add(covenant.get(0));
+    }
+
+    const b = this.db.batch();
+    for (const nameHash of nameHashes.values()) {
+      const ns = await this.getNameStatus(nameHash);
+      await this.putAlert(b, this.alertHeight(ns), nameHash);
+    }
+
+    // TODO: prune old alerts
+    await b.write();
+
+    const record = await this.getAlerts(tip.height);
+
+    if (record) {
+      const entry = await this.client.getEntry(tip.height);
+
+      for (const nameHash of record.values()) {
+        if (!this.testFilter(nameHash))
+          continue;
+
+        const map = await this.getNameMap(nameHash);
+
+        if (!map)
+          continue;
+
+        for (const wid of map.wids) {
+          const wallet = await this.get(wid);
+          await wallet.alert(tip.height, entry);
+        }
+      }
     }
 
     if (total > 0) {
@@ -2089,13 +2130,14 @@ class WalletDB extends EventEmitter {
    * Unconfirm a block's transactions
    * and write the new best hash (SPV version).
    * @param {ChainEntry} entry
+   * @param {TX[]} txs
    * @returns {Promise}
    */
 
-  async removeBlock(entry) {
+  async removeBlock(entry, txs) {
     const unlock = await this.txLock.lock();
     try {
-      return await this._removeBlock(entry);
+      return await this._removeBlock(entry, txs);
     } finally {
       unlock();
     }
@@ -2105,10 +2147,11 @@ class WalletDB extends EventEmitter {
    * Unconfirm a block's transactions.
    * @private
    * @param {ChainEntry} entry
+   * @param {TX[]} txs
    * @returns {Promise}
    */
 
-  async _removeBlock(entry) {
+  async _removeBlock(entry, txs) {
     const tip = BlockMeta.fromEntry(entry);
 
     if (tip.height === 0)
@@ -2123,6 +2166,20 @@ class WalletDB extends EventEmitter {
 
     if (tip.height !== this.state.height)
       throw new Error('WDB: Bad disconnection (height mismatch).');
+
+    // Remove alerts
+    const b = this.db.batch();
+    for (const tx of txs) {
+      for (const {covenant} of tx.outputs) {
+        if (!covenant.isName())
+          continue;
+
+        const nameHash = covenant.get(0);
+        const ns = await this.getNameStatus(nameHash);
+        await this.deleteAlert(b, this.alertHeight(ns), nameHash);
+      }
+    }
+    await b.write();
 
     const prev = await this.getBlock(tip.height - 1);
     assert(prev);
@@ -2269,6 +2326,133 @@ class WalletDB extends EventEmitter {
       throw new Error('WDB: Bad reset height.');
 
     return this.rollback(entry.height);
+  }
+
+  /**
+   * Get name alerts by height.
+   * @param {Number} height
+   * @returns {AlertRecord}
+   */
+
+  async getAlerts(height) {
+    const raw = await this.db.get(layout.e.encode(height));
+
+    if (!raw)
+      return null;
+
+    const record = AlertRecord.decode(raw, height);
+
+    return record;
+  }
+
+  /**
+   * Put name alert by height.
+   * @param {bdb.Batch} b
+   * @param {Number} height
+   * @param {Hash} hash
+   */
+
+  async putAlert(b, height, hash) {
+    const raw = await this.db.get(layout.e.encode(height));
+
+    if (!raw) {
+      const record = new AlertRecord();
+      record.add(hash);
+      b.put(layout.e.encode(height), record.encode());
+      return;
+    }
+
+    const record = AlertRecord.decode(raw, height);
+    record.add(hash);
+    b.put(layout.e.encode(height), record.encode());
+    return;
+  }
+
+  /**
+   * Test for alerts by height.
+   * @param {Number} height
+   * @returns {Boolean}
+   */
+
+  async hasAlerts(height) {
+    return this.db.has(layout.e.encode(height));
+  }
+
+  /**
+   * Test for alert by height and name hash.
+   * @param {Number} height
+   * @param {Hash} nameHash
+   * @returns {Boolean}
+   */
+
+  async hasAlert(height, nameHash) {
+    const raw = await this.db.get(layout.e.encode(height));
+
+    if (!raw)
+      return false;
+
+    const record = AlertRecord.decode(raw);
+    return record.has(nameHash);
+  }
+
+  /**
+   * Remove alert from data at height
+   * by name hash.
+   * @param {bdb.Batch} b
+   * @param {Number} height
+   * @param {Hash} nameHash
+   */
+
+  async deleteAlert(b, height, nameHash) {
+    const raw = await this.db.get(layout.e.encode(height));
+
+    if (!raw)
+      return;
+
+    const record = AlertRecord.decode(raw);
+    record.remove(nameHash);
+    b.put(layout.e.encode(height), record.encode());
+  }
+
+  /**
+   * Delete all alerts at a height.
+   * @param {bdb.Batch} b
+   * @param {Number} height
+   */
+
+  async deleteAlerts(b, height) {
+    b.del(layout.e.encode(height));
+  }
+
+  /**
+   * Calculate the height to issue an alert.
+   * This differs based on the current period
+   * of the auction.
+   * @param {NameState} ns
+   * @returns {Number}
+   */
+
+  alertHeight(ns) {
+    const network = this.network;
+    const height = this.height;
+    const stats = ns.toStats(height, network);
+
+    switch (ns.state(height, network)) {
+      case states.OPENING:
+        return stats.openPeriodEnd;
+      case states.BIDDING:
+        return stats.bidPeriodEnd;
+      case states.REVEAL:
+        return stats.revealPeriodEnd;
+      case states.CLOSED:
+        return stats.renewalPeriodEnd;
+      case states.REVOKED:
+        return stats.revokePeriodEnd;
+      case states.LOCKED:
+        return stats.lockupPeriodEnd;
+      default:
+        return 0;
+    }
   }
 }
 

--- a/lib/wallet/walletdb.js
+++ b/lib/wallet/walletdb.js
@@ -77,7 +77,7 @@ class WalletDB extends EventEmitter {
     // Lock for handling anything tx related.
     this.txLock = new Lock();
 
-    // Address and outpoint filter.
+    // Address, outpoint and name filter.
     this.filter = new BloomFilter();
 
     this.init();
@@ -246,7 +246,7 @@ class WalletDB extends EventEmitter {
   }
 
   /**
-   * Watch addresses and outpoints.
+   * Watch addresses, outpoints and names.
    * @private
    * @returns {Promise}
    */

--- a/test/auction-alert-test.js
+++ b/test/auction-alert-test.js
@@ -1,0 +1,183 @@
+/**
+ * auction-alert-test.js - Auction Alert Tests
+ * Copyright (c) 2019, Mark Tyneway (MIT License).
+ */
+
+'use strict';
+
+const assert = require('bsert');
+const FullNode = require('../lib/node/fullnode');
+const {NodeClient, WalletClient} = require('hs-client');
+const Network = require('../lib/protocol/network');
+const network = Network.get('regtest');
+const rules = require('../lib/covenants/rules');
+const common = require('./util/common');
+
+const {
+  biddingPeriod,
+  revealPeriod,
+  treeInterval
+} = network.names;
+
+const node = new FullNode({
+  network: 'regtest',
+  apiKey: 'foo',
+  walletAuth: true,
+  memory: true,
+  workers: true,
+  plugins: [require('../lib/wallet/plugin')]
+});
+
+const nclient = new NodeClient({
+  port: network.rpcPort,
+  apiKey: 'foo'
+});
+
+const wclient = new WalletClient({
+  port: network.walletPort,
+  apiKey: 'foo'
+});
+
+const wallet = wclient.wallet('primary');
+
+const {wdb} = node.require('walletdb');
+
+let name, nameHash, primary;
+const alerts = [];
+describe('Auction Alerts', function() {
+  this.timeout(10000);
+
+  before(async () => {
+    await node.open();
+
+    wclient.on('connect', async () => {
+      await wclient.call('join', wallet.id);
+    });
+
+    // set up listeners
+    wclient.bind('alert', (wallet, ns, details) => {
+      alerts.push([wallet, ns, details]);
+    });
+
+    await nclient.open();
+    await wclient.open();
+
+    name = rules.grindName(2, 0, Network.get('regtest'));
+    nameHash = rules.hashName(name);
+    const address = (await wallet.getAccount('default')).receiveAddress;
+
+    // fetch the primary, corresponds with
+    // the primary wallet client
+    primary = await wdb.get(0);
+
+    // build up an initial wallet balance
+    await mineBlocks(4, address);
+  });
+
+  after(async () => {
+    await wclient.close();
+    await nclient.close();
+    await node.close();
+  });
+
+  it('should emit alert events', async () => {
+    await runAuction(name, wallet, nclient);
+
+    const {info} = await nclient.execute('getnameinfo', [name]);
+    const height = info.height;
+
+    // Calculate the expected heights to receive alerts.
+    // Should receive alerts when the next auction period
+    // begins. See logic in NameState.js, in particular
+    // NameState.{toStats,state}.
+    const expected = [
+      { height: height + treeInterval + 1 },
+      { height: height + treeInterval + 1 + biddingPeriod },
+      { height: height + treeInterval + 1
+        + biddingPeriod + revealPeriod }
+    ];
+
+    // An entire auction is completed, there should
+    // be an alert for OPEN -> BIDDING, BIDDING -> REVEAL
+    // and REVEAL -> CLOSED. Ignore the RENEW alert because
+    // regtest has a very large renewal period and mining
+    // that many blocks would not be useful. It will be
+    // checked manually by querying the database.
+    assert.equal(expected.length, alerts.length);
+
+    for (const [i, alert] of Object.entries(alerts)) {
+      const [, ns, details] = alert;
+      assert.equal(ns.name, name);
+      assert.equal(ns.height, height);
+      assert.equal(expected[i].height, details.height);
+    }
+
+    // Assert that the NameState is actually CLOSED.
+    const nameinfo = await nclient.execute('getnameinfo', [name]);
+    assert.equal(nameinfo.info.state, 'CLOSED');
+    const stats = nameinfo.info.stats;
+    const final = stats.renewalPeriodEnd;
+
+    // Manually check the wallet for alerts at
+    // the renewalPeriodEnd.
+    assert(await primary.hasAlerts(final));
+
+    // Query the AlertRecord and assert that it
+    // contains the correct name hash and the
+    // correct height.
+    const alert = await primary.getAlerts(final);
+    assert(alert.has(nameHash));
+    assert.equal(alert.height, final);
+  });
+
+  it('should alter the alerts when there is a reorg', async () => {
+    this.skip();
+  });
+
+  it('should prune after safe number of confirmations', async () => {
+    this.skip();
+  });
+});
+
+async function runAuction(name, wallet, node) {
+  const address = (await wallet.getAccount('default')).receiveAddress;
+
+  await wallet.client.post(`/wallet/${wallet.id}/open`, {
+    name: name
+  });
+
+  await mineBlocks(treeInterval + 1, address);
+
+  await wallet.client.post(`/wallet/${wallet.id}/bid`, {
+    name: name,
+    bid: 1000,
+    lockup: 2000
+  });
+
+  await mineBlocks(biddingPeriod + 1, address);
+
+  await wallet.client.post(`/wallet/${wallet.id}/reveal`, {
+    name: name
+  });
+
+  await mineBlocks(revealPeriod + 1, address);
+
+  await wallet.client.post(`/wallet/${wallet.id}/update`, {
+    name: name,
+    data: {text: ['foobar']}
+  });
+
+  await mineBlocks(treeInterval + 1, address);
+}
+
+// take into account race conditions
+async function mineBlocks(count, address) {
+  for (let i = 0; i < count; i++) {
+    const obj = { complete: false };
+    node.once('block', () => {
+      obj.complete = true;
+    });
+    await nclient.execute('generatetoaddress', [1, address]);
+    await common.forValue(obj, 'complete', true);
+  }
+}

--- a/test/wallet-test.js
+++ b/test/wallet-test.js
@@ -258,7 +258,7 @@ describe('Wallet', function() {
     const wallet = doubleSpendWallet;
 
     // Reorg and unconfirm all previous txs.
-    await wdb.removeBlock(curBlock(wdb));
+    await wdb.removeBlock(curBlock(wdb), []);
 
     {
       const txs = await wallet.getHistory();


### PR DESCRIPTION
A desirable feature is to receive a notification when the next auction period starts. This PR creates that functionality by adding a new index to the wallet database that maps a `uint32` (height) -> `nameHashes`. When a new block comes in, the name hashes are looked up in the new index and the wallets that know about those names emit events over websocket. When name state is being indexed, the height of its next period is calculated and used as the key to index the name hash. 

This functionality could be hidden behind a feature flag to prevent the need for additional indexing.
This is useful for automated auction runners.