### PR TITLE
Switch to Schnorr

### DIFF
--- a/lib/primitives/keyring.js
+++ b/lib/primitives/keyring.js
@@ -465,7 +465,7 @@ class KeyRing extends bio.Struct {
 
   sign(msg) {
     assert(this.privateKey, 'Cannot sign without private key.');
-    return secp256k1.sign(msg, this.privateKey);
+    return secp256k1.schnorrSign(msg, this.privateKey);
   }
 
   /**
@@ -476,7 +476,7 @@ class KeyRing extends bio.Struct {
    */
 
   verify(msg, sig) {
-    return secp256k1.verify(msg, sig, this.publicKey);
+    return secp256k1.schnorrVerify(msg, sig, this.publicKey);
   }
 
   /**

--- a/lib/primitives/tx.js
+++ b/lib/primitives/tx.js
@@ -382,7 +382,7 @@ class TX extends bio.Struct {
     const type = sig[sig.length - 1];
     const hash = this.signatureHash(index, prev, value, type);
 
-    return secp256k1.verify(hash, sig.slice(0, -1), key);
+    return secp256k1.schnorrVerify(hash, sig.slice(0, -1), key);
   }
 
   /**
@@ -402,7 +402,7 @@ class TX extends bio.Struct {
       type = hashType.ALL;
 
     const hash = this.signatureHash(index, prev, value, type);
-    const sig = secp256k1.sign(hash, key);
+    const sig = secp256k1.schnorrSign(hash, key);
     const bw = bio.write(65);
 
     bw.writeBytes(sig);

--- a/lib/script/common.js
+++ b/lib/script/common.js
@@ -11,7 +11,6 @@
  */
 
 const assert = require('bsert');
-const secp256k1 = require('bcrypto/lib/secp256k1');
 const ScriptNum = require('./scriptnum');
 
 /**
@@ -507,9 +506,6 @@ exports.isSignatureEncoding = function isSignatureEncoding(sig) {
   type &= ~exports.hashType.ANYONECANPAY;
 
   if (type < exports.hashType.ALL || type > exports.hashType.SINGLEREVERSE)
-    return false;
-
-  if (!secp256k1.isLowS(sig.slice(0, -1)))
     return false;
 
   return true;

--- a/lib/script/script.js
+++ b/lib/script/script.js
@@ -2454,7 +2454,7 @@ function validateSignature(sig, flags) {
  */
 
 function checksig(msg, sig, key) {
-  return secp256k1.verify(msg, sig.slice(0, -1), key);
+  return secp256k1.schnorrVerify(msg, sig.slice(0, -1), key);
 }
 
 /*

--- a/lib/script/sigcache.js
+++ b/lib/script/sigcache.js
@@ -101,12 +101,12 @@ class SigCache {
 
   verify(hash, sig, key) {
     if (this.size === 0)
-      return secp256k1.verify(hash, sig, key);
+      return secp256k1.schnorrVerify(hash, sig, key);
 
     if (this.has(hash, sig, key))
       return true;
 
-    const result = secp256k1.verify(hash, sig, key);
+    const result = secp256k1.schnorrVerify(hash, sig, key);
 
     if (!result)
       return false;

--- a/lib/workers/jobs.js
+++ b/lib/workers/jobs.js
@@ -142,7 +142,7 @@ jobs.signInput = function signInput(tx, index, coin, ring, type) {
  */
 
 jobs.ecVerify = function ecVerify(msg, sig, key) {
-  const result = secp256k1.verify(msg, sig, key);
+  const result = secp256k1.schnorrVerify(msg, sig, key);
   return new packets.ECVerifyResultPacket(result);
 };
 
@@ -156,7 +156,7 @@ jobs.ecVerify = function ecVerify(msg, sig, key) {
  */
 
 jobs.ecSign = function ecSign(msg, key) {
-  const sig = secp256k1.sign(msg, key);
+  const sig = secp256k1.schnorrSign(msg, key);
   return new packets.ECSignResultPacket(sig);
 };
 


### PR DESCRIPTION
Switch to using `bip-schnorr` as defined in [sipa/bip-schnorr](https://github.com/sipa/bips/blob/bip-schnorr/bip-schnorr.mediawiki) and implemented in [bcrypto](https://github.com/bcoin-org/bcrypto/blob/master/lib/js/schnorr.js).

This pull request simply replaces ECDSA with Schnorr. It does not change the curve (secp256k1).
A complete replacement is the most simple solution as supporting both ECDSA and Schnorr adds complexity - no need for additional opcodes, no need to decide on which is "standard" (use Schnorr or ECDSA when the address data is 20 bytes?), no worry of depending on the weakest link.

This will require changes in https://github.com/boymanjor/ledger-app-hns @boymanjor 

All addresses that currently exist will **still** be valid addresses.

Closes https://github.com/handshake-org/hsd/issues/202