### PR TITLE
dns/records: bugfix assertion in TLSA JSON parsing

### DIFF
--- a/lib/dns/records.js
+++ b/lib/dns/records.js
@@ -780,8 +780,8 @@ class TLS extends Struct {
     assert((json.usage & 0xff) === json.usage);
     assert((json.selector & 0xff) === json.selector);
     assert((json.matchingType & 0xff) === json.matchingType);
-    assert(typeof json.fingerprint === 'string');
-    assert((json.fingerprint.length >>> 1) <= 255);
+    assert(typeof json.certificate === 'string');
+    assert((json.certificate.length >>> 1) <= 255);
     assert(isSingle(json.protocol));
     this.protocol = util.fqdn(json.protocol);
     this.port = json.port;


### PR DESCRIPTION
Fix TLSA record parsing so that they will be accepted and emitted by testnet4 resolvers.

(This change should eventually be merged into master as well) 