### PR TITLE
readme: update to testnet4

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,16 +40,17 @@ See the [node-gyp](https://github.com/nodejs/node-gyp) documentation for more in
 
 ## Testnet
 
-Testnet3 is running as of January 22nd.
+Testnet4 is running as of April 3rd, 2019. Use the branch `testnet4-stable`.
+Breaking changes were introduced into `master`.
 
-Testnet3 seed nodes (`pubkey@ip`):
+Testnet4 seed nodes (`pubkey@ip`):
 
 - `aoihqqagbhzz6wxg43itefqvmgda4uwtky362p22kbimcyg5fdp54@172.104.214.189`
 - `ajdzrpoxsusaw4ixq4ttibxxsuh5fkkduc5qszyboidif2z25i362@173.255.209.126`
 - `ajk57wutnhfdzvqwqrgab3wwh4wxoqgnkz4avbln54pgj5jwefcts@172.104.177.177`
 - `am2lsmbzzxncaptqjo22jay3mztfwl33bxhkp7icfx7kmi5rvjaic@139.162.183.168`
 
-Testnet3 public DNS servers:
+Testnet4 public DNS servers:
 
 - 172.104.214.189 - Recursive Server 1.
 - 173.255.209.126 - Authoritative Server 1.


### PR DESCRIPTION
Add light copy to `README` regarding the stable testnet4 branch.

Closes https://github.com/handshake-org/hsd/issues/239