### PR TITLE
events: websocket event on chain reorganize

### DIFF
--- a/lib/node/http.js
+++ b/lib/node/http.js
@@ -680,6 +680,15 @@ class HTTP extends Server {
       this.to('chain', 'chain reset', tip.encode());
     });
 
+    this.chain.on('reorganize', (tip, competitor) => {
+      const sockets = this.channel('chain');
+
+      if (!sockets)
+        return;
+
+      this.to('chain', 'chain reorganize', competitor.toRaw());
+    });
+
     pool.on('tx', (tx) => {
       const sockets = this.channel('mempool');
 


### PR DESCRIPTION
Add a websocket event `chain reorganize`. The node client can `bind` to this event after doing a `call` to `watch chain`. This is useful for letting clients get a notification when there has been a reorg event on the `chain`. Currently, there is a `reset` event, but it is only called when there is a rescan caused by the user. I need to be alerted when there is a reorg.

Will follow up with tests.

See PR in `bcoin`: https://github.com/bcoin-org/bcoin/pull/826