### PR TITLE
fix locations of prevBlock and treeRoot within the _raw block shared …

### DIFF
--- a/lib/primitives/memblock.js
+++ b/lib/primitives/memblock.js
@@ -68,8 +68,8 @@ class MemBlock extends AbstractBlock {
     assert((size >>> 0) === size);
 
     const pad = Buffer.alloc(size);
-    const prevBlock = this._raw.slice(4, 4 + 32);
-    const treeRoot = this._raw.slice(100, 100 + 32);
+    const prevBlock = this._raw.slice(12, 12 + 32);
+    const treeRoot = this._raw.slice(44, 44 + 32);
 
     for (let i = 0; i < size; i++)
       pad[i] = prevBlock[i % 32] ^ treeRoot[i % 32];

--- a/test/block-test.js
+++ b/test/block-test.js
@@ -4,19 +4,65 @@
 
 'use strict';
 
-const {BloomFilter} = require('bfilter');
 const assert = require('bsert');
-const common = require('./util/common');
 const Block = require('../lib/primitives/block');
 const MerkleBlock = require('../lib/primitives/merkleblock');
-const consensus = require('../lib/protocol/consensus');
+const MemBlock = require('../lib/primitives/memblock');
 const Network = require('../lib/protocol/network');
-const Script = require('../lib/script/script');
 const bip152 = require('../lib/net/bip152');
 const CompactBlock = bip152.CompactBlock;
-const TXRequest = bip152.TXRequest;
-const TXResponse = bip152.TXResponse;
+const WorkerPool = require('../lib/workers/workerpool');
+const Chain = require('../lib/blockchain/chain');
+const Miner = require('../lib/mining/miner');
+
+const network = Network.get('regtest');
+
+const workers = new WorkerPool({
+  enabled: true
+});
+
+const chain = new Chain({
+  memory: true,
+  network,
+  workers
+});
+
+const miner = new Miner({
+  chain,
+  workers
+});
 
 describe('Block', function() {
   this.timeout(10000);
+
+  before(async () => {
+    await chain.open();
+    await miner.open();
+  });
+
+  after(async () => {
+    await chain.close();
+    await miner.close();
+  });
+
+  describe('Serialization', function() {
+    let block = null;
+    let raw = null;
+
+    it('should mine 1 block', async () => {
+      block = await miner.mineBlock();
+      assert(block);
+    });
+
+    it('should deserialize and reserialze block', async () => {
+      raw = block.toRaw();
+      const block2 = Block.fromRaw(raw);
+      assert.deepStrictEqual(block.toJSON(), block2.toJSON());
+    });
+
+    it('should create memblock from raw block', async () => {
+      const memblock = MemBlock.decode(raw);
+      assert.bufferEqual(block.hash(), memblock.hash());
+    });
+  });
 });


### PR DESCRIPTION
…by peers used in memblock.js abstraction of padding method.

substring locations used in memblock.js .padding() method are incorrect for powNG _raw block format. This bug didnt cause an issue when mining on one single node (because it uses .padding method in abstractblock.js), however this becomes a huge problem when you try to sync with a node and the peer's blocks received dont hash properly on the local node and the local node gets lots of 'unrequested blocks' errors and never syncs.

How to verify the bug: Create 2 simnet nodes, both on #pow-ng. On miner node: setgenerate=true for a hot second to mine some blocks. Then stop mining because logs. Now on the second node, add miner node as a peer and watch the 'unrequested blocks' errors fly in. Even more fun: Turn setgenerate back on in the miner node while watching peer's logs and watch the orphan blocks fly in.