### PR TITLE
minor serialization fixes

### DIFF
--- a/lib/net/packets.js
+++ b/lib/net/packets.js
@@ -1839,10 +1839,22 @@ class UnknownPacket extends Packet {
   /**
    * Inject properties from serialized data.
    * @private
+   * @param {BufferReader} br
+   */
+
+  read(br, type) {
+    this.data = br.data;
+    this.type = type;
+    return this;
+  }
+
+  /**
+   * Inject properties from serialized data.
+   * @private
    * @param {Buffer} data
    */
 
-  read(data, type) {
+  decode(data, type) {
     this.data = data;
     this.type = type;
     return this;

--- a/lib/wallet/records.js
+++ b/lib/wallet/records.js
@@ -181,7 +181,7 @@ class BlockMeta extends bio.Struct {
    */
 
   getSize() {
-    return 42;
+    return 40;
   }
 
   /**


### PR DESCRIPTION
This is fixes minor inconsistency. `this.data` must be `Buffer` but after deserialization it will instead be `BufferReader`. 

This fixes that inconsistency.

NOTE: buffer will be **referenced** in both cases (when using `decode` or when using `read`).
Even though `read` could still be `normal` cloning of the buffer that happens in other packet deserializations. I could change so it copies buffer in both cases **but** for unknown packets it should be safe to just reuse the buffer. (It wont be used for anything and we wont waste resources copying it.) 

p.s. Will be useful to backport these tests: https://github.com/bcoin-org/bcoin/pull/779

--

Also fixes BlockMeta serialization size.