### PR TITLE
Dockerfile: gmp-dev is required by bcrypto at runtime

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /code
 CMD "hsd"
 
 RUN apk upgrade --no-cache && \
-    apk add --no-cache bash unbound-dev
+    apk add --no-cache bash unbound-dev gmp-dev
 
 COPY package.json \
      #package-lock.json \
@@ -12,7 +12,7 @@ COPY package.json \
 
 # Install build dependencies and compile
 FROM base AS build
-RUN apk add --no-cache g++ gcc make python2 gmp-dev
+RUN apk add --no-cache g++ gcc make python2
 RUN npm install --production
 
 FROM base
@@ -20,4 +20,3 @@ ENV PATH="${PATH}:/code/bin:/code/node_modules/.bin"
 COPY --from=build /code/node_modules /code/node_modules/
 COPY bin /code/bin/
 COPY lib /code/lib/
-


### PR DESCRIPTION
Without GMP in the base image, attempting to run the image leads to `Error loading shared library libgmp.so.10` which gets suppressed and reported confusingly as `Bindings for bcrypto were not built`