### PR TITLE
[consensus] gTLDs are always reserved

### DIFF
--- a/lib/covenants/rules.js
+++ b/lib/covenants/rules.js
@@ -368,10 +368,15 @@ rules.isReserved = function isReserved(nameHash, height, network) {
   if (network.names.noReserved)
     return false;
 
+  const name = reserved.get(nameHash);
+  // gTLDs are always reserved, forever.
+  if (name && name.root)
+    return true;
+
   if (height >= network.names.claimPeriod)
     return false;
 
-  return reserved.has(nameHash);
+  return Boolean(name);
 };
 
 /**

--- a/test/reserved-test.js
+++ b/test/reserved-test.js
@@ -3,6 +3,7 @@
 const assert = require('bsert');
 const fs = require('bfile');
 const reserved = require('../lib/covenants/reserved');
+const rules = require('../lib/covenants/rules');
 
 describe('Reserved', function() {
   it('should get a domain', () => {
@@ -94,5 +95,36 @@ describe('Reserved', function() {
     }
 
     assert.strictEqual(total, 203999999937640 - (10200000 * 1e6));
+  });
+
+  it('should always reserve a root TLD', async () => {
+    const network = {
+      names: {
+        noReserved: false,
+        claimPeriod: 10
+      }
+    };
+
+    // Reserved names are only reserved for a limited time
+    assert(rules.isReserved(
+      rules.hashString('facebook'),
+      5,
+      network));
+
+    assert(!rules.isReserved(
+      rules.hashString('facebook'),
+      50,
+      network));
+
+    // Root names (gTLDs) are always reserved
+    assert(rules.isReserved(
+      rules.hashString('com'),
+      5,
+      network));
+
+    assert(rules.isReserved(
+      rules.hashString('com'),
+      50,
+      network));
   });
 });


### PR DESCRIPTION
After a discussion with @jacobhaven, a good deal of concern was brought up that root zone TLDs like `com`, `org`, and `info` could be auctioned and owned by users after the claim period ends (4 years on mainnet).

I'm not sure I entirely agree with this position, but came up with this patch to implement the rule and maybe we can have public discussion about it here.