### PR TITLE
dns/server: remove duplicate opts parsing

### DIFF
--- a/lib/dns/server.js
+++ b/lib/dns/server.js
@@ -509,11 +509,6 @@ class RecursiveServer extends DNSServer {
       this.host = IP.normalize(options.host);
     }
 
-    if (options.host != null) {
-      assert(typeof options.host === 'string');
-      this.host = IP.normalize(options.host);
-    }
-
     if (options.port != null) {
       assert((options.port & 0xffff) === options.port);
       assert(options.port !== 0);


### PR DESCRIPTION
The `RecursiveServer` duplicates the logic for parsing `options.host`. This Pull Request eliminates the second time that it is parsed.