### PR TITLE
dns/server: allow configurable use of unbound

### DIFF
--- a/lib/dns/server.js
+++ b/lib/dns/server.js
@@ -11,6 +11,7 @@ const IP = require('binet');
 const Logger = require('blgr');
 const bns = require('bns');
 const UnboundResolver = require('bns/lib/resolver/unbound');
+const RecursiveResolver = require('bns/lib/resolver/recursive');
 const RootResolver = require('bns/lib/resolver/root');
 const secp256k1 = require('bcrypto/lib/secp256k1');
 const LRU = require('blru');
@@ -480,10 +481,10 @@ class RecursiveServer extends DNSServer {
       minimize: true
     });
 
-    this.initNode();
-
     if (options)
       this.initOptions(options);
+
+    this.initNode();
 
     this.hns.setStub(this.stubHost, this.stubPort, key.ds);
   }
@@ -533,6 +534,19 @@ class RecursiveServer extends DNSServer {
       assert((options.stubPort & 0xffff) === options.stubPort);
       assert(options.stubPort !== 0);
       this.stubPort = options.stubPort;
+    }
+
+    if (options.noUnbound != null) {
+      assert(typeof options.noUnbound === 'boolean');
+      if (options.noUnbound) {
+        this.hns = new RecursiveResolver({
+          inet6: false,
+          tcp: true,
+          edns: true,
+          dnssec: true,
+          minimize: true
+        });
+      }
     }
 
     return this;

--- a/lib/node/fullnode.js
+++ b/lib/node/fullnode.js
@@ -157,7 +157,8 @@ class FullNode extends Node {
       host: this.config.str('rs-host'),
       port: this.config.uint('rs-port', this.network.rsPort),
       stubHost: this.ns.host,
-      stubPort: this.ns.port
+      stubPort: this.ns.port,
+      noUnbound: this.config.bool('rs-no-unbound')
     });
 
     this.init();

--- a/lib/node/spvnode.js
+++ b/lib/node/spvnode.js
@@ -108,7 +108,8 @@ class SPVNode extends Node {
       host: this.config.str('rs-host'),
       port: this.config.uint('rs-port', this.network.rsPort),
       stubHost: this.ns.host,
-      stubPort: this.ns.port
+      stubPort: this.ns.port,
+      noUnbound: this.config.bool('rs-no-unbound')
     });
 
     this.rescanJob = null;


### PR DESCRIPTION
This PR adds a new config option `rs-no-unbound` that is expected to be a boolean. If set to true, it will not use `unbound` and instead use the node.js based `RecursiveResolver`.

Since `initNode` sets listeners on `this.hns`, it is moved to after the call to `initOptions`, since `initOptions` can will overwrite `this.hns` if `noUnbound` is set to true.