### PR TITLE
test: rename reorg test describe blocks

### DIFF
--- a/test/auction-reorg-test.js
+++ b/test/auction-reorg-test.js
@@ -65,10 +65,10 @@ function createNode() {
   };
 }
 
-describe('Auction', function() {
+describe('Auction Reorg', function() {
   this.timeout(15000);
 
-  describe('Vickrey Auction', function() {
+  describe('Vickrey Auction Reorg', function() {
     const node = createNode();
     const orig = createNode();
     const comp = createNode();
@@ -395,7 +395,7 @@ describe('Auction', function() {
     });
   });
 
-  describe('Claim', function() {
+  describe('Claim Reorg', function() {
     const node = createNode();
     const {chain, miner, cpu} = node;
 


### PR DESCRIPTION
This PR simply updates the names of the `describe` blocks in `test/auction-reorg-test.js` so that they do not conflict with the `describe` blocks in `test/auction-test.js`. This prevents developer confusion when running tests, as the names of the `describe` blocks are printed to the console by the test runner. Developers will no longer potentially be thrown off and waste time looking in the wrong test file.

Note that no actual test functionality is modified, re:

```
// DO NOT TOUCH THESE TESTS
// They trigger the tree interval reorg bug.
```