### PR TITLE
covenants: add arpa to consensus name blacklist

### DIFF
--- a/lib/covenants/rules.js
+++ b/lib/covenants/rules.js
@@ -79,10 +79,12 @@ rules.typesByVal = {
 
 /**
  * Blacklisted names.
+ * See https://tools.ietf.org/html/rfc6761
  * @const {Set}
  */
 
 rules.blacklist = new Set([
+  'arpa', // ICANN reserved
   'example', // ICANN reserved
   'invalid', // ICANN reserved
   'local', // mDNS


### PR DESCRIPTION
Add the ICANN `arpa` TLD to the consensus level blacklist for names.

According to IANA:

> The .arpa domain is the “Address and Routing Parameter Area” domain and is designated to be used exclusively for Internet-infrastructure purposes. We administer the domain in cooperation with the Internet technical community through the guidance of the Internet Architecture Board. For the management guidelines and operational requirements of the .arpa domain, see RFC 3172. 

This leads me to believe that `arpa` should be placed in the same category as the other ICANN reserved names, such as `example`, `invalid` and `localhost`.

https://www.iana.org/domains/arpa

The Special Use Names RFC
https://tools.ietf.org/html/rfc6761