### PR TITLE
node/rpc: getdnssecproof

### DIFF
--- a/lib/node/rpc.js
+++ b/lib/node/rpc.js
@@ -37,6 +37,7 @@ const pkg = require('../pkg');
 const rules = require('../covenants/rules');
 const {Resource} = require('../dns/resource');
 const NameState = require('../covenants/namestate');
+const ownership = require('../covenants/ownership');
 const AirdropProof = require('../primitives/airdropproof');
 const {EXP} = consensus;
 const RPCBase = bweb.RPC;
@@ -237,6 +238,7 @@ class RPC extends RPCBase {
     this.add('getnameinfo', this.getNameInfo);
     this.add('getnameresource', this.getNameResource);
     this.add('getnameproof', this.getNameProof);
+    this.add('getdnssecproof', this.getDNSSECProof);
     this.add('getnamebyhash', this.getNameByHash);
     this.add('grindname', this.grindName);
     this.add('sendrawclaim', this.sendRawClaim);
@@ -2405,6 +2407,24 @@ class RPC extends RPCBase {
       key: key.toString('hex'),
       proof: proof.toJSON()
     };
+  }
+
+  async getDNSSECProof(args, help) {
+    if (help || args.length < 1 || args.length > 3)
+      throw new RPCError(errs.MISC_ERROR,
+        'getdnssecproof "name" ( estimate ) ( verbose )');
+
+    const valid = new Validator(args);
+    const name = valid.str(0);
+    const estimate = valid.bool(1, false);
+    const verbose = valid.bool(2, true);
+
+    const proof = await ownership.prove(name, estimate);
+
+    if (!verbose)
+      return proof.toHex();
+
+    return proof.toJSON();
   }
 
   async getNameByHash(args, help) {


### PR DESCRIPTION
Add a `getdnssecproof` RPC method that accepts three arguments (two of which are optional), a domain name, an estimate `boolean` and a verbose `boolean`. Setting `estimate` to false will cause an error if the full proof cannot be made. Setting `verbose` to `false` will result in raw hex being returned, otherwise JSON is returned. This follows the same pattern as in the `bitcoind` RPC, see `getblock`.

This method uses the built in DNS resolver to query out to 8.8.8.8 or 8.8.4.4 and builds a DNSSEC proof.

Try it against any of the names in `lib/dns/tld.json`.

For example:

```$
$ ./bin/cli rpc getdnssecproof brave.com
```