### PR TITLE
test: add dns resolver tests

### DIFF
--- a/lib/dns/records.js
+++ b/lib/dns/records.js
@@ -104,6 +104,39 @@ const typesByVal = {
 };
 
 /**
+ * DNS RR Query Types by Handshake
+ * record type. This allows a lookup
+ * to determine which kind of DNS
+ * query to send based on which type
+ * of Handshake record would like
+ * to be resolved.
+ * @constant
+ */
+
+const dnsByType = {
+  [types.INET4]: wire.types.A,
+  [types.INET6]: wire.types.AAAA,
+  [types.ONION]: wire.types.A,    // encoded as TXT
+  [types.ONIONNG]: wire.types.A,  // encoded as TXT
+  [types.NAME]: wire.types.CNAME,
+  [types.CANONICAL]: wire.types.CNAME,
+  [types.DELEGATE]: wire.types.DNAME,
+  [types.NS]: wire.types.NS,
+  [types.SERVICE]: wire.types.SRV,
+  [types.URI]: wire.types.URI,
+  [types.EMAIL]: wire.types.RP,
+  [types.TEXT]: wire.types.TXT,
+  [types.LOCATION]: wire.types.LOC,
+  [types.MAGNET]: wire.types.URI,
+  [types.DS]: wire.types.DS,
+  [types.TLS]: wire.types.TLSA,
+  [types.SMIME]: wire.types.SMIMEA,
+  [types.SSH]: wire.types.SSHFP,
+  [types.PGP]: wire.types.OPENPGPKEY,
+  [types.ADDR]: wire.types.URI
+};
+
+/**
  * Target
  * @extends {Struct}
  */
@@ -1341,6 +1374,7 @@ function isSingle(label) {
 
 records.types = types;
 records.typesByVal = typesByVal;
+records.dnsByType = dnsByType;
 
 records.Target = Target;
 records.Service = Service;

--- a/lib/dns/records.js
+++ b/lib/dns/records.js
@@ -64,14 +64,14 @@ const types = {
   TEXT: 13, // TXT
   LOCATION: 14, // LOC
   // new record
-  MAGNET: 15, // TXT
+  MAGNET: 15, // URI
   DS: 16, // DS
   TLS: 17, // TLSA
   SMIME: 18, // SMIMEA
   SSH: 19, // SSHFP
   PGP: 20, // OPENPGPKEY
   // new record
-  ADDR: 21 // TXT
+  ADDR: 21 // URI
 };
 
 /**

--- a/lib/dns/records.js
+++ b/lib/dns/records.js
@@ -75,6 +75,35 @@ const types = {
 };
 
 /**
+ * Record Types By Value
+ * @constant
+ */
+
+const typesByVal = {
+  [types.INET4]: 'INET4',
+  [types.INET6]: 'INET6',
+  [types.ONION]: 'ONION',
+  [types.ONIONNG]: 'ONIONNG',
+  [types.NAME]: 'NAME',
+  [types.GLUE]: 'GLUE',
+  [types.CANONICAL]: 'CANONICAL',
+  [types.DELEGATE]: 'DELEGATE',
+  [types.NS]: 'NS',
+  [types.SERVICE]: 'SERVICE',
+  [types.URI]: 'URI',
+  [types.EMAIL]: 'EMAIL',
+  [types.TEXT]: 'TEXT',
+  [types.LOCATION]: 'LOCATION',
+  [types.MAGNET]: 'MAGNET',
+  [types.DS]: 'DS',
+  [types.TLS]: 'TLS',
+  [types.SMIME]: 'SMIME',
+  [types.SSH]: 'SSH',
+  [types.PGP]: 'PGP',
+  [types.ADDR]: 'ADDR'
+};
+
+/**
  * Target
  * @extends {Struct}
  */
@@ -1311,6 +1340,7 @@ function isSingle(label) {
  */
 
 records.types = types;
+records.typesByVal = typesByVal;
 
 records.Target = Target;
 records.Service = Service;

--- a/lib/dns/resource.js
+++ b/lib/dns/resource.js
@@ -1203,13 +1203,13 @@ class Resource extends Struct {
       case types.A:
         res.answer = this.toA(name);
         key.signZSK(res.answer, types.A);
-        if (this.hasTOR())
+        if (this.hasTor())
           key.signZSK(res.answer, types.TXT);
         break;
       case types.AAAA:
         res.answer = this.toAAAA(name);
         key.signZSK(res.answer, types.AAAA);
-        if (this.hasTOR())
+        if (this.hasTor())
           key.signZSK(res.answer, types.TXT);
         break;
       case types.CNAME:

--- a/test/data/resources-v0.json
+++ b/test/data/resources-v0.json
@@ -1,0 +1,206 @@
+{
+  "INET4": [{
+    "type": "A",
+    "resource": {
+      "hosts": [
+        "192.168.0.91",
+        "192.168.1.19"
+      ],
+      "ttl": 64
+    }
+  }],
+  "INET6": [{
+    "type": "AAAA",
+    "resource": {
+      "hosts": ["fc00::"],
+      "ttl": 64
+    }
+  }],
+  "ONION": [{
+    "_NOTE": "Returned as TXT record from A/AAAA query",
+    "type": "A",
+    "resource": {
+      "hosts": ["blockchainbdgpzk.onion"],
+      "ttl": 64
+    }
+  }],
+  "ONIONNG": [{
+    "_NOTE": "Returned as TXT record from A/AAAA query",
+    "type": "A",
+    "resource": {
+      "hosts": [
+        "sik5nlgfc5qylnnsr57qrbm64zbdx6t4lreyhpon3ychmxmiem7tioad.onion"
+      ],
+      "ttl": 64
+    }
+  }],
+  "NAME": [{
+    "type": "CNAME",
+    "resource": {
+      "canonical": "foo.",
+      "ttl": 64
+    }
+  }],
+  "CANONICAL": [{
+    "type": "CNAME",
+    "resource": {
+      "canonical": "foo.bar@1.2.3.4",
+      "ttl": 64
+    }
+  }],
+  "DELEGATE": [{
+    "type": "DNAME",
+    "resource": {
+      "delegate": "bar.foo@4.3.2.1",
+      "ttl": 64
+    }
+  }],
+  "NS": [{
+    "_NOTE": "Includes glue A records",
+    "type": "NS",
+    "resource": {
+      "ns": [
+        "ns1.cloudflare.com@1.2.3.4",
+        "ns2.cloudflare.com@1.2.4.4"
+      ],
+      "ttl": 64
+    }
+  }],
+  "SERVICE": [{
+    "_NOTE": "Includes 2 SRV records, the target is a name or an IP",
+    "type": "SRV",
+    "resource": {
+      "service": [{
+        "service": "a2.",
+        "protocol": "lseed.",
+        "target": "1.2.3.4",
+        "priority": 0,
+        "weight": 5,
+        "port": 7868
+      }, {
+        "service": "a2.",
+        "protocol": "lseed.",
+        "target": "btcseeder",
+        "priority": 0,
+        "weight": 2,
+        "port": 1337
+      }],
+      "ttl": 64
+    }
+  }],
+  "URI": [{
+    "type": "URI",
+    "resource": {
+      "uri": ["ftp://ftp1.example.com/public"],
+      "ttl": 64
+    }
+  }],
+  "EMAIL": [{
+    "type": "RP",
+    "resource": {
+      "email": ["foo.gmail.com"],
+      "ttl": 64
+    }
+  }],
+  "TEXT": [{
+    "type": "TXT",
+    "resource": {
+      "text": ["this is a txt record", "foobar"],
+      "ttl": 64
+    }
+  }],
+  "LOCATION": [{
+    "type": "LOC",
+    "resource": {
+      "location": [{
+        "version": 0,
+        "size": 0,
+        "horizPre": 1,
+        "vertPre": 2,
+        "latitude": 128,
+        "longitude": 256,
+        "altitude": 16
+      }],
+      "ttl": 64
+    }
+  }],
+  "MAGNET": [{
+    "type": "URI",
+    "resource": {
+      "magnet": [
+        "magnet:?xt=urn:btih:8c271f4d2e92a3449e2d1bde633cd49f64af888f"
+      ],
+      "ttl": 64
+    }
+  }],
+  "DS": [{
+    "type": "DS",
+    "resource": {
+      "ds": [{
+        "keyTag": 35215,
+        "algorithm": 13,
+        "digestType": 2,
+        "digest": "7C50EA94A63AEECB65B510D1EAC1846C973A89D4AB292287D5A4D715136B57A3"
+      }],
+      "ttl": 64
+    }
+  }],
+  "TLS": [{
+    "type": "TLSA",
+    "resource": {
+      "tls": [{
+        "protocol": "tcp.",
+        "port": 443,
+        "usage": 0,
+        "selector": 0,
+        "matchingType": 0,
+        "certificate": "0102348790"
+      }],
+      "ttl": 64
+    }
+  }],
+  "SMIME": [{
+    "type": "SMIMEA",
+    "resource": {
+      "smime": [{
+        "hash": "92faa0601d44a3c2b98318d8f7e4cd3b17f25caa6753cc04365d753d",
+        "usage": 0,
+        "selector": 0,
+        "matchingType": 0,
+        "certificate": "85fc1da9c82de277abd69f65b962aa55c335697a8bb8418894b65f24d86c6de4"
+      }],
+      "ttl": 64
+    }
+  }],
+  "SSH": [{
+    "type": "SSHFP",
+    "resource": {
+      "ssh": [{
+        "algorithm": 0,
+        "digestType": 1,
+        "fingerprint": "9be3ba6df1bc232ad4642d33ac09b8dc991e9b76f4f74bc96dd2ff17aa94500d9af2bd8f73a9eee9"
+      }],
+      "ttl": 64
+    }
+  }],
+  "PGP": [{
+    "type": "OPENPGPKEY",
+    "resource": {
+      "pgp": [{
+        "hash": "0e9baa5e5ce8cffd7bf13c37423957ed5e0061c9c8807628979ef475",
+        "publicKey": "b796a94d827d3b3142dde13d945a0467b5c9afa53ae551bdf898b1f3101ef883"
+      }],
+      "ttl": 64
+    }
+  }],
+  "ADDR": [{
+    "type": "URI",
+    "resource": {
+      "addr": [
+        "bitcoin:bc1q6yteaqmza4h7en72pwu4hk952c03wr32xxlp7v",
+        "bitcoin:tb1q6yteaqmza4h7en72pwu4hk952c03wr32vqyj9l"
+      ],
+      "ttl": 64
+    }
+  }]
+}

--- a/test/dns-test.js
+++ b/test/dns-test.js
@@ -1,0 +1,300 @@
+/**
+ * dns-test.js - DNS Server Testing for hsd
+ * Copyright (c) 2019, Mark Tyneway (MIT License).
+ * https://github.com/handshake-org/hsd
+ */
+
+'use strict';
+
+const assert = require('bsert');
+const StubResolver = require('bns/lib/resolver/stub');
+const bcrypto = require('bcrypto');
+const dnssec = require('bns/lib/dnssec');
+const util = require('bns/lib/util');
+const wire = require('bns/lib/wire');
+const FullNode = require('../lib/node/fullnode');
+const Resource = require('../lib/dns/resource');
+const Records = require('../lib/dns/records');
+const Network = require('../lib/protocol/network');
+const NameState = require('../lib/covenants/namestate');
+const rules = require('../lib/covenants/rules');
+const {types} = wire;
+
+const json = require('./data/resources-v0.json');
+
+const network = Network.get('regtest');
+
+const node = new FullNode({
+  network: 'regtest',
+  apiKey: 'foo',
+  walletAuth: true,
+  rsNoUnbound: true,
+  memory: true,
+  workers: true,
+  plugins: [require('../lib/wallet/plugin')]
+});
+
+const nstub = new StubResolver({
+  rd: true,
+  cd: true,
+  edns: true,
+  ednsSize: 4096,
+  maxAttempts: 2,
+  maxTimeout: 3000,
+  dnssec: true,
+  servers: [`127.0.0.1:${network.nsPort}`]
+});
+
+describe('DNS Servers', function() {
+  this.timeout(15000);
+
+  before(async () => {
+    await node.open();
+    await nstub.open();
+  });
+
+  after(async () => {
+    await node.close();
+    await nstub.close();
+  });
+
+  describe('Authoritative Resolver', () => {
+    // write each resource json to the tree
+    for (const [hstype, list] of Object.entries(json)) {
+      for (const item of list) {
+        // DNS RR type
+        const type = types[item.type];
+
+        // assert that the type maps are correct
+        const rtype = Records.types[hstype];
+        // handshake type -> DNS RR type
+        assert.equal(Records.dnsByType[rtype], type);
+        // handshake type -> handshake value (string)
+        assert.equal(Records.typesByVal[rtype], hstype);
+
+        const resource = Resource.fromJSON(item.resource);
+
+        let name;
+        before(async () => {
+          // args: size, height, network
+          name = rules.grindName(5, 1, network);
+          const raw = Buffer.from(name, 'ascii');
+          const nameHash = rules.hashName(raw);
+          // create a namestate to save the data to
+          const ns = new NameState();
+          ns.set(raw, 0);
+          ns.setData(resource.encode());
+
+          // Create a database transaction, as
+          // writing directly to the database is
+          // discouraged. Write to the txn and
+          // then commit it.
+          const txn = node.chain.db.tree.transaction();
+          await txn.insert(nameHash, ns.encode());
+          await txn.commit();
+        });
+
+        it(`should return authenticated ${hstype} record`, async () => {
+          // Certain types of queries require the
+          // name to be formatted with additional data
+          const query = buildQuery(name, resource, type);
+
+          // query the authoritative name server
+          let res = await nstub.lookup(query, type);
+
+          // create the dns response locally
+          let dns = resource.toDNS(query, type);
+
+          // query for the zone signing key
+          const dnskey = await nstub.lookup('.', types.DNSKEY);
+
+          // parse the zone signing key and
+          // key signing key out of the response
+          const {zsk, ksk} = getSigningKeys(dnskey);
+
+          assert(zsk instanceof wire.Record);
+          assert(ksk instanceof wire.Record);
+
+          // validate the signature on the ZSK
+          verifyDNSSEC(dnskey, ksk, types.DNSKEY, '.');
+          // validate the signature over the rrsets
+          verifyDNSSEC(res, zsk, type, query);
+
+          // NOTE: the signatures are not canonical
+          // when the native backend is being used
+          // because it uses OpenSSL which does not
+          // yet use RFC 6979, so nullify the
+          // signatures before comparing them
+          if (bcrypto.native === 2) {
+            dns = nullSig(dns);
+            res = nullSig(res);
+            assert(dns && res);
+          }
+
+          assert.deepEqual(dns.answer, res.answer);
+          assert.deepEqual(dns.authority, res.authority);
+          assert.deepEqual(dns.additional, res.additional);
+        });
+      }
+    }
+  });
+});
+
+/**
+ * Verify DNSSEC for each name in the
+ * response. Only check the answer and
+ * authority sections. If all rrsets
+ * are signed, the responses will be
+ * too large and not fit into udp packets
+ */
+
+function verifyDNSSEC(resource, pubkey, qtype, name) {
+  // rr types that are not committed to in DNSSEC
+  const skip = new Set([
+    types.RRSIG
+  ]);
+
+  name = util.fqdn(name);
+
+  const {answer, authority} = resource;
+  const targets = [answer, authority];
+
+  const records = [];
+
+  for (const target of targets) {
+    const toVerify = new Set();
+    for (const record of target) {
+      records.push(record);
+
+      if (!skip.has(record.type))
+        toVerify.add(record.type);
+    }
+
+    for (const type of toVerify) {
+      const rrsig = target.find((rr) => {
+        return rr.type === types.RRSIG
+          && rr.data.typeCovered === type;
+      });
+
+      if (name !== rrsig.name) {
+        const record = records.find((rr) => {
+          return rr.name === util.fqdn(name)
+            && (rr.type === types.CNAME
+            || rr.type === types.DNAME
+            || rr.type === types.SRV
+            || rr.type === types.NS);
+        });
+
+        assert(record);
+
+        switch (qtype) {
+          case types.CNAME:
+          case types.DNAME:
+          case types.SRV:
+            name = record.data.target;
+            break;
+          case types.NS:
+            name = record.data.ns;
+            break;
+          default:
+            assert(false, 'rrsig name does not match');
+        }
+      }
+
+      const rrs = util.extractSet(target, name, type);
+
+      const valid = dnssec.verify(rrsig, pubkey, rrs);
+      assert(valid);
+    }
+  }
+}
+
+/**
+ * Nullify out any signatures in
+ * a DNS response. This is to allow
+ * a deep equality check on DNS responses
+ * when using a non-deterministic
+ * signature scheme.
+ */
+
+function nullSig(response) {
+  const sections = ['answer', 'authority', 'additional'];
+  for (const section of sections) {
+    for (const resource of response[section])
+      if (resource.data.signature)
+        resource.data.signature = null;
+  }
+  return response;
+}
+
+/**
+ * Parse the ZSKs and KSKs from
+ * a record. Asserts that only
+ * one of each type is returned,
+ * as that is the currently expected
+ * behavior.
+ */
+
+function getSigningKeys(record) {
+  const ksks = [];
+  const zsks = [];
+  for (const rr of record.answer) {
+    if (rr.type === types.DNSKEY) {
+      const {data} = rr.toJSON();
+      if (data.keyType === 'ZSK')
+        zsks.push(rr);
+      else if (data.keyType === 'KSK')
+        ksks.push(rr);
+    }
+  }
+
+  assert.equal(ksks.length, 1);
+  assert.equal(zsks.length, 1);
+
+  return {
+    zsk: zsks[0],
+    ksk: ksks[0]
+  };
+}
+
+/**
+ * Build a name to query for the types
+ * that require additional labels.
+ */
+
+function buildQuery(name, resource, type) {
+  switch (type) {
+    case types.SRV: {
+      const service = resource.service[0];
+      return util.fqdn('_'
+        + service.service
+        + '_'
+        + service.protocol
+        + name);
+    }
+    case types.TLSA: {
+      const tls = resource.tls[0];
+      return util.fqdn('_'
+        + tls.port
+        + '._'
+        + tls.protocol
+        + name);
+    }
+    case types.SMIMEA: {
+      const smime = resource.smime[0];
+      return util.fqdn(smime.hash.toString('hex')
+        + '.'
+        + '_smimecert.'
+        + name);
+    }
+    case types.OPENPGPKEY: {
+      const pgp = resource.pgp[0];
+      return util.fqdn(pgp.hash.toString('hex')
+        + '.'
+        + '_openpgpkey.'
+        + name);
+    }
+    default:
+      return util.fqdn(name);
+  }
+}


### PR DESCRIPTION
This PR includes a test that purchases names and then writes one of each of the different Handshake records into the tree. A DNS stub resolver then queries for the name and asserts on the correct data being returned.

The DNSSEC test tests that all resource records sets in the answer and authority sections are signed. If all resource record sets in the additional section were signed as well, it could cause problems because there could potentially be many signatures and would force the DNS server to fall back to TCP. Ideally a different authentication mechanism is devised, because the DNSSEC key is public information anyways.

@boymanjor happy to split this up into smaller PRs if it would make it easier to review

Closes https://github.com/handshake-org/hsd/issues/264