### PR TITLE
rpc: add getnamedns method

### DIFF
--- a/lib/node/rpc.js
+++ b/lib/node/rpc.js
@@ -2383,14 +2383,14 @@ class RPC extends RPCBase {
   }
 
   async getNameDNS(args, help) {
-    if (help || args.length !== 2)
+    if (help || args.length < 1 || args.length > 2)
       throw new RPCError(errs.MISC_ERROR, 'getnamedns "name" "type"');
 
     const valid = new Validator(args);
     const name = valid.str(0, '');
-    const value = valid.str(1, '');
+    const value = valid.str(1, 'A');
 
-    if (!name || !rules.verifyName(name))
+    if (!name)
       throw new RPCError(errs.TYPE_ERROR, 'Invalid name.');
 
     const type = bns.wire.types[value.toUpperCase()];
@@ -2398,16 +2398,9 @@ class RPC extends RPCBase {
     if (!type)
       throw new RPCError(errs.TYPE_ERROR, 'Invalid type.');
 
-    const nameHash = rules.hashName(name);
-    const ns = await this.chain.db.getNameState(nameHash);
-
-    if (!ns || ns.data.length === 0)
-      return null;
-
     try {
-      const res = Resource.decode(ns.data);
-      const dns = res.toDNS(bns.util.fqdn(name), type);
-      return dns.toJSON();
+      const res = await this.node.rs.lookup(bns.util.fqdn(name), type);
+      return res.toJSON();
     } catch (e) {
       return {};
     }

--- a/lib/node/rpc.js
+++ b/lib/node/rpc.js
@@ -8,6 +8,7 @@
 
 const assert = require('bsert');
 const bweb = require('bweb');
+const bns = require('bns');
 const {Lock} = require('bmutex');
 const IP = require('binet');
 const Validator = require('bval');
@@ -236,6 +237,7 @@ class RPC extends RPCBase {
     this.add('getnames', this.getNames);
     this.add('getnameinfo', this.getNameInfo);
     this.add('getnameresource', this.getNameResource);
+    this.add('getnamedns', this.getNameDNS);
     this.add('getnameproof', this.getNameProof);
     this.add('getnamebyhash', this.getNameByHash);
     this.add('grindname', this.grindName);
@@ -2375,6 +2377,37 @@ class RPC extends RPCBase {
     try {
       const res = Resource.decode(ns.data);
       return res.getJSON(name);
+    } catch (e) {
+      return {};
+    }
+  }
+
+  async getNameDNS(args, help) {
+    if (help || args.length !== 2)
+      throw new RPCError(errs.MISC_ERROR, 'getnamedns "name" "type"');
+
+    const valid = new Validator(args);
+    const name = valid.str(0, '');
+    const value = valid.str(1, '');
+
+    if (!name || !rules.verifyName(name))
+      throw new RPCError(errs.TYPE_ERROR, 'Invalid name.');
+
+    const type = bns.wire.types[value.toUpperCase()];
+
+    if (!type)
+      throw new RPCError(errs.TYPE_ERROR, 'Invalid type.');
+
+    const nameHash = rules.hashName(name);
+    const ns = await this.chain.db.getNameState(nameHash);
+
+    if (!ns || ns.data.length === 0)
+      return null;
+
+    try {
+      const res = Resource.decode(ns.data);
+      const dns = res.toDNS(bns.util.fqdn(name), type);
+      return dns.toJSON();
     } catch (e) {
       return {};
     }


### PR DESCRIPTION
This PR adds a new Node `rpc` method called `getnamedns`. It accepts two arguments - the `name` (string) and a `type` (string). It will resolve the DNS query using the recursive resolver, and return the DNS response in JSON format.

I plan on using this RPC method to help people visualize what DNS messages look like. It is also a way for people to query against their local node without using something like `dig`. I do not recommend using this method in production, although a DoH proxy could be built on top of it.