### PR TITLE
node/http: add mempool details param

### DIFF
--- a/lib/node/http.js
+++ b/lib/node/http.js
@@ -334,11 +334,22 @@ class HTTP extends Server {
     this.get('/mempool', async (req, res) => {
       enforce(this.mempool, 'No mempool available.');
 
-      const hashes = this.mempool.getSnapshot();
+      const valid = Validator.fromRequest(req);
+      const details = valid.bool('details', false);
+
       const result = [];
 
-      for (const hash of hashes)
-        result.push(hash.toString('hex'));
+      if (details) {
+        const txs = this.mempool.getHistory();
+
+        for (const tx of txs)
+          result.push(tx.toJSON());
+      } else {
+        const hashes = this.mempool.getSnapshot();
+
+        for (const hash of hashes)
+          result.push(hash.toString('hex'));
+      }
 
       res.json(200, result);
     });


### PR DESCRIPTION
GET /mempool now accepts a query param
`details=bool`. When set to true, it
will return the TX JSON instead of just
the hashes. This is useful for block
explorers and also anybody who is interested
in more details about what exactly is in the
mempool at any given time.

I had fun watching the mempool using this
functionality.

bcoin: https://github.com/bcoin-org/bcoin/pull/869