### PR TITLE
address: add toScript method and expose to api

### DIFF
--- a/lib/primitives/address.js
+++ b/lib/primitives/address.js
@@ -8,6 +8,8 @@
 
 const assert = require('bsert');
 const bio = require('bufio');
+const Script = require('../script/script');
+const Opcode = require('../script/opcode');
 const {bech32} = require('bstring');
 const blake2b = require('bcrypto/lib/blake2b');
 const sha3 = require('bcrypto/lib/sha3');
@@ -190,6 +192,38 @@ class Address extends bio.Struct {
     const hrp = network.addressPrefix;
 
     return bech32.encode(hrp, version, hash);
+  }
+
+  /**
+   * Create Script from Address.
+   * @param {Witness} witness
+   * @returns {Script|null}
+   */
+
+  toScript(witness) {
+    const hash = this.getHash();
+
+    if (this.version === 0) {
+      if (hash.length === 20)
+        return Script.fromPubkeyhash(hash);
+      else if (hash.length === 32) {
+        if (!witness)
+          return null;
+
+        const preimage = witness.get(-1);
+        if(sha3.digest(preimage).equals(hash))
+          return Script.decode(preimage);
+      }
+    }
+
+    if (this.version === 31) {
+      return Script.fromArray([
+        Opcode.fromSymbol('return'),
+        Opcode.fromPush(hash)
+      ]);
+    }
+
+    return null;
   }
 
   /**

--- a/lib/primitives/coin.js
+++ b/lib/primitives/coin.js
@@ -205,17 +205,22 @@ class Coin extends Output {
    * for JSON serialization.
    * @param {Network} network
    * @param {Boolean} minimal
+   * @param {Witness} witness
    * @returns {Object}
    */
 
-  getJSON(network, minimal) {
+  getJSON(network, minimal, witness) {
     network = Network.get(network);
+
+    const script = this.address.toScript(witness);
 
     return {
       version: this.version,
       height: this.height,
       value: this.value,
       address: this.address.toString(network),
+      program: script ? script.toHex() : undefined,
+      asm: script ? script.toASM() : undefined,
       covenant: this.covenant.toJSON(),
       coinbase: this.coinbase,
       hash: !minimal ? this.txid() : undefined,

--- a/lib/primitives/input.js
+++ b/lib/primitives/input.js
@@ -176,9 +176,11 @@ class Input extends bio.Struct {
   getJSON(network, coin, path) {
     network = Network.get(network);
 
-    let addr;
+    let addr, script;
     if (!coin) {
       addr = this.getAddress();
+      script = addr.toScript(this.witness);
+
       if (addr)
         addr = addr.toString(network);
     }
@@ -188,6 +190,8 @@ class Input extends bio.Struct {
       witness: this.witness.toJSON(),
       sequence: this.sequence,
       address: addr,
+      program: script ? script.toHex() : undefined,
+      asm: script ? script.toASM() : undefined,
       coin: coin ? coin.getJSON(network, true) : undefined,
       path: path ? path.getJSON(network) : undefined
     };

--- a/lib/primitives/output.js
+++ b/lib/primitives/output.js
@@ -169,15 +169,20 @@ class Output extends bio.Struct {
    * Convert the output to an object suitable
    * for JSON serialization.
    * @param {Network} network
+   * @param {Witness} witness
    * @returns {Object}
    */
 
-  getJSON(network) {
+  getJSON(network, witness) {
     network = Network.get(network);
+
+    const script = this.address.toScript(witness);
 
     return {
       value: this.value,
       address: this.address.toString(network),
+      program: script ? script.toHex() : undefined,
+      asm: script ? script.toASM() : undefined,
       covenant: this.covenant.toJSON()
     };
   }

--- a/test/address-test.js
+++ b/test/address-test.js
@@ -5,6 +5,12 @@
 
 const assert = require('bsert');
 const Address = require('../lib/primitives/address');
+const Script = require('../lib/script/script');
+const Opcode = require('../lib/script/opcode');
+const Witness = require('../lib/script/witness');
+const secp256k1 = require('bcrypto/lib/secp256k1');
+const blake2b = require('bcrypto/lib/blake2b');
+const random = require('bcrypto/lib/random');
 
 describe('Address', function() {
   it('should match mainnet p2pkh address', () => {
@@ -13,5 +19,93 @@ describe('Address', function() {
     const addr = Address.fromPubkeyhash(p2pkh);
     const expect = 'hs1qd42hrldu5yqee58se4uj6xctm7nk28r70e84vx';
     assert.strictEqual(addr.toString('main'), expect);
+  });
+
+  it('should render the correct p2wpkh script', () => {
+    // create a keypair and hash the pubkey
+    const priv = secp256k1.privateKeyGenerate();
+    const pub = secp256k1.publicKeyCreate(priv);
+    const hash = blake2b.digest(pub, 20);
+
+    // create an address from the pubkey
+    const addr = Address.fromPubkeyhash(hash);
+
+    // convert the address to a script
+    const script = addr.toScript();
+
+    // expect a pay to pubkey hash
+    const expect = Script.fromArray([
+      Opcode.fromSymbol('dup'),
+      Opcode.fromSymbol('blake160'),
+      Opcode.fromPush(hash),
+      Opcode.fromSymbol('equalverify'),
+      Opcode.fromSymbol('checksig')
+    ]);
+
+    assert(script.equals(expect));
+    assert.deepEqual(script.toHex(), expect.toHex());
+  });
+
+  it('should render the correct p2sh script', () => {
+    const script = Script.fromArray([
+      Opcode.fromInt(2),
+      Opcode.fromSymbol('add'),
+      Opcode.fromInt(4),
+      Opcode.fromSymbol('equal')
+    ]);
+
+    const witness = Witness.fromArray([
+      Buffer.from([2]),
+      script.encode()
+    ]);
+
+    const addr = Address.fromScript(script);
+    const got = addr.toScript(witness);
+
+    assert(script.equals(got));
+    assert.deepEqual(script.toHex(), got.toHex());
+  });
+
+  it('should not render p2sh script when incorrect', () => {
+    const script = Script.fromArray([
+      Opcode.fromSymbol('verify')
+    ]);
+
+    const fake = Script.fromArray([
+      Opcode.fromSymbol('return')
+    ]);
+
+    const witness = Witness.fromArray([
+      fake.encode()
+    ]);
+
+    const addr = Address.fromScript(script);
+    const got = addr.toScript(witness);
+
+    assert.deepEqual(got, null);
+  });
+
+  it('should render the correct opreturn script', () => {
+    const msg = Buffer.from('1100112233', 'hex');
+
+    const addr = Address.fromNulldata(msg);
+    const got = addr.toScript();
+
+    const expect = Script.fromArray([
+      Opcode.fromSymbol('return'),
+      Opcode.fromPush(msg)
+    ]);
+
+    assert(got.equals(expect));
+    assert.deepEqual(got.toHex(), expect.toHex());
+  });
+
+  it('should render null when unknown version', () => {
+    const hash = random.randomBytes(20);
+    // version 30 is unknown at this time
+    const addr = Address.fromHash(hash, 30);
+    const script = addr.toScript();
+
+    assert.deepEqual(script, null);
   });
 });


### PR DESCRIPTION
An address is a commitment to some program that will run in the Script interpreter. Every address has a mapping to a program. Depending on the type of address, it may or may not need an opening to the commitment. For example, p2pkh does not need an opening while p2sh does (the program preimage).

The abstract function that maps an address to a program accepts a version, data (hash in this codebase) and an opening to the commitment (top of Witness stack in this codebase). I find reasoning about addresses in this way to be useful. The `hsd` codebase calls things `Script` when in reality I think they should be called `Program`. There is a lot of confusion between what is a script/program/redeem script/witness etc.

This PR addresses this mapping by:

- Adding a `toScript` method to the `Address` class that encompasses the functionality of converting an address to a script that can be ran in the Script interpreter. See codepath mentioned above here:

https://github.com/handshake-org/hsd/blob/7c172277476ea2a41501413f4f43a4a0a040b100/lib/script/script.js#L2262

This method must accept the witness as an argument in the case of pay to witness script hash, as it is impossible to know the program that will be ran without the preimage. In the case of pay to pubkey hash, you do not need the witness.

For each of `Coin`, `Input` and `Output` the `getJSON` method additionally renders `program` and `asm`. The program is the `address.toScript` where the program is the raw hex bytecode of the program and the asm is the assembly printed for human consumption.

This will allow block explorers to better visualize the locking scripts of addresses. It will also allow block explorers to display the redeem script (program preimage) when p2sh outputs are spent. @kilpatty 
