### PR TITLE
WIP primitives/covenant: add assembly method

### DIFF
--- a/lib/primitives/covenant.js
+++ b/lib/primitives/covenant.js
@@ -530,11 +530,68 @@ class Covenant extends bio.Struct {
   }
 
   /**
+   * Render the Covenant as human
+   * readable assembly.
+   * @returns {String}
+   */
+
+  toASM() {
+    const schema = [
+      'NAMEHASH',
+      'HEIGHT',
+      {
+        [types.CLAIM]: 'NAME',
+        [types.OPEN]: 'NAME',
+        [types.BID]: 'NAME',
+        [types.REVEAL]: 'NONCE',
+        [types.REGISTER]: 'RECORDDATA',
+        [types.UPDATE]: 'RECORDDATA',
+        [types.RENEW]: 'BLOCKHASH',
+        [types.TRANSFER]: 'VERSION',
+        [types.FINALIZE]: 'NAME'
+      },
+      {
+        [types.CLAIM]: 'FLAGS',
+        [types.BID]: 'HASH',
+        [types.REGISTER]: 'BLOCKHASH',
+        [types.TRANSFER]: 'ADDRESS',
+        [types.FINALIZE]: 'FLAGS'
+
+      },
+      'CLAIMHEIGHT',
+      'RENEWALCOUNT',
+      'BLOCKHASH'
+    ];
+
+    const type = typesByVal[this.type];
+    const out = [`TYPE:${type}`];
+
+    for (const [index, item] of Object.entries(this.items)) {
+      const pre = schema[Number(index)];
+      let render = item;
+
+      if (pre === 'NAME')
+        render = item.toString('ascii');
+      if (pre === 'HEIGHT')
+        render = item.readUInt32LE();
+      else
+        render = item.toString('hex');
+
+      if (typeof pre === 'string')
+        out.push(`${pre}:${render}`);
+      else
+        out.push(`${pre[this.type]}:${render}`);
+    }
+
+    return out.join(' ');
+  }
+
+  /**
    * Convert covenant to a hex string.
    * @returns {String}
    */
 
-  getJSON() {
+  getJSON(minimal) {
     const items = [];
 
     for (const item of this.items)
@@ -543,7 +600,8 @@ class Covenant extends bio.Struct {
     return {
       type: this.type,
       action: typesByVal[this.type],
-      items
+      items,
+      asm: !minimal ? this.toASM(): undefined
     };
   }
 


### PR DESCRIPTION
When looking at the `Covenant` field in JSON, it is not very helpful to understand what it means. This PR adds a `Covenant.toASM` method to return a human readable string.

The initial implementation takes advantage of a `schema` object that maps the index in `Covenant.items` to its type. Since different types of Covenants may have different types at the same index, an object is required to differentiate between the covenant item type that gets prefixed to the data in the covenant.items field.

A `NONE` type would look like this:
`TYPE:NONE`

A `BID` type would look like this:
`TYPE:BID NAMEHASH:.... HEIGHT:24256 NAME:... HASH:....`

I am open to suggestions on how to improve this method and make it more human friendly.