### PR TITLE
WIP primitives/covenant: add assembly method

### DIFF
--- a/lib/primitives/covenant.js
+++ b/lib/primitives/covenant.js
@@ -530,11 +530,68 @@ class Covenant extends bio.Struct {
   }
 
   /**
+   * Render the Covenant as human
+   * readable assembly.
+   * @returns {String}
+   */
+
+  toASM() {
+    const schema = [
+      'NAMEHASH',
+      'HEIGHT',
+      {
+        [types.CLAIM]: 'NAME',
+        [types.OPEN]: 'NAME',
+        [types.BID]: 'NAME',
+        [types.REVEAL]: 'NONCE',
+        [types.REGISTER]: 'RECORDDATA',
+        [types.UPDATE]: 'RECORDDATA',
+        [types.RENEW]: 'BLOCKHASH',
+        [types.TRANSFER]: 'VERSION',
+        [types.FINALIZE]: 'NAME'
+      },
+      {
+        [types.CLAIM]: 'FLAGS',
+        [types.BID]: 'HASH',
+        [types.REGISTER]: 'BLOCKHASH',
+        [types.TRANSFER]: 'ADDRESS',
+        [types.FINALIZE]: 'FLAGS'
+
+      },
+      'CLAIMHEIGHT',
+      'RENEWALCOUNT',
+      'BLOCKHASH'
+    ];
+
+    const type = typesByVal[this.type];
+    const out = [`TYPE:${type}`];
+
+    for (const [index, item] of Object.entries(this.items)) {
+      const pre = schema[Number(index)];
+      let render = item;
+
+      if (pre === 'NAME')
+        render = item.toString('ascii');
+      if (pre === 'HEIGHT')
+        render = item.readUInt32LE();
+      else
+        render = item.toString('hex');
+
+      if (typeof pre === 'string')
+        out.push(`${pre}:${render}`);
+      else
+        out.push(`${pre[this.type]}:${render}`);
+    }
+
+    return out.join(' ');
+  }
+
+  /**
    * Convert covenant to a hex string.
    * @returns {String}
    */
 
-  getJSON() {
+  getJSON(minimal) {
     const items = [];
 
     for (const item of this.items)
@@ -543,7 +600,8 @@ class Covenant extends bio.Struct {
     return {
       type: this.type,
       action: typesByVal[this.type],
-      items
+      items,
+      asm: !minimal ? this.toASM(): undefined
     };
   }
 


### PR DESCRIPTION
When looking at the Covenant field in JSON, it is not very helpful to understand what it means. This PR adds a Covenant.toASM method to return a human readable string.

The initial implementation takes advantage of a schema object that maps the index in Covenant.items to its type. Since different types of Covenants may have different types at the same index, an object is required to differentiate between the covenant item type that gets prefixed to the data in the covenant.items field.

A NONE type would look like this:
TYPE:NONE

A BID type would look like this:
TYPE:BID NAMEHASH:.... HEIGHT:24256 NAME:... HASH:....

I am open to suggestions on how to improve this method and make it more human friendly.

```
"covenant": {
  "type": 3,
  "action": "BID",
  "items": [
    "bbd9e905510ec6ca554591336a8ef507390c1fdb3200ea00a3af637535acfb63",
    "9d5e0000",
 "74687265652d68756e647265642d646f6d61696e732d74656e2d626964732d332d3634",
    "342714d9ea2c4eeb81209ebcedbc7d760cbff00a4edea5e67f297848b1f8051d"
  ],
  "asm": "TYPE:BID NAMEHASH:bbd9e905510ec6ca554591336a8ef507390c1fdb3200ea00a3af637535acfb63 HEIGHT:24221 NAME:74687265652d68756e647265642d646f6d61696e732d74656e2d626964732d332d3634 HASH:342714d9ea2c4eeb81209ebcedbc7d760cbff00a4edea5e67f297848b1f8051d"


"covenant": {
  "type": 0,
  "action": "NONE",
  "items": [],
  "asm": "TYPE:NONE"
}
```

TODO: make sure the schema is 100% accurate for each covenant type
Edit: return a schema list instead where the indexes line up 