### PR TITLE
policy: move blacklist to protocol/policy

### DIFF
--- a/lib/dns/server.js
+++ b/lib/dns/server.js
@@ -17,6 +17,7 @@ const LRU = require('blru');
 const NameState = require('../covenants/namestate');
 const rules = require('../covenants/rules');
 const reserved = require('../covenants/reserved');
+const policy = require('../protocol/policy');
 const Resource = require('./resource');
 const key = require('./key');
 
@@ -47,17 +48,6 @@ const {
 // Possibly add A, AAAA, and DS
 const TYPE_MAP = Buffer.from('000722000000000380', 'hex');
 const RES_OPT = { inet6: false, tcp: true };
-
-const blacklist = new Set([
-  'bit', // Namecoin
-  'eth', // ENS
-  'exit', // Tor
-  'gnu', // GNUnet (GNS)
-  'i2p', // Invisible Internet Project
-  'onion', // Tor
-  'tor', // OnioNS
-  'zkey' // GNS
-]);
 
 /**
  * RootCache
@@ -286,7 +276,7 @@ class RootServer extends DNSServer {
     const tld = util.label(name, labels, -1);
 
     // Ask the urkel tree for the name data.
-    const data = !blacklist.has(tld)
+    const data = !policy.blacklist.has(tld)
       ? (await this.lookupName(tld))
       : null;
 

--- a/lib/protocol/policy.js
+++ b/lib/protocol/policy.js
@@ -235,3 +235,20 @@ exports.getRate = function getRate(size, fee) {
 
   return Math.floor(fee * 1000 / size);
 };
+
+/**
+ * Policy based DNS Resolver blacklist.
+ * @const {Set}
+ * @default
+ */
+
+exports.blacklist = new Set([
+  'bit', // Namecoin
+  'eth', // ENS
+  'exit', // Tor
+  'gnu', // GNUnet (GNS)
+  'i2p', // Invisible Internet Project
+  'onion', // Tor
+  'tor', // OnioNS
+  'zkey' // GNS
+]);


### PR DESCRIPTION
Moving the already defined policy based blacklist to the `protocol/policy` file. It is defined as a `Set`, so a smarter blacklist class can be defined if it implements the `Set` interface.