### PR TITLE
rpc: getnameresource return name

### DIFF
--- a/lib/node/rpc.js
+++ b/lib/node/rpc.js
@@ -2366,7 +2366,7 @@ class RPC extends RPCBase {
 
     try {
       const res = Resource.decode(ns.data);
-      return res.toJSON();
+      return res.getJSON(name);
     } catch (e) {
       return {};
     }


### PR DESCRIPTION
If the `name` isn't passed along to `resource.getJSON`, then the `name` will be `null` in the JSON.