### PR TITLE
dns/records: fix smime parsing bug

### DIFF
--- a/lib/dns/records.js
+++ b/lib/dns/records.js
@@ -850,8 +850,8 @@ class SMIME extends Struct {
     assert((json.usage & 0xff) === json.usage);
     assert((json.selector & 0xff) === json.selector);
     assert((json.matchingType & 0xff) === json.matchingType);
-    assert(typeof json.fingerprint === 'string');
-    assert((json.fingerprint.length >>> 1) <= 255);
+    assert(typeof json.certificate === 'string');
+    assert((json.certificate.length >>> 1) <= 255);
     this.hash = util.parseHex(json.hash);
     this.port = json.port;
     this.usage = json.usage;


### PR DESCRIPTION
The `SMIME` record is defined to have a `certificate` but the `fromJSON` method looks for `fingerprint`. This PR renames `fingerprint` to `certificate`.