### PR TITLE
worker: use specific process title

### DIFF
--- a/lib/workers/worker.js
+++ b/lib/workers/worker.js
@@ -9,4 +9,6 @@
 const Master = require('./master');
 const server = new Master();
 
+process.title = 'hsd-worker';
+
 server.listen();


### PR DESCRIPTION
The workers will now have the title
`hsd-worker` when they run, instead
of the generic `node` title.

Port of bcoin commit:
ace4a08ebfbd4179c24b7c2fac49a68c52818372

Co-authored-by: Mark Tyneway <mark@purse.io>
Co-authored-by: Braydon Fuller <braydon@purse.io>