### PR TITLE
wallet: include network in master key JSON serialization calls

### DIFF
--- a/lib/wallet/masterkey.js
+++ b/lib/wallet/masterkey.js
@@ -615,7 +615,7 @@ class MasterKey extends bio.Struct {
 
     return {
       encrypted: false,
-      key: unsafe ? this.key.toJSON(network) : undefined,
+      key: unsafe ? this.key.getJSON(network) : undefined,
       mnemonic: unsafe && this.mnemonic ? this.mnemonic.toJSON() : undefined
     };
   }

--- a/lib/wallet/wallet.js
+++ b/lib/wallet/wallet.js
@@ -4295,7 +4295,7 @@ class Wallet extends EventEmitter {
       accountDepth: this.accountDepth,
       token: this.token.toString('hex'),
       tokenDepth: this.tokenDepth,
-      master: this.master.toJSON(this.network, unsafe),
+      master: this.master.getJSON(this.network, unsafe),
       balance: balance ? balance.toJSON(true) : null
     };
   }


### PR DESCRIPTION
Basically, since `toJSON` was incorrectly used instead of `getJSON`, all keys were being serialized with the default mainnet prefix instead of the prefix corresponding to their actual network.