### PR TITLE
dns/records: add cosmoshub support to Addr record

### DIFF
--- a/lib/dns/records.js
+++ b/lib/dns/records.js
@@ -972,6 +972,24 @@ class PGP extends Struct {
 /**
  * Addr
  * @extends {Struct}
+ *
+ * The binary serialization begins with
+ * a Uint8 which represents the type.
+ * The currently defined types are:
+ *
+ * 1 - Handshake
+ * 2 - Bitcoin bech32
+ * 3 - Ethereum
+ * 4 - Cosmoshub
+ * 0 - Unknown
+ *
+ * For the defined types, some metadata
+ * is used to encode the human readable
+ * prefix for bech32 based addresses
+ * along with the size of the data.
+ *
+ * For the unknown type, it is serialized
+ * in ascii as currency:address.
  */
 
 class Addr extends Struct {
@@ -996,6 +1014,11 @@ class Addr extends Struct {
 
     if (util.equal(this.currency, 'ethereum.'))
       return 1 + 20;
+
+    if (util.equal(this.currency, 'cosmoshub.')) {
+      const {hash} = bech32.decode(this.address);
+      return 1 + 1 + 1 + 1 + hash.length;
+    }
 
     return 1 + sizeName(this.currency) + 1 + this.address.length;
   }
@@ -1043,6 +1066,33 @@ class Addr extends Struct {
       return this;
     }
 
+    if (util.equal(this.currency, 'cosmoshub.')) {
+      const {hrp, version, hash} = bech32.decode(this.address);
+
+      assert(hash.length >= 1);
+      assert(hash.length <= 256);
+
+      let field = 0x00;
+      if (/val/.test(hrp))
+        field |= 0x80;
+      if (/oper/.test(hrp))
+        field |= 0x40;
+      if (/cons/.test(hrp))
+        field |= 0x20;
+      if (/pub/.test(hrp))
+        field |= 0x10;
+
+      const size = hash.length - 1;
+
+      bw.writeU8(4);
+      bw.writeU8(field);
+      bw.writeU8(size);
+      bw.writeU8(version);
+      bw.writeBytes(hash);
+
+      return this;
+    }
+
     bw.writeU8(0);
     writeNameBW(bw, this.currency, c.labels);
     bw.writeU8(this.address.length);
@@ -1087,6 +1137,48 @@ class Addr extends Struct {
     if (type === 3) {
       this.currency = 'ethereum.';
       this.address = '0x' + br.readString(20, 'hex');
+      return this;
+    }
+
+    if (type === 4) {
+      /**
+       * The field defines the bech32
+       * human readable parts. The bits
+       * are observed from left to right
+       * as the full hrp is constructed.
+       *
+       * val
+       * 1000 0000  -  0x80
+       *
+       * oper
+       * 0100 0000  -  0x40
+       *
+       * cons
+       * 0010 0000  -  0x20
+       *
+       * pub
+       * 0001 0000  -  0x10
+       */
+
+      const field = br.readU8();
+
+      let hrp = 'cosmos';
+      if ((field & 0x80) !== 0)
+        hrp += 'val';
+      if ((field & 0x40) !== 0)
+        hrp += 'oper';
+      if ((field & 0x20) !== 0)
+        hrp += 'cons';
+      if ((field & 0x10) !== 0)
+        hrp += 'pub';
+
+      const size = br.readU8() + 1;
+      const version = br.readU8();
+      const hash = br.readBytes(size);
+
+      this.currency = 'cosmoshub.';
+      this.address = bech32.encode(hrp, version, hash);
+
       return this;
     }
 

--- a/test/records-test.js
+++ b/test/records-test.js
@@ -1,0 +1,50 @@
+/**
+ * records-test.js - Records tests for hsd
+ * Copyright (c) 2019, Mark Tyneway (MIT License).
+ * https://github.com/handshake-org/hsd
+ */
+
+'use strict';
+
+const assert = require('bsert');
+const Records = require('../lib/dns/records');
+const {Compressor} = require('../lib/dns/compress');
+
+describe('Records V0', function () {
+  describe('Serialize and Deserialize', function () {
+    it('Addr', () => {
+      const check = (record, expect) => {
+        const [currency, address] = expect;
+        assert.equal(record.currency, currency);
+        assert.equal(record.address, address);
+      };
+
+      const mocks = [
+        ['bitcoin.', 'bc1q3ff2cc63fs6frk8nkyus4n82xxe7l3g37vs3vu'],
+        ['bitcoin.', 'tb1qf0vlknfcfrcmh9h298ktgnaxm6lwfrxvh3gc3v'],
+        ['bitcoin.', '17A16QmavnUfCW11DAApiJxp7ARnxN5pGX'],
+        ['handshake.', 'hs1q5z7yym8xrh4quqg3kw498ngy7hnd4sru5cr8x2'],
+        ['handshake.', 'ts1qhvp7est34xekyc3qt9sjhst0dt09r670ruz3wk'],
+        ['ethereum.', '0xdac17f958d2ee523a2206206994597c13d831ec7'],
+        ['cosmoshub.', 'cosmos1qvn96e22fw02gfd2v6x94n5m8udsmgqvtl6uxxz'],
+        ['cosmoshub.', 'cosmospub1qvn96e22fw02gfd2v6x94n5m8udsmgqvtn65mff'],
+        ['cosmoshub.', 'cosmosvalcons1qvn96e22fw02gfd2v6x94n5m8udsmgqvts2ftur'],
+        ['cosmoshub.', 'cosmosvalconspub1qvn96e22fw02gfd2v6x94n5m8udsmgqvtsrp8a4'],
+        ['cosmoshub.', 'cosmosvaloper1qvn96e22fw02gfd2v6x94n5m8udsmgqvtejle82'],
+        ['cosmoshub.', 'cosmosvaloperpub1qvn96e22fw02gfd2v6x94n5m8udsmgqvtu04qy5']
+      ];
+
+      for (const mock of mocks) {
+        const [currency, address] = mock;
+
+        let record = new Records.Addr(currency, address);
+        check(record, mock);
+
+        const c = new Compressor();
+        record = Records.Addr.decode(record.encode(c));
+        check(record, mock);
+      }
+    });
+  });
+});
+


### PR DESCRIPTION
This PR adds native support for Cosmoshub addresses with human readable parts `cosmos`, `cosmosvalcons` and `cosmosvaloper`. With native support, on chain serialization sizes are decreased by 36-40%. 

Unknown currencies are saved on chain in ascii format as currency:address. Adding 'cosmoshub' as a known currency will save space for saving these types of addresses on chain, as the hrp will be encoded in a field instead of saving the ascii to chain. This is particularly helpful for cosmoshub addresses, as the hrp is relatively large compared to other chains.

The sizes below are the on chain serialization sizes in bytes for a single `Addr` record

```

hrp           | size before  | size after |
--------------|--------------|------------|
cosmos        | 59           | 24         |
cosmosvalcons | 66           | 24         |
cosmosvaloper | 66           | 24         |

This reduces the size of the cosmoshub addresses
on chain to 36-40% of the size.

```

These calculations were created using the code snippet below.
I don't think that the address data for cosmoshub is a 20 byte blake2b of a secp256k1 key, but that shouldn't make a difference in the relative space savings.

```javascript
const Records = require('hsd/lib/dns/records');
const {bech32} = require('bstring');
const secp256k1 = require('bcrypto/lib/secp256k1');
const blake2b = require('bcrypto/lib/blake2b');

const hrps = [
  'cosmos',
  'cosmosvalcons',
  'cosmosvaloper'
];

const version = 0;

const priv = secp256k1.privateKeyGenerate();
const pub = secp256k1.publicKeyCreate(priv);
const hash = blake2b.digest(pub, 20);

for (const hrp of hrps) {
  const address = bech32.encode(hrp, version, hash);
  const record = new Records.Addr('cosmoshub.', address);
  console.log(`size: ${record.getSize()}`);
}
```

