### PR TITLE
dns/record: fix ssh record object property

### DIFF
--- a/lib/dns/records.js
+++ b/lib/dns/records.js
@@ -871,7 +871,7 @@ class SSH extends Struct {
   constructor() {
     super();
     this.algorithm = 0;
-    this.keyType = 0;
+    this.digestType = 0;
     this.fingerprint = DUMMY;
   }
 
@@ -883,7 +883,7 @@ class SSH extends Struct {
 
   write(bw) {
     bw.writeU8(this.algorithm);
-    bw.writeU8(this.keyType);
+    bw.writeU8(this.digestType);
     bw.writeU8(this.fingerprint.length);
     bw.writeBytes(this.fingerprint);
     return this;
@@ -891,7 +891,7 @@ class SSH extends Struct {
 
   read(br) {
     this.algorithm = br.readU8();
-    this.keyType = br.readU8();
+    this.digestType = br.readU8();
     const size = br.readU8();
     assert(size <= 64);
     this.fingerprint = br.readBytes(size);
@@ -901,7 +901,7 @@ class SSH extends Struct {
   getJSON() {
     return {
       algorithm: this.algorithm,
-      keyType: this.keyType,
+      digestType: this.digestType,
       fingerprint: this.fingerprint.toString('hex')
     };
   }
@@ -909,11 +909,11 @@ class SSH extends Struct {
   fromJSON(json) {
     assert(json && typeof json === 'object');
     assert((json.algorithm & 0xff) === json.algorithm);
-    assert((json.keyType & 0xff) === json.keyType);
+    assert((json.digestType & 0xff) === json.digestType);
     assert(typeof json.fingerprint === 'string');
     assert((json.fingerprint >>> 1) <= 255);
     this.algorithm = json.algorithm;
-    this.keyType = json.keyType;
+    this.digestType = json.digestType;
     this.fingerprint = util.parseHex(json.fingerprint);
     return this;
   }

--- a/lib/dns/resource.js
+++ b/lib/dns/resource.js
@@ -816,7 +816,7 @@ class Resource extends Struct {
       rr.data = rd;
 
       rd.algorithm = ssh.algorithm;
-      rd.keyType = ssh.keyType;
+      rd.digestType = ssh.digestType;
       rd.fingerprint = ssh.fingerprint;
 
       answer.push(rr);


### PR DESCRIPTION
The Handshake `SSH` record type was defined to have a `keyType`, but the `bns` based `SSHFPRecord` was defined with a `digestType`.

This commit changes the `keyType` property to being called `digestType`, as the data was not being properly assigned in `hsd/lib/resource` when the `Resource` was being rendered into a `sshfp` DNS request.

Closes #285 