### PR TITLE
dockerfile: update, add docs

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,5 @@
 .git
 node_modules
+bench
+docs
+scripts

--- a/README.md
+++ b/README.md
@@ -326,6 +326,11 @@ The above will output a base64 string which can then be passed to the RPC:
 $ hsd-rpc sendrawclaim 'base64-string'
 ```
 
+## Docker
+
+To build and run with Docker, see the
+[docs](docs/docker.md).
+
 ## Support
 
 Join us on [freenode][freenode] in the [#handshake][irc] channel.

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -1,0 +1,42 @@
+# Docker
+
+### Building with Docker
+
+To build a Docker image with the name
+`hsd:version-hash` run the following command:
+
+```bash
+VERSION=$(jq -r .version < package.json)
+HASH=$(git rev-parse --short HEAD)
+
+$ docker build -t hsd:$VERSION-$HASH .
+```
+
+### Running with Docker
+
+To start a container with command line options,
+pass them along like so:
+
+```bash
+API_KEY=foo
+
+$ docker run --rm --name hsd hsd:0.0.0-a90a45bb \
+    --network regtest \
+    --memory true \
+    --http-host 0.0.0.0 \
+    --rs-host 0.0.0.0 \
+    --api-key $API_KEY
+```
+
+Note that the container name `hsd:0.0.0-a90a45bb` is
+an example and will differ depending on the current
+`HEAD` of the git repo.
+
+### Stopping the Container
+
+The container was named `hsd`, so stop it
+with this command:
+
+```bash
+$ docker stop hsd
+```


### PR DESCRIPTION
Update the `Dockerfile` and add documentation on how to use it.

The node HTTP server and wallet HTTP server are both exposed.
The recursive resolver is exposed with both TCP and UDP.
The authoritative resolver is not exposed.