### PR TITLE
dns/server: return KEY record with sig0 key

### DIFF
--- a/lib/dns/server.js
+++ b/lib/dns/server.js
@@ -36,6 +36,7 @@ const {
   NSRecord,
   SOARecord,
   NSECRecord,
+  KEYRecord,
   types,
   codes
 } = wire;
@@ -270,6 +271,10 @@ class RootServer extends DNSServer {
           res.answer.push(key.ds.deepClone());
           key.signZSK(res.answer, types.DS);
           break;
+        case types.KEY:
+          res.answer.push(this.toKEY());
+          key.signZSK(res.answer, types.KEY);
+          break;
         default:
           // Empty Proof:
           res.authority.push(this.toNSEC());
@@ -448,6 +453,10 @@ class RootServer extends DNSServer {
     rd.nextDomain = '.';
     rd.typeBitmap = TYPE_MAP;
     return rr;
+  }
+
+  toKEY() {
+    return hsig.createKey(this.key);
   }
 }
 

--- a/lib/dns/server.js
+++ b/lib/dns/server.js
@@ -456,7 +456,7 @@ class RootServer extends DNSServer {
   }
 
   toKEY() {
-    return hsig.createKey(this.key);
+    return hsig.makeKey(this.key);
   }
 }
 

--- a/lib/node/node.js
+++ b/lib/node/node.js
@@ -175,14 +175,20 @@ class Node extends EventEmitter {
    */
 
   loadKey() {
-    if (this.memory || fs.unsupported)
+    let key = this.config.buf('identity-key');
+
+    // Create a new key in memory if no key
+    // was passed via config at runtime and
+    // there is no filesystem backend.
+    if (!key && (this.memory || fs.unsupported))
       return this.genKey();
 
     const filename = this.location('key');
 
-    let key = this.config.buf('identity-key');
     let fresh = false;
 
+    // No key was passed in at runtime via config,
+    // try to read the key from hsd dot directory.
     if (!key) {
       try {
         const data = fs.readFileSync(filename, 'utf8');


### PR DESCRIPTION
As part of end to end testing the dns server in https://github.com/handshake-org/hsd/pull/265, I wanted to also test out the sig0 implementation.

From the [rfc](https://tools.ietf.org/html/rfc2931):

```
For all transaction SIG(0)s, the signer field MUST be a name of the
originating host and there MUST be a KEY RR at that name with the
public key corresponding to the private key used to calculate the
```

The root server does not handle the `KEY` record type and also does not return the `KEY` record for the `ANY` request, as the rfc specifies below.

```
The private keys used in transaction security belong to the host
composing the DNS response message, not to the zone involved.
Request authentication may also involve the private key of the host
or other entity composing the request or of a zone to be affected by
the request or other private keys depending on the request authority
it is sought to establish. The corresponding public key(s) are
normally stored in and retrieved from the DNS for verification as KEY
RRs with a protocol byte of 3 (DNSSEC) or 255 (ANY).
```

Using the helper function `createKey` built into `bns/lib/hsig`, which is a Handshake specific wrapper of sig0, to add the `KEY` record to the dns response, it causes an error with `dig` but not with `dig.js`. The error can be seen here:

```
;; Got bad packet: bad compression pointer
181 bytes
aa ad 81 a0 00 01 00 01 00 00 00 02 00 00 19 00          ................
01 00 00 19 00 ff 00 00 00 00 00 24 00 00 00 fd          ...........$....
10 49 32 18 1c fe d7 58 41 05 c7 28 cd c0 eb 9a          .I2....XA..(....
f1 e7 ff dc 4a 00 74 3f d4 5e 5d e6 6c ac 76 68          ....J.t?.^].l.vh
00 00 29 10 00 00 00 00 00 00 0c 00 0a 00 08 0a          ..).............
e5 7a e6 ac b0 7b ed 00 00 18 00 ff 00 00 00 00          .z...{..........
00 53 00 00 fd 00 00 00 00 00 5d b6 aa 2d 5d b6          .S........]..-].
01 6d 71 52 00 f7 6b 55 ba 40 14 f4 61 c1 4e 78          .mqR..kU.@..a.Nx
b7 ab 08 ff 3b 43 6b 92 d7 d2 7e 26 13 e5 a9 f7          ....;Ck....&....
b2 01 31 52 b1 1e 33 ee 82 f8 de c0 cb 95 09 c7          ..1R..3.........
02 6f 31 c2 2f 13 00 c4 6c d7 5e f0 f5 0b a1 e9          .o1./...l.^.....
95 10 e0 5d 4c                                           ...]L

```

This lead me to believe that there was an error in the serialization of the `KEYRecord` defined here: https://tools.ietf.org/html/rfc2535#section-3

This pull request also allows a node operator to pass along an `identity-key` when running in memory. This will allow me to rebase this PR on top of https://github.com/handshake-org/hsd/pull/265 and also test the sig0 implementation for each rr type.

TODO:
- [ ] squash the bug
- [ ] rebase on https://github.com/handshake-org/hsd/pull/265