### PR TITLE
utils: fix amount to unit.

### DIFF
--- a/lib/types.js
+++ b/lib/types.js
@@ -97,3 +97,9 @@
  * @see {module:network.types}
  * @global
  */
+
+/**
+ * One of `doo`, `uhns`, `mhns`, `hns`, `handshake`.
+ * @typedef {String} AmountUnitType
+ * @global
+ */

--- a/lib/ui/amount.js
+++ b/lib/ui/amount.js
@@ -15,7 +15,7 @@ const pkg = require('../pkg');
  * Amount
  * Represents a currency amount (base unit internally).
  * @alias module:currency.Amount
- * @property {Amount} value
+ * @property {Number} value
  */
 
 class Amount {
@@ -23,7 +23,7 @@ class Amount {
    * Create an amount.
    * @constructor
    * @param {(String|Number)?} value
-   * @param {String?} unit
+   * @param {AmountUnitType} [unit=doo]
    */
 
   constructor(value, unit) {
@@ -36,8 +36,8 @@ class Amount {
   /**
    * Inject properties from options.
    * @private
-   * @param {(String|Number)?} value
-   * @param {String?} unit
+   * @param {String|Number} value
+   * @param {AmountUnitType} [unit=doo]
    * @returns {Amount}
    */
 
@@ -62,7 +62,7 @@ class Amount {
 
   /**
    * Get base unit string or value.
-   * @param {Boolean?} num
+   * @param {Boolean} [num=false] - Return a number.
    * @returns {String|Amount}
    */
 
@@ -74,18 +74,8 @@ class Amount {
   }
 
   /**
-   * Get bits string or value.
-   * @param {Boolean?} num
-   * @returns {String|Amount}
-   */
-
-  toBits(num) {
-    return Amount.encode(this.value, 2, num);
-  }
-
-  /**
    * Get mhns string or value.
-   * @param {Boolean?} num
+   * @param {Boolean} [num=false] - Return a number.
    * @returns {String|Amount}
    */
 
@@ -95,7 +85,7 @@ class Amount {
 
   /**
    * Get currency string or value.
-   * @param {Boolean?} num
+   * @param {Boolean} [num=false] - Return a number.
    * @returns {String|Amount}
    */
 
@@ -105,20 +95,20 @@ class Amount {
 
   /**
    * Get unit string or value.
-   * @param {String} unit
-   * @param {Boolean?} num
+   * @param {AmountUnitType} unit
+   * @param {Boolean} [num=false] - Return a number.
    * @returns {String|Amount}
+   * @throws on incorrect unit type.
    */
 
   to(unit, num) {
     switch (unit) {
       case pkg.base:
-        return this.toBase(num);
       case `u${pkg.unit}`:
-      case 'bits':
-        return this.toBits(num);
+        return this.toBase(num);
       case `m${pkg.unit}`:
         return this.toMilli(num);
+      case pkg.unit:
       case pkg.currency:
         return this.toCoins(num);
     }
@@ -161,18 +151,6 @@ class Amount {
   }
 
   /**
-   * Inject properties from bits.
-   * @private
-   * @param {Number|String} value
-   * @returns {Amount}
-   */
-
-  fromBits(value) {
-    this.value = Amount.decode(value, 2);
-    return this;
-  }
-
-  /**
    * Inject properties from mhns.
    * @private
    * @param {Number|String} value
@@ -199,21 +177,21 @@ class Amount {
   /**
    * Inject properties from unit.
    * @private
-   * @param {String} unit
+   * @param {AmountUnitType} unit
    * @param {Number|String} value
    * @returns {Amount}
+   * @throws on incorrect unit type.
    */
 
   from(unit, value) {
     switch (unit) {
       case pkg.base:
-        return this.fromBase(value);
       case `u${pkg.unit}`:
-      case 'bits':
-        return this.fromBits(value);
+        return this.fromBase(value);
       case `m${pkg.unit}`:
         return this.fromMilli(value);
       case pkg.unit:
+      case pkg.currency:
         return this.fromCoins(value);
     }
     throw new Error(`Unknown unit "${unit}".`);
@@ -221,8 +199,8 @@ class Amount {
 
   /**
    * Instantiate amount from options.
-   * @param {(String|Number)?} value
-   * @param {String?} unit
+   * @param {String|Number} value
+   * @param {AmountUnitType} [unit=doo]
    * @returns {Amount}
    */
 
@@ -252,16 +230,6 @@ class Amount {
   }
 
   /**
-   * Instantiate amount from bits.
-   * @param {Number|String} value
-   * @returns {Amount}
-   */
-
-  static fromBits(value) {
-    return new this().fromBits(value);
-  }
-
-  /**
    * Instantiate amount from milliunit.
    * @param {Number|String} value
    * @returns {Amount}
@@ -283,7 +251,7 @@ class Amount {
 
   /**
    * Instantiate amount from unit.
-   * @param {String} unit
+   * @param {AmountUnitType} unit
    * @param {Number|String} value
    * @returns {Amount}
    */
@@ -306,7 +274,8 @@ class Amount {
    * This function explicitly avoids any
    * floating point arithmetic.
    * @param {Amount} value - Base unit.
-   * @returns {String} Currency string.
+   * @param {Boolean} [num=false] - Return a number.
+   * @returns {String|Number} Currency string.
    */
 
   static coin(value, num) {
@@ -334,7 +303,7 @@ class Amount {
    * Safely convert base unit to a currency string.
    * @param {Amount} value
    * @param {Number} exp - Exponent.
-   * @param {Boolean} num - Return a number.
+   * @param {Boolean} [num=false] - Return a number.
    * @returns {String|Number}
    */
 

--- a/test/utils-test.js
+++ b/test/utils-test.js
@@ -8,6 +8,27 @@ const Amount = require('../lib/ui/amount');
 const fixed = require('../lib/utils/fixed');
 const {COIN} = require('../lib/protocol/consensus');
 
+const toFromVectors = [
+  {
+    value: 5460, // doos
+    units: {
+      doo: [5460, '5460'],
+      uhns: [5460, '5460'],
+      mhns: [5.46, '5.46'],
+      hns: [0.00546, '0.00546']
+    }
+  },
+  {
+    value: 54678 * 1000000,
+    units: {
+      doo: [54678 * 1000000, '54678000000'],
+      uhns: [54678 * 1000000, '54678000000'],
+      mhns: [54678 * 1000, '54678000.0'],
+      hns: [54678, '54678.0']
+    }
+  }
+];
+
 describe('Utils', function() {
   it('should convert dollarydoos to hns', () => {
     assert.strictEqual(Amount.coin(5460), '0.00546');
@@ -54,5 +75,44 @@ describe('Utils', function() {
     assert.strictEqual(fixed.encode(15645647, 8), '0.15645647');
     assert.strictEqual(fixed.fromFloat(0.15645647, 8), 15645647);
     assert.strictEqual(fixed.toFloat(15645647, 8), 0.15645647);
+  });
+
+  it('should convert Amount from units', () => {
+    for (const vector of toFromVectors) {
+      const units = Object.keys(vector.units);
+
+      for (const unit of units) {
+        const numAmount = Amount.from(unit, vector.units[unit][0]);
+        const strAmount = Amount.from(unit, vector.units[unit][1]);
+
+        assert.strictEqual(numAmount.toValue(), vector.value,
+          `Amount.from(${unit}, ${vector.units[unit][0]}) is not ${vector.value}.`
+        );
+
+        assert.strictEqual(strAmount.toValue(), vector.value,
+          `Amount.from(${unit}, '${vector.units[unit][1]}') is not ${vector.value}.`
+        );
+      }
+    }
+  });
+
+  it('should convert Amount to units', () => {
+    for (const vector of toFromVectors) {
+      const units = Object.keys(vector.units);
+      const amount = Amount.fromValue(vector.value);
+
+      for (const unit of units) {
+        const numValue = amount.to(unit, true);
+        const strValue = amount.to(unit, false);
+
+        assert.strictEqual(numValue, vector.units[unit][0],
+          `Amount(${vector.value}).to(${unit}, true) is not ${vector.units[unit][0]}.`
+        );
+
+        assert.strictEqual(strValue, vector.units[unit][1],
+          `Amount(${vector.value}).to(${unit}, false) is not '${vector.units[unit][1]}'.`
+        );
+      }
+    }
   });
 });


### PR DESCRIPTION
Added small test vector.

Updated!

So changes:
 - Removed toBits/fromBits.
 - Apparently `uhns` was broken, it should be same as `doo`.
 - Added `handshake` as amount unit type as well.

Notes about types:
 - Added `@typedef` for unit enum: `AmountUnitType`

So we get currencies:
| Unit   | Decimal (HNS) | Exponent | Note              |
| ---    | ---           | ---      | ---               |
| `doo`  | 0.000001      | 0        | Base unit         |
| `uhns` | 0.000001      | 0        | micro-hns or μhns |
| `mhns` | 0.001         | 3        | milli-hns or mhns |
| `hns`  | 1             | 6        | or `handshake`    |


There's an issue with conflicting types: `lib/types` defines global typedefs for the project.
There's typedef: https://github.com/handshake-org/hsd/blob/2d1cbe9c17b0ad4e8858c06a8f85625dbee35ba9/lib/types.js#L66-L74

Which has same name as `Amount` class, so neither jsdoc nor tools can determine what is Amount.
So I can't actually define `@return {Amount}` meaning the class instead of typedef.

One solution would be to change name for either of them:
 e.g. call DooInteger or something like that to that typedef.