### PR TITLE
dns/server: add lookup method to rs

### DIFF
--- a/lib/dns/server.js
+++ b/lib/dns/server.js
@@ -601,6 +601,10 @@ class RecursiveServer extends DNSServer {
     const [qs] = req.question;
     return this.hns.resolve(qs);
   }
+
+  async lookup(name, type) {
+    return this.hns.lookup(name, type);
+  }
 }
 
 /*


### PR DESCRIPTION
Adds a `lookup` method to the `RecursiveServer` that wraps `hns.lookup`. This makes it easy to hook into the `RecursiveServer` through alternative means, ie DNS over HTTP. This is a building block for a DNS over HTTPS proxy in front of `hsd`.

The `lookup` method accepts the name and RR type, which abstracts away the need to create a `Message`.

There is a `lookup` method passed to the `RootServer` that is responsible for looking up names in the authenticated tree. Now both servers have a `lookup` method.

https://github.com/chjj/bns/blob/f889a41234fc6ea53df8450970730a0af1b69dc0/lib/resolver/recursive.js#L577