### PR TITLE
node: sig(0) config option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,10 @@ boolean parameter "own" (default: `false`) that filters out names the wallet doe
 - DNSSEC proofs from the root name server were fixed, particularly around non-existent
 domains. The empty zone proofs were replaced with minimally covering NSEC records.
 
+- `FullNode` and `SPVNode` parse new option `--no-sig0` which disables SIG0 signing
+in the root nameserver and recursive resolver. The current SIG0 algorithm uses Blake2b
+and is identified as `PRIVATEDNS` which is incompatible with most legacy DNS software.
+
 ### Other changes
 
 - The logging module `blgr` has been updated. Log files will now be rolled over

--- a/lib/dns/server.js
+++ b/lib/dns/server.js
@@ -105,7 +105,7 @@ class RootServer extends DNSServer {
     this.ra = false;
     this.edns = true;
     this.dnssec = true;
-    this.sig0 = true;
+    this.noSig0 = false;
     this.icann = new RootResolver(RES_OPT);
 
     this.logger = Logger.global;
@@ -170,9 +170,9 @@ class RootServer extends DNSServer {
       this.lookup = options.lookup;
     }
 
-    if (options.sig0 != null) {
-      assert(typeof options.sig0 === 'boolean');
-      this.sig0 = options.sig0;
+    if (options.noSig0 != null) {
+      assert(typeof options.noSig0 === 'boolean');
+      this.noSig0 = options.noSig0;
     }
 
     if (options.publicHost != null) {
@@ -209,14 +209,16 @@ class RootServer extends DNSServer {
   }
 
   signSize() {
-    if (this.sig0)
+    if (!this.sig0)
       return 94;
+
     return 0;
   }
 
   sign(msg, host, port) {
-    if (this.sig0)
+    if (!this.noSig0)
       return hsig.sign(msg, this.key);
+
     return msg;
   }
 
@@ -593,7 +595,7 @@ class RecursiveServer extends DNSServer {
     this.ra = true;
     this.edns = true;
     this.dnssec = true;
-    this.sig0 = true;
+    this.noSig0 = false;
     this.noAny = true;
 
     this.logger = Logger.global;
@@ -662,9 +664,9 @@ class RecursiveServer extends DNSServer {
       this.stubPort = options.stubPort;
     }
 
-    if (options.sig0 != null) {
-      assert(typeof options.sig0 === 'boolean');
-      this.sig0 = options.sig0;
+    if (options.noSig0 != null) {
+      assert(typeof options.noSig0 === 'boolean');
+      this.noSig0 = options.noSig0;
     }
 
     if (options.noUnbound != null) {
@@ -713,14 +715,16 @@ class RecursiveServer extends DNSServer {
   }
 
   signSize() {
-    if (this.sig0)
+    if (!this.noSig0)
       return 94;
+
     return 0;
   }
 
   sign(msg, host, port) {
-    if (this.sig0)
+    if (!this.noSig0)
       return hsig.sign(msg, this.key);
+
     return msg;
   }
 

--- a/lib/dns/server.js
+++ b/lib/dns/server.js
@@ -105,6 +105,7 @@ class RootServer extends DNSServer {
     this.ra = false;
     this.edns = true;
     this.dnssec = true;
+    this.sig0 = true;
     this.icann = new RootResolver(RES_OPT);
 
     this.logger = Logger.global;
@@ -169,6 +170,11 @@ class RootServer extends DNSServer {
       this.lookup = options.lookup;
     }
 
+    if (options.sig0 != null) {
+      assert(typeof options.sig0 === 'boolean');
+      this.sig0 = options.sig0;
+    }
+
     if (options.publicHost != null) {
       assert(typeof options.publicHost === 'string');
       this.publicHost = IP.normalize(options.publicHost);
@@ -203,11 +209,15 @@ class RootServer extends DNSServer {
   }
 
   signSize() {
-    return 94;
+    if (this.sig0)
+      return 94;
+    return 0;
   }
 
   sign(msg, host, port) {
-    return hsig.sign(msg, this.key);
+    if (this.sig0)
+      return hsig.sign(msg, this.key);
+    return msg;
   }
 
   async lookupName(name) {
@@ -583,6 +593,7 @@ class RecursiveServer extends DNSServer {
     this.ra = true;
     this.edns = true;
     this.dnssec = true;
+    this.sig0 = true;
     this.noAny = true;
 
     this.logger = Logger.global;
@@ -651,6 +662,11 @@ class RecursiveServer extends DNSServer {
       this.stubPort = options.stubPort;
     }
 
+    if (options.sig0 != null) {
+      assert(typeof options.sig0 === 'boolean');
+      this.sig0 = options.sig0;
+    }
+
     if (options.noUnbound != null) {
       assert(typeof options.noUnbound === 'boolean');
       if (options.noUnbound) {
@@ -697,11 +713,15 @@ class RecursiveServer extends DNSServer {
   }
 
   signSize() {
-    return 94;
+    if (this.sig0)
+      return 94;
+    return 0;
   }
 
   sign(msg, host, port) {
-    return hsig.sign(msg, this.key);
+    if (this.sig0)
+      return hsig.sign(msg, this.key);
+    return msg;
   }
 
   async open(...args) {

--- a/lib/node/fullnode.js
+++ b/lib/node/fullnode.js
@@ -166,7 +166,7 @@ class FullNode extends Node {
         port: this.config.uint('ns-port', this.network.nsPort),
         lookup: key => this.chain.db.tree.get(key),
         publicHost: this.config.str('public-host'),
-        sig0: this.config.bool('ns-sig0')
+        noSig0: this.config.bool('no-sig0')
       });
 
       if (!this.config.bool('no-rs')) {
@@ -178,7 +178,7 @@ class FullNode extends Node {
           stubHost: this.ns.host,
           stubPort: this.ns.port,
           noUnbound: this.config.bool('rs-no-unbound'),
-          sig0: this.config.bool('rs-sig0')
+          noSig0: this.config.bool('no-sig0')
         });
       }
     }

--- a/lib/node/fullnode.js
+++ b/lib/node/fullnode.js
@@ -165,7 +165,8 @@ class FullNode extends Node {
         host: this.config.str('ns-host'),
         port: this.config.uint('ns-port', this.network.nsPort),
         lookup: key => this.chain.db.tree.get(key),
-        publicHost: this.config.str('public-host')
+        publicHost: this.config.str('public-host'),
+        sig0: this.config.bool('ns-sig0')
       });
 
       if (!this.config.bool('no-rs')) {
@@ -176,7 +177,8 @@ class FullNode extends Node {
           port: this.config.uint('rs-port', this.network.rsPort),
           stubHost: this.ns.host,
           stubPort: this.ns.port,
-          noUnbound: this.config.bool('rs-no-unbound')
+          noUnbound: this.config.bool('rs-no-unbound'),
+          sig0: this.config.bool('rs-sig0')
         });
       }
     }

--- a/lib/node/spvnode.js
+++ b/lib/node/spvnode.js
@@ -100,7 +100,8 @@ class SPVNode extends Node {
         host: this.config.str('ns-host'),
         port: this.config.uint('ns-port', this.network.nsPort),
         lookup: key => this.pool.resolve(key),
-        publicHost: this.config.str('public-host')
+        publicHost: this.config.str('public-host'),
+        sig0: this.config.bool('ns-sig0')
       });
 
       if (!this.config.bool('no-rs')) {
@@ -111,7 +112,8 @@ class SPVNode extends Node {
           port: this.config.uint('rs-port', this.network.rsPort),
           stubHost: this.ns.host,
           stubPort: this.ns.port,
-          noUnbound: this.config.bool('rs-no-unbound')
+          noUnbound: this.config.bool('rs-no-unbound'),
+          sig0: this.config.bool('rs-sig0')
         });
       }
     }

--- a/lib/node/spvnode.js
+++ b/lib/node/spvnode.js
@@ -101,7 +101,7 @@ class SPVNode extends Node {
         port: this.config.uint('ns-port', this.network.nsPort),
         lookup: key => this.pool.resolve(key),
         publicHost: this.config.str('public-host'),
-        sig0: this.config.bool('ns-sig0')
+        noSig0: this.config.bool('no-sig0')
       });
 
       if (!this.config.bool('no-rs')) {
@@ -113,7 +113,7 @@ class SPVNode extends Node {
           stubHost: this.ns.host,
           stubPort: this.ns.port,
           noUnbound: this.config.bool('rs-no-unbound'),
-          sig0: this.config.bool('rs-sig0')
+          noSig0: this.config.bool('no-sig0')
         });
       }
     }

--- a/test/ns-test.js
+++ b/test/ns-test.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const assert = require('bsert');
-const {wire, util, encoding} = require('bns');
+const {wire, util, encoding, StubResolver} = require('bns');
 const {RootServer} = require('../lib/dns/server');
 const {Resource} = require('../lib/dns/resource');
 const NameState = require('../lib/covenants/namestate');
@@ -575,6 +575,51 @@ describe('RootServer DNSSEC', function () {
       const proof = set[0];
       assert.strictEqual(proof.data.typeBitmap, query.bitmap);
     }
+  });
+});
+
+describe('RootServer SIG0', function() {
+  let ns;
+
+  afterEach(async () => {
+    await ns.close();
+  });
+
+  it('should answer with SIG0', async () => {
+    ns = new RootServer({
+      port: 25349
+    });
+
+    const stub = new StubResolver();
+    stub.setServers(['127.0.0.1:25349']);
+
+    // Use a synth name for this so no Urkel Tree or ICANN DNS is required
+    const name = '_fs0000g._synth.';
+
+    await ns.open();
+    const res = await stub.lookup(name);
+
+    assert(res.sig0);
+    const json = res.getJSON();
+    assert.strictEqual(json.sig0.algName, 'PRIVATEDNS');
+  });
+
+  it('should not answer with SIG0', async () => {
+    ns = new RootServer({
+      port: 25349,
+      noSig0: true
+    });
+
+    const stub = new StubResolver();
+    stub.setServers(['127.0.0.1:25349']);
+
+    // Use a synth name for this so no Urkel Tree or ICANN DNS is required
+    const name = '_fs0000g._synth.';
+
+    await ns.open();
+    const res = await stub.lookup(name);
+
+    assert(!res.sig0);
   });
 });
 


### PR DESCRIPTION
This PR allows for turning on/off `SIG(0)` for both the `RecursiveServer` and the `RootServer` with the options:

- `--rs-sig0 <true|false>`
- `--ns-sig0 <true|false>`

They both default to `true`, which is the current behavior.

This will make the removal of `SIG(0)` in the future easier as a release could turn it off once something better has been implemented.

The `sign` function is updated to check to make sure that `sig0` is enabled before signing. It needs to return the `msg` as `hsig.sign` returns a modified `msg`.

The `signSize` function is updated to check that `sig0` is enabled before returning its hard coded size. If it it not enabled, it will return 0.

You can see the code path that calls the `sign` function and the `signSize` function here:
https://github.com/chjj/bns/blob/master/lib/server/dns.js#L266