### PR TITLE
ui: decouple consensus from ui

### DIFF
--- a/lib/covenants/ownership.js
+++ b/lib/covenants/ownership.js
@@ -137,12 +137,13 @@ class Ownership extends BNSOwnership {
     const br = bio.read(raw);
     const version = br.readU8();
 
-    if (version > 31)
+    if (version > consensus.MAX_WITNESS_PROGRAM_VERSION)
       return null;
 
     const size = br.readU8();
 
-    if (size < 2 || size > 40)
+    if (size < consensus.MIN_WITNESS_PROGRAM_SIZE
+        || size > consensus.MAX_WITNESS_PROGRAM_SIZE)
       return null;
 
     const hash = br.readBytes(size);

--- a/lib/covenants/rules.js
+++ b/lib/covenants/rules.js
@@ -960,11 +960,12 @@ rules.hasSaneCovenants = function hasSaneCovenants(tx) {
         const hash = covenant.items[3];
 
         // Todo: Add policy rule for high versions.
-        if (version > 31)
+        if (version > consensus.MAX_WITNESS_PROGRAM_VERSION)
           return false;
 
         // Must obey address size limits.
-        if (hash.length < 2 || hash.length > 40)
+        if (hash.length < consensus.MIN_WITNESS_PROGRAM_SIZE
+            || hash.length > consensus.MAX_WITNESS_PROGRAM_SIZE)
           return false;
 
         break;

--- a/lib/dns/records.js
+++ b/lib/dns/records.js
@@ -10,6 +10,7 @@ const assert = require('bsert');
 const {encoding, wire, util} = require('bns');
 const base32 = require('bs32');
 const {IP, onion} = require('binet');
+const hbech32 = require('../ui/bech32');
 const {bech32} = require('bstring');
 const {Struct} = require('bufio');
 const sha3 = require('bcrypto/lib/sha3');
@@ -1047,7 +1048,7 @@ class Addr extends Struct {
 
   getSize() {
     if (util.equal(this.currency, 'handshake.')) {
-      const {hash} = bech32.decode(this.address);
+      const [,,hash] = hbech32.decode(this.address);
       return 1 + 2 + hash.length;
     }
 
@@ -1064,7 +1065,7 @@ class Addr extends Struct {
 
   write(bw, c) {
     if (util.equal(this.currency, 'handshake.')) {
-      const {hrp, version, hash} = bech32.decode(this.address);
+      const [hrp, version, hash] = bech32.decode(this.address);
 
       assert(hash.length >= 1);
       assert(hash.length <= 128);
@@ -1126,7 +1127,7 @@ class Addr extends Struct {
       const hash = br.readBytes(size);
 
       this.currency = 'handshake.';
-      this.address = bech32.encode(hrp, version, hash);
+      this.address = hbech32.encode(hrp, version, hash);
 
       return this;
     }

--- a/lib/primitives/address.js
+++ b/lib/primitives/address.js
@@ -199,16 +199,9 @@ class Address extends bio.Struct {
    * @returns {Address}
    */
 
-  fromPubkey(key, version) {
-    if (version == null)
-      version = 0;
-
-    if (version === 0) {
-      assert(Buffer.isBuffer(key) && key.length === 33);
-      return this.fromHash(blake2b.digest(key, 20), 0);
-    }
-
-    return null;
+  fromPubkey(key) {
+    assert(Buffer.isBuffer(key) && key.length === 33);
+    return this.fromHash(blake2b.digest(key, 20), 0);
   }
 
   /**
@@ -217,16 +210,9 @@ class Address extends bio.Struct {
    * @returns {Address}
    */
 
-  fromScript(script, version) {
-    if (version == null)
-      version = 0;
-
-    if (version === 0) {
-      assert(script && typeof script.encode === 'function');
-      return this.fromHash(sha3.digest(script.encode()), 0);
-    }
-
-    return null;
+  fromScript(script) {
+    assert(script && typeof script.encode === 'function');
+    return this.fromHash(sha3.digest(script.encode()), 0);
   }
 
   /**
@@ -251,15 +237,14 @@ class Address extends bio.Struct {
    * Inject properties from witness.
    * @private
    * @param {Witness} witness
-   * @param {Number} version
    */
 
-  fromWitness(witness, version) {
+  fromWitness(witness) {
     const [, pk] = witness.getPubkeyhashInput();
 
     if (pk) {
       this.hash = blake2b.digest(pk, 20);
-      this.version = version ? version : 0;
+      this.version = 0;
       return this;
     }
 
@@ -267,7 +252,7 @@ class Address extends bio.Struct {
 
     if (redeem) {
       this.hash = sha3.digest(redeem);
-      this.version = version ? version : 0;
+      this.version = 0;
       return this;
     }
 
@@ -314,16 +299,9 @@ class Address extends bio.Struct {
    * @returns {Address}
    */
 
-  fromPubkeyhash(hash, version) {
-    if (version == null)
-      version = 0;
-
-    if (version === 0) {
-      assert(hash && hash.length === 20, 'P2WPKH must be 20 bytes.');
-      return this.fromHash(hash, 0);
-    }
-
-    return null;
+  fromPubkeyhash(hash) {
+    assert(hash && hash.length === 20, 'P2WPKH must be 20 bytes.');
+    return this.fromHash(hash, 0);
   }
 
   /**
@@ -333,16 +311,9 @@ class Address extends bio.Struct {
    * @returns {Address}
    */
 
-  fromScripthash(hash, version) {
-    if (version == null)
-      version = 0;
-
-    if (version === 0) {
-      assert(hash && hash.length === 32, 'P2WSH must be 32 bytes.');
-      return this.fromHash(hash, 0);
-    }
-
-    return null;
+  fromScripthash(hash) {
+    assert(hash && hash.length === 32, 'P2WSH must be 32 bytes.');
+    return this.fromHash(hash, 0);
   }
 
   /**
@@ -375,12 +346,8 @@ class Address extends bio.Struct {
    * @returns {Boolean}
    */
 
-  isPubkeyhash(version) {
-    if (version == null)
-      version = 0;
-
-    return this.version === version
-      && this.hash.length === 20;
+  isPubkeyhash() {
+    return this.version === 0 && this.hash.length === 20;
   }
 
   /**
@@ -388,12 +355,8 @@ class Address extends bio.Struct {
    * @returns {Boolean}
    */
 
-  isScripthash(version) {
-    if (version == null)
-      version = 0;
-
-    return this.version === version
-      && this.hash.length === 32;
+  isScripthash() {
+    return this.version === 0 && this.hash.length === 32;
   }
 
   /**
@@ -542,8 +505,8 @@ class Address extends bio.Struct {
    * @returns {Address}
    */
 
-  static fromPubkeyhash(hash, version) {
-    return new this().fromPubkeyhash(hash, version);
+  static fromPubkeyhash(hash) {
+    return new this().fromPubkeyhash(hash);
   }
 
   /**
@@ -552,8 +515,8 @@ class Address extends bio.Struct {
    * @returns {Address}
    */
 
-  static fromScripthash(hash, version) {
-    return new this().fromScripthash(hash, version);
+  static fromScripthash(hash) {
+    return new this().fromScripthash(hash);
   }
 
   /**

--- a/lib/primitives/address.js
+++ b/lib/primitives/address.js
@@ -8,7 +8,7 @@
 
 const assert = require('bsert');
 const bio = require('bufio');
-const {bech32} = require('bstring');
+const bech32 = require('../ui/bech32');
 const blake2b = require('bcrypto/lib/blake2b');
 const sha3 = require('bcrypto/lib/sha3');
 const Network = require('../protocol/network');
@@ -182,8 +182,9 @@ class Address extends bio.Struct {
     const version = this.version;
     const hash = this.hash;
 
-    assert(version <= 31);
-    assert(hash.length >= 2 && hash.length <= 40);
+    assert(version <= consensus.MAX_WITNESS_PROGRAM_VERSION);
+    assert(hash.length >= consensus.MIN_WITNESS_PROGRAM_SIZE
+      && hash.length <= consensus.MAX_WITNESS_PROGRAM_SIZE);
 
     network = Network.get(network);
 
@@ -198,9 +199,16 @@ class Address extends bio.Struct {
    * @returns {Address}
    */
 
-  fromPubkey(key) {
-    assert(Buffer.isBuffer(key) && key.length === 33);
-    return this.fromHash(blake2b.digest(key, 20), 0);
+  fromPubkey(key, version) {
+    if (version == null)
+      version = 0;
+
+    if (version === 0) {
+      assert(Buffer.isBuffer(key) && key.length === 33);
+      return this.fromHash(blake2b.digest(key, 20), 0);
+    }
+
+    return null;
   }
 
   /**
@@ -209,9 +217,16 @@ class Address extends bio.Struct {
    * @returns {Address}
    */
 
-  fromScript(script) {
-    assert(script && typeof script.encode === 'function');
-    return this.fromHash(sha3.digest(script.encode()), 0);
+  fromScript(script, version) {
+    if (version == null)
+      version = 0;
+
+    if (version === 0) {
+      assert(script && typeof script.encode === 'function');
+      return this.fromHash(sha3.digest(script.encode()), 0);
+    }
+
+    return null;
   }
 
   /**
@@ -225,25 +240,26 @@ class Address extends bio.Struct {
   fromString(data, network) {
     assert(typeof data === 'string');
 
-    const addr = bech32.decode(data);
+    const [hrp, version, hash] = bech32.decode(data);
 
-    Network.fromAddress(addr.hrp, network);
+    Network.fromAddress(hrp, network);
 
-    return this.fromHash(addr.hash, addr.version);
+    return this.fromHash(hash, version);
   }
 
   /**
    * Inject properties from witness.
    * @private
    * @param {Witness} witness
+   * @param {Number} version
    */
 
-  fromWitness(witness) {
+  fromWitness(witness, version) {
     const [, pk] = witness.getPubkeyhashInput();
 
     if (pk) {
       this.hash = blake2b.digest(pk, 20);
-      this.version = 0;
+      this.version = version ? version : 0;
       return this;
     }
 
@@ -251,7 +267,7 @@ class Address extends bio.Struct {
 
     if (redeem) {
       this.hash = sha3.digest(redeem);
-      this.version = 0;
+      this.version = version ? version : 0;
       return this;
     }
 
@@ -273,8 +289,12 @@ class Address extends bio.Struct {
     assert(Buffer.isBuffer(hash));
     assert((version & 0xff) === version);
 
-    assert(version >= 0 && version <= 31, 'Bad program version.');
-    assert(hash.length >= 2 && hash.length <= 40, 'Hash is the wrong size.');
+    assert(version >= consensus.MIN_WITNESS_PROGRAM_VERSION
+      && version <= consensus.MAX_WITNESS_PROGRAM_VERSION,
+      'Bad program version.');
+    assert(hash.length >= consensus.MIN_WITNESS_PROGRAM_SIZE
+      && hash.length <= consensus.MAX_WITNESS_PROGRAM_SIZE,
+      'Hash is the wrong size.');
 
     if (version === 0) {
       assert(hash.length === 20 || hash.length === 32,
@@ -294,9 +314,16 @@ class Address extends bio.Struct {
    * @returns {Address}
    */
 
-  fromPubkeyhash(hash) {
-    assert(hash && hash.length === 20, 'P2WPKH must be 20 bytes.');
-    return this.fromHash(hash, 0);
+  fromPubkeyhash(hash, version) {
+    if (version == null)
+      version = 0;
+
+    if (version === 0) {
+      assert(hash && hash.length === 20, 'P2WPKH must be 20 bytes.');
+      return this.fromHash(hash, 0);
+    }
+
+    return null;
   }
 
   /**
@@ -306,9 +333,16 @@ class Address extends bio.Struct {
    * @returns {Address}
    */
 
-  fromScripthash(hash) {
-    assert(hash && hash.length === 32, 'P2WSH must be 32 bytes.');
-    return this.fromHash(hash, 0);
+  fromScripthash(hash, version) {
+    if (version == null)
+      version = 0;
+
+    if (version === 0) {
+      assert(hash && hash.length === 32, 'P2WSH must be 32 bytes.');
+      return this.fromHash(hash, 0);
+    }
+
+    return null;
   }
 
   /**
@@ -320,7 +354,9 @@ class Address extends bio.Struct {
    */
 
   fromProgram(version, hash) {
-    assert(version >= 0, 'Bad version for witness program.');
+    assert(version >= consensus.MIN_WITNESS_PROGRAM_VERSION
+      && version <= consensus.MAX_WITNESS_PROGRAM_VERSION,
+      'Bad version for witness program.');
     return this.fromHash(hash, version);
   }
 
@@ -339,8 +375,12 @@ class Address extends bio.Struct {
    * @returns {Boolean}
    */
 
-  isPubkeyhash() {
-    return this.version === 0 && this.hash.length === 20;
+  isPubkeyhash(version) {
+    if (version == null)
+      version = 0;
+
+    return this.version === version
+      && this.hash.length === 20;
   }
 
   /**
@@ -348,8 +388,12 @@ class Address extends bio.Struct {
    * @returns {Boolean}
    */
 
-  isScripthash() {
-    return this.version === 0 && this.hash.length === 32;
+  isScripthash(version) {
+    if (version == null)
+      version = 0;
+
+    return this.version === version
+      && this.hash.length === 32;
   }
 
   /**
@@ -384,10 +428,12 @@ class Address extends bio.Struct {
   isValid() {
     assert(this.version >= 0);
 
-    if (this.version > 31)
+    if (this.version > consensus.MAX_WITNESS_PROGRAM_VERSION)
       return false;
 
-    if (this.hash.length < 2 || this.hash.length > 40)
+    const hash = this.hash;
+    if (hash.length < consensus.MIN_WITNESS_PROGRAM_SIZE
+        || hash.length > consensus.MAX_WITNESS_PROGRAM_SIZE)
       return false;
 
     return true;
@@ -423,10 +469,11 @@ class Address extends bio.Struct {
 
   read(br) {
     const version = br.readU8();
-    assert(version <= 31);
+    assert(version <= consensus.MAX_WITNESS_PROGRAM_VERSION);
 
     const size = br.readU8();
-    assert(size >= 2 && size <= 40);
+    assert(size >= consensus.MIN_WITNESS_PROGRAM_SIZE
+      && size <= consensus.MAX_WITNESS_PROGRAM_SIZE);
 
     const hash = br.readBytes(size);
 
@@ -495,8 +542,8 @@ class Address extends bio.Struct {
    * @returns {Address}
    */
 
-  static fromPubkeyhash(hash) {
-    return new this().fromPubkeyhash(hash);
+  static fromPubkeyhash(hash, version) {
+    return new this().fromPubkeyhash(hash, version);
   }
 
   /**
@@ -505,8 +552,8 @@ class Address extends bio.Struct {
    * @returns {Address}
    */
 
-  static fromScripthash(hash) {
-    return new this().fromScripthash(hash);
+  static fromScripthash(hash, version) {
+    return new this().fromScripthash(hash, version);
   }
 
   /**

--- a/lib/primitives/airdropkey.js
+++ b/lib/primitives/airdropkey.js
@@ -5,6 +5,7 @@
 const assert = require('bsert');
 const bio = require('bufio');
 const bech32 = require('../ui/bech32');
+const networks = require('../protocol/networks');
 const BLAKE2b = require('bcrypto/lib/blake2b');
 const SHA256 = require('bcrypto/lib/sha256');
 const rsa = require('bcrypto/lib/rsa');
@@ -302,9 +303,9 @@ class AirdropKey extends bio.Struct {
 
     const [hrp, version, hash] = bech32.decode(addr);
 
-    assert(hrp === 'hs'
-        || hrp === 'ts'
-        || hrp === 'rs');
+    assert(hrp === networks.main.addressPrefix
+        || hrp === networks.testnet.addressPrefix
+        || hrp === networks.regtest.addressPrefix);
     assert(version === 0);
     assert(hash.length === 20
         || hash.length === 32);

--- a/lib/primitives/airdropkey.js
+++ b/lib/primitives/airdropkey.js
@@ -4,7 +4,7 @@
 
 const assert = require('bsert');
 const bio = require('bufio');
-const {bech32} = require('bstring');
+const bech32 = require('../ui/bech32');
 const BLAKE2b = require('bcrypto/lib/blake2b');
 const SHA256 = require('bcrypto/lib/sha256');
 const rsa = require('bcrypto/lib/rsa');
@@ -300,18 +300,18 @@ class AirdropKey extends bio.Struct {
     assert(Number.isSafeInteger(value) && value >= 0);
     assert(typeof sponsor === 'boolean');
 
-    const data = bech32.decode(addr);
+    const [hrp, version, hash] = bech32.decode(addr);
 
-    assert(data.hrp === 'hs'
-        || data.hrp === 'ts'
-        || data.hrp === 'rs');
-    assert(data.version === 0);
-    assert(data.hash.length === 20
-        || data.hash.length === 32);
+    assert(hrp === 'hs'
+        || hrp === 'ts'
+        || hrp === 'rs');
+    assert(version === 0);
+    assert(hash.length === 20
+        || hash.length === 32);
 
     this.type = keyTypes.ADDRESS;
-    this.version = data.version;
-    this.address = data.hash;
+    this.version = version;
+    this.address = hash;
     this.value = value;
     this.sponsor = sponsor;
 

--- a/lib/primitives/airdropproof.js
+++ b/lib/primitives/airdropproof.js
@@ -320,10 +320,11 @@ class AirdropProof extends bio.Struct {
     if (this.key.length === 0)
       return false;
 
-    if (this.version > 31)
+    if (this.version > consensus.MAX_WITNESS_PROGRAM_VERSION)
       return false;
 
-    if (this.address.length < 2 || this.address.length > 40)
+    if (this.address.length < consensus.MIN_WITNESS_PROGRAM_SIZE
+        || this.address.length > consensus.MAX_WITNESS_PROGRAM_SIZE)
       return false;
 
     const value = this.getValue();

--- a/lib/protocol/consensus.js
+++ b/lib/protocol/consensus.js
@@ -344,6 +344,38 @@ exports.MAX_SCRIPT_OPS = 201;
 exports.MAX_MULTISIG_PUBKEYS = 20;
 
 /**
+ * Max address data size (consensus).
+ * @const {Number}
+ * @default
+ */
+
+exports.MAX_WITNESS_PROGRAM_SIZE = 64;
+
+/**
+ * Min address data size (consensus).
+ * @const {Number}
+ * @default
+ */
+
+exports.MIN_WITNESS_PROGRAM_SIZE = 2;
+
+/**
+ * Max address version (consensus).
+ * @const {Number}
+ * @default
+ */
+
+exports.MAX_WITNESS_PROGRAM_VERSION = 255;
+
+/**
+ * Min address version (consensus).
+ * @const {Number}
+ * @default
+ */
+
+exports.MIN_WITNESS_PROGRAM_VERSION = 0;
+
+/**
  * A hash of all zeroes.
  * @const {Buffer}
  * @default

--- a/lib/ui/bech32.js
+++ b/lib/ui/bech32.js
@@ -1,0 +1,403 @@
+/*!
+ * hbech32.js - bech32 for hsd
+ * Copyright (c) 2019, Handshake Developers (MIT License).
+ * Copyright (c) 2017-2019, Christopher Jeffrey (MIT License).
+ * https://github.com/bcoin-org/bcrypto
+ *
+ * bech32 without Bitcoin size restrictions.
+ *
+ * Parts of this software are based on lightningnetwork/lnd:
+ *   Copyright (C) 2015-2018 Lightning Labs and The
+ *   Lightning Network Developers.
+ *   https://github.com/lightningnetwork/lnd
+ *
+ * Parts of this software are based on sipa/bech32:
+ *   Copyright (c) 2017, Pieter Wuille (MIT License).
+ *   https://github.com/sipa/bech32
+ *
+ * Resources:
+ *   https://github.com/bitcoin/bips/blob/master/bip-0173.mediawiki
+ *   https://github.com/sipa/bech32/blob/master/ref/c/segwit_addr.c
+ *   https://github.com/bitcoin/bitcoin/blob/master/src/bech32.cpp
+ */
+
+'use strict';
+
+const assert = require('bsert');
+
+/**
+ * Constants
+ */
+
+const POOL128 = Buffer.allocUnsafe(128);
+const CHARSET = 'qpzry9x8gf2tvdw0s3jn54khce6mua7l';
+const TABLE = [
+  -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+  -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+  -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+  15, -1, 10, 17, 21, 20, 26, 30,  7,  5, -1, -1, -1, -1, -1, -1,
+  -1, 29, -1, 24, 13, 25,  9,  8, 23, -1, 18, 22, 31, 27, 19, -1,
+   1,  0,  3, 16, 11, 28, 12, 14,  6,  4,  2, -1, -1, -1, -1, -1,
+  -1, 29, -1, 24, 13, 25,  9,  8, 23, -1, 18, 22, 31, 27, 19, -1,
+   1,  0,  3, 16, 11, 28, 12, 14,  6,  4,  2, -1, -1, -1, -1, -1
+];
+
+/**
+ * Update checksum.
+ * @ignore
+ * @param {Number} chk
+ * @returns {Number}
+ */
+
+function polymod(pre) {
+  const b = pre >>> 25;
+  return ((pre & 0x1ffffff) << 5)
+    ^ (-((b >>> 0) & 1) & 0x3b6a57b2)
+    ^ (-((b >>> 1) & 1) & 0x26508e6d)
+    ^ (-((b >>> 2) & 1) & 0x1ea119fa)
+    ^ (-((b >>> 3) & 1) & 0x3d4233dd)
+    ^ (-((b >>> 4) & 1) & 0x2a1462b3);
+}
+
+/**
+ * Encode hrp and data as a bech32 string.
+ * @param {String} hrp
+ * @param {Buffer} data
+ * @returns {String}
+ */
+
+function serialize(hrp, data) {
+  assert(typeof hrp === 'string');
+  assert(Buffer.isBuffer(data));
+
+  let chk = 1;
+  let i;
+
+  for (i = 0; i < hrp.length; i++) {
+    const ch = hrp.charCodeAt(i);
+
+    if ((ch & 0xff00) || (ch >>> 5) === 0)
+      throw new Error('Invalid bech32 character.');
+
+    chk = polymod(chk) ^ (ch >>> 5);
+  }
+
+  chk = polymod(chk);
+
+  let str = '';
+
+  for (let i = 0; i < hrp.length; i++) {
+    const ch = hrp.charCodeAt(i);
+    chk = polymod(chk) ^ (ch & 0x1f);
+    str += hrp[i];
+  }
+
+  str += '1';
+
+  for (let i = 0; i < data.length; i++) {
+    const ch = data[i];
+
+    if ((ch >>> 5) !== 0) {
+      throw new Error('Invalid bech32 value.');
+    }
+
+    chk = polymod(chk) ^ ch;
+    str += CHARSET[ch];
+  }
+
+  for (let i = 0; i < 6; i++)
+    chk = polymod(chk);
+
+  chk ^= 1;
+
+  for (let i = 0; i < 6; i++)
+    str += CHARSET[(chk >>> ((5 - i) * 5)) & 0x1f];
+
+  return str;
+}
+
+/**
+ * Decode a bech32 string.
+ * @param {String} str
+ * @returns {Array} [hrp, data]
+ */
+
+function deserialize(str) {
+  assert(typeof str === 'string');
+
+  let dlen = 0;
+
+  while (dlen < str.length && str[(str.length - 1) - dlen] !== '1')
+    dlen += 1;
+
+  const hlen = str.length - (1 + dlen);
+
+  if (1 + dlen >= str.length || dlen < 6)
+    throw new Error('Invalid bech32 data length.');
+
+  dlen -= 6;
+
+  const data = Buffer.allocUnsafe(dlen);
+
+  let chk = 1;
+  let lower = false;
+  let upper = false;
+  let hrp = '';
+
+  for (let i = 0; i < hlen; i++) {
+    let ch = str.charCodeAt(i);
+
+    if (ch < 0x21 || ch > 0x7e)
+      throw new Error('Invalid bech32 character.');
+
+    if (ch >= 0x61 && ch <= 0x7a) {
+      lower = true;
+    } else if (ch >= 0x41 && ch <= 0x5a) {
+      upper = true;
+      ch = (ch - 0x41) + 0x61;
+    }
+
+    hrp += String.fromCharCode(ch);
+    chk = polymod(chk) ^ (ch >>> 5);
+  }
+
+  chk = polymod(chk);
+
+  let i;
+  for (i = 0; i < hlen; i++)
+    chk = polymod(chk) ^ (str.charCodeAt(i) & 0x1f);
+
+  i += 1;
+
+  while (i < str.length) {
+    const ch = str.charCodeAt(i);
+    const v = (ch & 0xff80) ? -1 : TABLE[ch];
+
+    if (v === -1)
+      throw new Error('Invalid bech32 character.');
+
+    if (ch >= 0x61 && ch <= 0x7a)
+      lower = true;
+    else if (ch >= 0x41 && ch <= 0x5a)
+      upper = true;
+
+    chk = polymod(chk) ^ v;
+
+    if (i + 6 < str.length)
+      data[i - (1 + hlen)] = v;
+
+    i += 1;
+  }
+
+  if (lower && upper)
+    throw new Error('Invalid bech32 casing.');
+
+  if (chk !== 1)
+    throw new Error('Invalid bech32 checksum.');
+
+  return [hrp, data.slice(0, dlen)];
+}
+
+/**
+ * Test whether a string is a bech32 string.
+ * @param {String} str
+ * @returns {Boolean}
+ */
+
+function is(str) {
+  assert(typeof str === 'string');
+
+  try {
+    deserialize(str);
+  } catch (e) {
+    return false;
+  }
+
+  return true;
+}
+
+/**
+ * Convert serialized data to another base.
+ * @param {Buffer} input
+ * @param {Number} i
+ * @param {Buffer} output
+ * @param {Number} j
+ * @param {Number} frombits
+ * @param {Number} tobits
+ * @param {Boolean} pad
+ * @returns {Buffer}
+ */
+
+function convert(input, i, output, j, frombits, tobits, pad) {
+  assert(Buffer.isBuffer(input));
+  assert((i >>> 0) === i);
+  assert(Buffer.isBuffer(output));
+  assert((j >>> 0) === j);
+  assert((frombits & 0xff) === frombits);
+  assert((tobits & 0xff) === tobits);
+  assert(typeof pad === 'boolean');
+  assert(frombits !== 0);
+  assert(tobits !== 0);
+
+  const maxv = (1 << tobits) - 1;
+
+  let acc = 0;
+  let bits = 0;
+
+  for (; i < input.length; i++) {
+    const value = input[i];
+
+    if ((value >>> frombits) !== 0)
+      throw new Error('Invalid bits.');
+
+    acc = (acc << frombits) | value;
+    bits += frombits;
+
+    while (bits >= tobits) {
+      bits -= tobits;
+      output[j++] = (acc >>> bits) & maxv;
+    }
+  }
+
+  if (pad) {
+    if (bits)
+      output[j++] = (acc << (tobits - bits)) & maxv;
+  } else {
+    if (bits >= frombits || ((acc << (tobits - bits)) & maxv))
+      throw new Error('Invalid bits.');
+  }
+
+  assert(j <= output.length);
+
+  return output.slice(0, j);
+}
+
+/**
+ * Calculate size required for bit conversion.
+ * @param {Number} len
+ * @param {Number} frombits
+ * @param {Number} tobits
+ * @param {Boolean} pad
+ * @returns {Number}
+ */
+
+function convertSize(len, frombits, tobits, pad) {
+  assert((len >>> 0) === len);
+  assert((frombits & 0xff) === frombits);
+  assert((tobits & 0xff) === tobits);
+  assert(typeof pad === 'boolean');
+  assert(frombits !== 0);
+  assert(tobits !== 0);
+
+  let size = (len * frombits + (tobits - 1)) / tobits;
+
+  size >>>= 0;
+
+  if (pad)
+    size += 1;
+
+  return size;
+}
+
+/**
+ * Convert serialized data to another base.
+ * @param {Buffer} data
+ * @param {Number} frombits
+ * @param {Number} tobits
+ * @param {Boolean} pad
+ * @returns {Buffer}
+ */
+
+function convertBits(data, frombits, tobits, pad) {
+  assert(Buffer.isBuffer(data));
+
+  const size = convertSize(data.length, frombits, tobits, pad);
+  const out = Buffer.allocUnsafe(size);
+
+  return convert(data, 0, out, 0, frombits, tobits, pad);
+}
+
+/**
+ * Serialize data to bech32 address.
+ * @param {String} hrp
+ * @param {Number} version
+ * @param {Buffer} hash
+ * @returns {String}
+ */
+
+function encode(hrp, version, hash) {
+  assert(typeof hrp === 'string');
+  assert((version & 0xff) === version);
+  assert(Buffer.isBuffer(hash));
+
+  // TODO: figure out max size of encode
+  // to allow for the pool to work
+
+  const out = POOL128;
+  out[0] = version;
+
+  const data = convert(hash, 0, out, 1, 8, 5, true);
+
+  return serialize(hrp, data);
+}
+
+/**
+ * Deserialize data from bech32 address.
+ * @param {String} str
+ * @returns {Array}
+ */
+
+function decode(str) {
+  const [hrp, data] = deserialize(str);
+
+  const version = data[0];
+
+  const hash = convert(data, 1, data, 0, 5, 8, false);
+
+  return [hrp, version, hash];
+}
+
+/**
+ * Test whether a string is a bech32 string.
+ * @param {String} str
+ * @param {Number} version - Maximum version
+ * @param {Number} size - Maximum data size
+ * @returns {Boolean}
+ */
+
+function test(str, version, size) {
+  assert(typeof str === 'string');
+  assert(typeof version === 'number');
+  assert(typeof size === 'number');
+
+  let data;
+
+  try {
+    [, data] = deserialize(str);
+  } catch (e) {
+    return false;
+  }
+
+  if (data.length === 0 || data.length > size)
+    return false;
+
+  if (data[0] < 0 || data[0] > version)
+    return false;
+
+  return true;
+}
+
+/*
+ * Expose
+ */
+
+exports.native = 0;
+exports.serialize = serialize;
+exports.deserialize = deserialize;
+exports.is = is;
+exports.convertBits = convertBits;
+exports.convert = convert;
+exports.encode = encode;
+exports.decode = decode;
+exports.test = test;
+

--- a/test/address-test.js
+++ b/test/address-test.js
@@ -1,10 +1,22 @@
+/**
+ * address-test.js - HNS Address Tests
+ * Copyright (c) 2019, Mark Tyneway (MIT License).
+ * https://github.com/handshake-org/hsd
+ */
+
 /* eslint-env mocha */
 /* eslint prefer-arrow-callback: "off" */
 
 'use strict';
 
 const assert = require('bsert');
+const random = require('bcrypto/lib/random');
 const Address = require('../lib/primitives/address');
+const consensus = require('../lib/protocol/consensus');
+const {
+  MAX_WITNESS_PROGRAM_VERSION,
+  MAX_WITNESS_PROGRAM_SIZE
+} = consensus;
 
 describe('Address', function() {
   it('should match mainnet p2pkh address', () => {
@@ -13,5 +25,45 @@ describe('Address', function() {
     const addr = Address.fromPubkeyhash(p2pkh);
     const expect = 'hs1qd42hrldu5yqee58se4uj6xctm7nk28r70e84vx';
     assert.strictEqual(addr.toString('main'), expect);
+  });
+
+  it('should serialize and deserialize', () => {
+    const data = random.randomBytes(20);
+    const addr = Address.fromPubkeyhash(data);
+    const decoded = Address.decode(addr.encode());
+    assert(addr.equals(decoded));
+    assert.deepEqual(addr.toString(), decoded.toString());
+  });
+
+  it('should allow for valid versions', () => {
+    const data = random.randomBytes(32);
+
+    for (let i = 0; i <= MAX_WITNESS_PROGRAM_VERSION; i++) {
+      const addr = Address.fromHash(data, i);
+      assert.equal(addr.version, i);
+      assert.bufferEqual(addr.hash, data);
+    }
+  });
+
+  it('should throw for invalid versions', () => {
+    const data = random.randomBytes(32);
+    const version = MAX_WITNESS_PROGRAM_VERSION + 1;
+
+    // Too large.
+    assert.throws(() => Address.fromHash(data, version));
+    // Too small.
+    assert.throws(() => Address.fromHash(data, -1));
+  });
+
+  it('should throw for invalid data sizes', () => {
+    const large = MAX_WITNESS_PROGRAM_SIZE + 1;
+    const small = MAX_WITNESS_PROGRAM_SIZE - 1;
+    let data = random.randomBytes(large);
+
+    // Too large
+    assert.throws(() => Address.fromHash(data, 0));
+    // Too small
+    data = random.randomBytes(small);
+    assert.throws(() => Address.fromHash(small, 0));
   });
 });

--- a/test/tx-test.js
+++ b/test/tx-test.js
@@ -242,7 +242,7 @@ describe('TX', function() {
 
     let raw = tx.encode();
     assert.strictEqual(encoding.readU64(raw, 46), 0xdeadbeef);
-    raw[54] = 0x7f;
+    raw[52] = 0x7f;
 
     assert.throws(() => TX.decode(raw));
 
@@ -251,7 +251,7 @@ describe('TX', function() {
 
     raw = tx.encode();
     assert.strictEqual(encoding.readU64(raw, 46), 0x00);
-    raw[54] = 0x80;
+    raw[52] = 0x80;
     assert.throws(() => TX.decode(raw));
   });
 


### PR DESCRIPTION
This pull request defines constants for the min/max address version and the min/max address data size, allowing for more address versions and larger address data size.

The constants defined in `lib/protocol/consensus` are:

- `MAX_WITNESS_PROGRAM_VERSION = 255`
- `MIN_WITNESS_PROGRAM_VERSION = 0`
- `MAX_WITNESS_PROGRAM_SIZE = 64`
- `MIN_WITNESS_PROGRAM_SIZE = 2`

Previously, the witness program size was a consensus rule that lived in the `bech32` library.  [BIP 173](https://github.com/bitcoin/bips/blob/master/bip-0173.mediawiki) defines the min and max values for Bitcoin's use of bech32, Lightning uses much longer bech32 encoded payment invoices.

From `lnd` source code:
```
// NOTE: This method it a slight modification of the method bech32.Decode found
// btcutil, allowing strings to be more than 90 characters.
```

To allow for this, I had to make a similar change to `bcrypto/lib/js/bech32` and vendor it in `hsd/lib/ui`. I am not sure if that is the best place for it to live, maybe it could live in `bcrypto` as a generalized bech32 implementation without any size restrictions.

See:
https://github.com/lightningnetwork/lnd/blob/4d7a151b4763f5893c91c4f6b49316391db17f73/zpay32/bech32.go#L12

Some considerations:

- 256 total address versions should be plenty although it could fracture the anonymity set
- 64 bytes in the address data should be enough for a stealth addressing scheme
- BLS pubkeys are 48 bytes
  - https://github.com/ethereum/eth2.0-specs/blob/dev/specs/bls_signature.md#g1-points
- Large enough to commit to two 32 byte hashes for `OP_RETURN` outputs (version=31)
- Should we allow a larger address data amount and then introduce a policy limit similar to bitcoin?
- Could remove `MIN_WITNESS_PROGRAM_VERSION` and just assume `0`

TODO:
- [x] Make sure all instances of min and max address size are accounted for, ie https://github.com/handshake-org/hsd/blob/af86d4899791601d10212115c80a2f2136fdb004/lib/covenants/ownership.js#L145

This PR also fixes a bug in the `tests/tx-test` where the incorrect bytes were being altered, the test still passed because the test asserts on a throw and it did throw but for the wrong reason. It was supposed to change the output value but it actually changed the address version. Previously it went unseen because it made the address version too large (which throws) but now it falls into the valid range, which no longer caused it to throw.