### PR TITLE
chain: disable goosig after 1 year + 1 month

### DIFF
--- a/lib/blockchain/chain.js
+++ b/lib/blockchain/chain.js
@@ -550,6 +550,24 @@ class Chain extends AsyncEmitter {
             100);
         }
 
+        if (this.height >= this.network.goosigStop) {
+          const key = proof.getKey();
+
+          if (!key) {
+            throw new VerifyError(block,
+              'invalid',
+              'bad-airdrop-format',
+              100);
+          }
+
+          if (key.isGoo()) {
+            throw new VerifyError(block,
+              'invalid',
+              'bad-goosig-disabled',
+              100);
+          }
+        }
+
         // Note: GooSig RSA 1024 is possible to
         // crack as well, but in order to make
         // it safe we would need to include a

--- a/lib/blockchain/chain.js
+++ b/lib/blockchain/chain.js
@@ -556,7 +556,7 @@ class Chain extends AsyncEmitter {
           if (!key) {
             throw new VerifyError(block,
               'invalid',
-              'bad-airdrop-format',
+              'bad-airdrop-proof',
               100);
           }
 

--- a/lib/mempool/mempool.js
+++ b/lib/mempool/mempool.js
@@ -282,6 +282,23 @@ class Mempool extends EventEmitter {
         this.untrackClaim(entry);
     }
 
+    // Remove all GooSig based airdrops from the mempool
+    // when the block one before the height that disables
+    // GooSig is added to the mempool to prevent the
+    // mining of invalid blocks.
+    if (block.height + 1 === this.network.goosigStop) {
+      for (const [hash, entry] of this.airdrops.entries()) {
+        const airdrop = this.getAirdrop(hash);
+        const key = airdrop.getKey();
+
+        if (!key)
+          continue;
+
+        if (key.isGoo())
+          this.untrackAirdrop(entry);
+      }
+    }
+
     this.cache.sync(block.hash);
 
     await this.cache.flush();
@@ -1232,6 +1249,16 @@ class Mempool extends EventEmitter {
 
     if (!proof.isSane())
       throw new VerifyError(proof, 'invalid', 'bad-aidrop-proof', 100);
+
+    if (this.chain.height + 1 >= this.network.goosigStop) {
+      const key = proof.getKey();
+
+      if (!key)
+        throw new VerifyError(proof, 'invalid', 'bad-airdrop-proof', 100);
+
+      if (key.isGoo())
+        throw new VerifyError(proof, 'invalid', 'bad-goosig-disabled', 100);
+    }
 
     if (this.chain.db.field.isSpent(proof.position())) {
       throw new VerifyError(proof,

--- a/lib/mempool/mempool.js
+++ b/lib/mempool/mempool.js
@@ -1254,10 +1254,10 @@ class Mempool extends EventEmitter {
       const key = proof.getKey();
 
       if (!key)
-        throw new VerifyError(proof, 'invalid', 'bad-airdrop-proof', 100);
+        throw new VerifyError(proof, 'invalid', 'bad-airdrop-proof', 0);
 
       if (key.isGoo())
-        throw new VerifyError(proof, 'invalid', 'bad-goosig-disabled', 100);
+        throw new VerifyError(proof, 'invalid', 'bad-goosig-disabled', 0);
     }
 
     if (this.chain.db.field.isSpent(proof.position())) {

--- a/lib/node/spvnode.js
+++ b/lib/node/spvnode.js
@@ -341,6 +341,20 @@ class SPVNode extends Node {
    */
 
   sendAirdrop(proof) {
+    const key = proof.getKey();
+
+    if (!key) {
+      this.emit('error', new Error('Invalid Airdrop.'));
+      return Promise.resolve();
+    }
+
+    if (this.chain.tip.height + 1 >= this.network.goosigStop) {
+      if (key.isGoo()) {
+        this.emit('error', new Error('GooSig disabled.'));
+        return Promise.resolve();
+      }
+    }
+
     return this.broadcast(proof);
   }
 

--- a/lib/protocol/network.js
+++ b/lib/protocol/network.js
@@ -40,6 +40,7 @@ class Network {
     this.genesisBlock = options.genesisBlock;
     this.pow = options.pow;
     this.names = options.names;
+    this.goosigStop = options.goosigStop;
     this.block = options.block;
     this.activationThreshold = options.activationThreshold;
     this.minerWindow = options.minerWindow;

--- a/lib/protocol/networks.js
+++ b/lib/protocol/networks.js
@@ -367,6 +367,19 @@ main.block = {
 };
 
 /**
+ * Block height at which GooSig claims are
+ * disabled. This limits risk associated
+ * with newly discovered cryptography
+ * attacks or social engineering attacks.
+ *
+ * Estimated to be disabled at 1 year +
+ * 1 month from the start of the network
+ * on mainnet.
+ */
+
+main.goosigStop = (365 + 30) * main.pow.blocksPerDay;
+
+/**
  * For versionbits.
  * @const {Number}
  * @default
@@ -627,6 +640,8 @@ testnet.block = {
   slowHeight: 0
 };
 
+testnet.goosigStop = 20 * testnet.pow.blocksPerDay;
+
 testnet.activationThreshold = 1512;
 
 testnet.minerWindow = 2016;
@@ -774,6 +789,8 @@ regtest.block = {
   maxTipAge: 0xffffffff,
   slowHeight: 0
 };
+
+regtest.goosigStop = Number.MAX_SAFE_INTEGER;
 
 regtest.activationThreshold = 108;
 
@@ -926,6 +943,8 @@ simnet.block = {
   maxTipAge: 0xffffffff,
   slowHeight: 0
 };
+
+simnet.goosigStop = Number.MAX_SAFE_INTEGER;
 
 simnet.activationThreshold = 75;
 

--- a/test/disable-goosig-test.js
+++ b/test/disable-goosig-test.js
@@ -1,0 +1,232 @@
+/**
+ * test/disable-goosig-test.js - Test disabling GooSig
+ * Copyright (c) 2020, The Handshake Developers (MIT License).
+ * https://github.com/handshake-org/hsd
+ */
+
+/* eslint-env mocha */
+/* eslint prefer-arrow-callback: "off" */
+
+'use strict';
+
+const assert = require('bsert');
+const fs = require('fs');
+const {resolve} = require('path');
+const random = require('bcrypto/lib/random');
+const FullNode = require('../lib/node/fullnode');
+const SPVNode = require('../lib/node/spvnode');
+const AirdropProof = require('../lib/primitives/airdropproof');
+const BlockTemplate = require('../lib/mining/template');
+const Block = require('../lib/primitives/block');
+const consensus = require('../lib/protocol/consensus');
+const Network = require('../lib/protocol/network');
+const common = require('../lib/blockchain/common');
+const VERIFY_NONE = common.flags.VERIFY_NONE;
+
+const network = Network.get('regtest');
+const PROOF_FILE = resolve(__dirname, 'data', 'airdrop-proof.base64');
+const raw = Buffer.from(fs.readFileSync(PROOF_FILE, 'binary'), 'base64');
+const proof = AirdropProof.decode(raw);
+
+/**
+ * Create a new FullNode with GooSig
+ * disabled at a specific height.
+ * @param {String} type
+ * @returns {FullNode|SPVNode}
+ */
+
+function createNode(type) {
+  if (type === 'spv')
+    return new SPVNode({
+      memory: true,
+      network: 'regtest'
+    });
+
+  return new FullNode({
+    memory: true,
+    network: 'regtest'
+  });
+}
+
+/**
+ * Create a mock block with a
+ * known previous blockhash.
+ * @param {Buffer} prev
+ * @returns {Block}
+ */
+
+function mockBlock(prev) {
+  assert(Buffer.isBuffer(prev));
+  assert(prev.length === 32);
+
+  return new Block({
+    version: 0,
+    prevBlock: prev,
+    merkleRoot: random.randomBytes(32),
+    witnessRoot: random.randomBytes(32),
+    treeRoot: random.randomBytes(32),
+    reservedRoot: random.randomBytes(32),
+    time: 0,
+    bits: network.pow.bits,
+    nonce: 0,
+    extraNonce: random.randomBytes(24),
+    mask: random.randomBytes(32)
+  });
+}
+
+describe('Disable GooSig', function() {
+  let goosigStop;
+
+  before(() => {
+    goosigStop = network.goosigStop;
+    network.goosigStop = 10;
+  });
+
+  after(() => {
+    network.goosigStop = goosigStop;
+  });
+
+  describe('Before Disable', () => {
+    let node;
+
+    before(async () => {
+      node = createNode();
+      await node.open();
+    });
+
+    after(async () => {
+      await node.close();
+    });
+
+    it('should accept GooSig based airdrop in mempool', async () => {
+      assert(node.chain.height < node.network.goosigStop);
+      await node.mempool.addAirdrop(proof);
+      assert.strictEqual(node.mempool.airdrops.size, 1);
+      assert(node.mempool.has(proof.hash()));
+    });
+
+    it('should accept GooSig based airdrop in block', async () => {
+      const block = await node.miner.mineBlock();
+      assert.strictEqual(block.txs[0].inputs.length, 2);
+      assert(await node.chain.add(block));
+    });
+  });
+
+  describe('After Disable', () => {
+    let node;
+
+    before(async () => {
+      node = createNode();
+      await node.open();
+    });
+
+    after(async () => {
+      await node.close();
+    });
+
+    it('should reject GooSig based airdrop in mempool', async () => {
+      while (node.chain.height - 1 < node.network.goosigStop) {
+        const block = await node.miner.mineBlock();
+        assert(await node.chain.add(block));
+      }
+
+      assert.strictEqual(node.chain.height - 1, node.network.goosigStop);
+      await assert.rejects(node.mempool.addAirdrop(proof),
+        {reason: 'bad-goosig-disabled'});
+    });
+
+    it('should reject GooSig based airdrop in block', async () => {
+      const tip = node.chain.tip;
+      const version = await node.chain.computeBlockVersion(tip);
+      const mtp = await node.chain.getMedianTime(tip);
+      const time = Math.max(node.network.now(), mtp + 1);
+      const target = await node.chain.getTarget(time, tip);
+      const root = node.chain.db.treeRoot();
+
+      const template = new BlockTemplate({
+        prevBlock: tip.hash,
+        treeRoot: root,
+        reservedRoot: consensus.ZERO_HASH,
+        height: tip.height + 1,
+        version: version,
+        time: time,
+        bits: target,
+        mtp: mtp
+      });
+
+      template.addAirdrop(proof);
+      template.refresh();
+
+      let block = template.toBlock(), nonce = 0;
+      while (!block.verifyPOW()) {
+        const proof = template.getProof(nonce++, time, consensus.ZERO_NONCE, consensus.ZERO_HASH);
+        block = template.commit(proof);
+      }
+
+      await assert.rejects(node.chain.add(block),
+        {reason: 'bad-goosig-disabled'});
+    });
+  });
+
+  describe('Clear Mempool', () => {
+    let node;
+
+    before(async () => {
+      node = createNode();
+      await node.open();
+      await node.mempool.addAirdrop(proof);
+    });
+
+    after(async () => {
+      await node.close();
+    });
+
+    it('should remove GooSig based airdrop', async () => {
+      assert.strictEqual(node.mempool.airdrops.size, 1);
+      assert(node.mempool.has(proof.hash()));
+
+      while (node.chain.height < node.network.goosigStop) {
+        const block = await node.miner.mineBlock();
+        assert(await node.chain.add(block));
+      }
+
+      assert.strictEqual(node.mempool.has(proof.hash()), false);
+      assert.strictEqual(node.mempool.airdrops.size, 0);
+    });
+  });
+
+  describe('SPV', () => {
+    let node;
+
+    before(async () => {
+      node = createNode('spv');
+      await node.open();
+    });
+
+    after(async () => {
+      await node.close();
+    });
+
+    it('should not send airdrop after', async () => {
+      const genesis = await node.chain.getEntryByHeight(0);
+
+      let err = null;
+      node.once('error', (error) => {
+        err = error;
+      });
+
+      let prev = genesis.hash;
+      while (node.chain.height < node.network.goosigStop) {
+        const block = mockBlock(prev);
+        await node.chain.add(block, VERIFY_NONE);
+        prev = block.hash();
+      }
+
+      await node.sendAirdrop(proof);
+
+      assert(err);
+      assert.strictEqual(err.message, 'GooSig disabled.');
+    });
+  });
+});
+

--- a/test/disable-goosig-test.js
+++ b/test/disable-goosig-test.js
@@ -165,6 +165,9 @@ describe('Disable GooSig', function() {
 
       await assert.rejects(node.chain.add(block),
         {reason: 'bad-goosig-disabled'});
+      // Block was added to invalid cache to
+      // prevent a revalidation attempt.
+      assert(node.chain.hasInvalid(block));
     });
   });
 

--- a/test/disable-goosig-test.js
+++ b/test/disable-goosig-test.js
@@ -131,8 +131,17 @@ describe('Disable GooSig', function() {
       }
 
       assert.strictEqual(node.chain.height - 1, node.network.goosigStop);
-      await assert.rejects(node.mempool.addAirdrop(proof),
-        {reason: 'bad-goosig-disabled'});
+
+      let err;
+      try {
+        await node.mempool.addAirdrop(proof);
+      } catch (e) {
+        err = e;
+      }
+
+      assert.equal(err.type, 'VerifyError');
+      assert.equal(err.reason, 'bad-goosig-disabled');
+      assert.equal(err.score, 0);
     });
 
     it('should reject GooSig based airdrop in block', async () => {
@@ -163,8 +172,17 @@ describe('Disable GooSig', function() {
         block = template.commit(proof);
       }
 
-      await assert.rejects(node.chain.add(block),
-        {reason: 'bad-goosig-disabled'});
+      let err;
+      try {
+        await node.chain.add(block);
+      } catch (e) {
+        err = e;
+      }
+
+      assert.equal(err.type, 'VerifyError');
+      assert.equal(err.reason, 'bad-goosig-disabled');
+      assert.equal(err.score, 100);
+
       // Block was added to invalid cache to
       // prevent a revalidation attempt.
       assert(node.chain.hasInvalid(block));


### PR DESCRIPTION
Edited 1/24/20

Adds a new hard coded deployment that disables GooSig after 1 year and 1 month of blocktime. This is to prevent the cryptography being broken in an unforseen way or a social attack where somebody claims it is broken when it actually isn't.

~~Two~~ One new field is added to `lib/protocol/networks`

- ~~`[network].airdrop.disableGoosig`~~
- ~~`[network].airdrop.disableGoosigHeight`~~
- `[network].goosigStop`

~~I used 2 variables to be very explicit, `disableGoosig` is a boolean and `disableGoosigHeight` is an integer. We could combine them into a single variable using `-1` as `disableGoosig: false` if that is preferred.~~

~~The `DeploymentState` is updated with a new property `goobye` and a getter `hasGooBye`. I wasn't sure what the best name for this deployment is, so I just went with that. Open to suggestions.~~

The functionality is as of follows:

If the network allows for GooSig to be disabled and the height of the previous block is greater than or equal to the hardcoded network height, then disable GooSig.

TODO:

- [x] Figure out correct testnet values