### PR TITLE
testnet: use binet fork with fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,14 +13,14 @@
       }
     },
     "bcrypto": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/bcrypto/-/bcrypto-3.1.0.tgz",
-      "integrity": "sha512-0ZLVyKwBi6UEfRKmIT6V4mhzQ5BhjKWb91GkIhTeaKa4R62Sf87wI/KB9q34IpjSaiH2y9wJO9fDkchvsMTT6A==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/bcrypto/-/bcrypto-4.3.0.tgz",
+      "integrity": "sha512-pxW9QssTb+lCkxbVGFIQQV4sFCR2ODenAL/joYhlgCqL/Jst1ftM4AQiOpPeE+AaEtxOwuN2viUx5+Q/DX6fEQ==",
       "requires": {
         "bsert": "~0.0.10",
         "bufio": "~1.0.6",
         "loady": "~0.0.1",
-        "nan": "^2.13.1"
+        "nan": "^2.14.0"
       }
     },
     "bcurl": {
@@ -82,9 +82,8 @@
       }
     },
     "binet": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/binet/-/binet-0.3.5.tgz",
-      "integrity": "sha512-suogkqXrt63Z76ABvwJjI28w+LWrRE53nwItDPz1VwNjHEuh1+rxudGYtoewFmMhkJ9pW/VGGnjoxP+AGzHgLQ==",
+      "version": "git+https://github.com/Handshake-Protocol/binet.git#1c3ba25dfca662b34325e05fc55b2ab0e884d8c1",
+      "from": "git+https://github.com/Handshake-Protocol/binet.git#1c3ba25dfca662b34325e05fc55b2ab0e884d8c1",
       "requires": {
         "bs32": "~0.1.5",
         "bsert": "~0.0.10"
@@ -115,9 +114,9 @@
       }
     },
     "bmocha": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/bmocha/-/bmocha-2.1.0.tgz",
-      "integrity": "sha512-XZTffEZyPsbyTIT/yjYxU4HShHDM+z4qxzmeOLEQkG+br87cJdoQeAfAc9KpyacJagxS4leSvdvFfgWJaeD0pA==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/bmocha/-/bmocha-2.1.3.tgz",
+      "integrity": "sha512-wKejlSjriBfiYfx3I9ngwLhQ0JY6RNfOJk/E+EsFrSYQOqbYcTKww0L4U94tcPHrkEKsZsIbLZixV2FjN6bdLw==",
       "dev": true
     },
     "bmutex": {
@@ -129,34 +128,34 @@
       }
     },
     "bns": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/bns/-/bns-0.7.0.tgz",
-      "integrity": "sha512-ZDwttQYRCPH/1CCBSr2PeV8Xbq5od1afGM/ZhcJhYkL4MLmh7BTTfRSJxIm/JD9Zzr8natih+qs/TEFQt37AxQ==",
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/bns/-/bns-0.9.0.tgz",
+      "integrity": "sha512-gSp2tmMHjDNMi61GMtL0gHguuw58KlrJVZefYMEwrZuN1rstKW8Ltj9zNhSbr3lETgeZMoNvlT9l01V4U0CfJQ==",
       "requires": {
-        "bcrypto": "~3.1.0",
+        "bcrypto": "~4.3.0",
         "bfile": "~0.2.1",
         "bheep": "~0.1.5",
         "binet": "~0.3.5",
-        "bs32": "~0.1.5",
+        "bs32": "~0.1.6",
         "bsert": "~0.0.10",
         "btcp": "~0.1.5",
         "budp": "~0.1.6",
         "bufio": "~1.0.6",
-        "unbound": "~0.3.4"
+        "unbound": "~0.3.5"
       }
     },
     "brq": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/brq/-/brq-0.1.7.tgz",
-      "integrity": "sha512-mFoSpFJx7pI8IfuNojIul7Bto4Wcp1a7SOj8MTV4Qsd6Jg3leHJFzSlTcnKfG8BIOg46nvEFDXdLmM0v0YwEPQ==",
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/brq/-/brq-0.1.8.tgz",
+      "integrity": "sha512-6SDY1lJMKXgt5TZ6voJQMH2zV1XPWWtm203PSkx3DSg9AYNYuRfOPFSBDkNemabzgpzFW9/neR4YhTvyJml8rQ==",
       "requires": {
         "bsert": "~0.0.10"
       }
     },
     "bs32": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/bs32/-/bs32-0.1.5.tgz",
-      "integrity": "sha512-YR9OXFjx8qmW/TpuJKc1RSdzRogpCYh1ygCSMi5Z3fG2QkP+Ra1IfcHsICqd/I/tmFAtc7ov8BpEyN8HJD7jlw==",
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/bs32/-/bs32-0.1.6.tgz",
+      "integrity": "sha512-usjDesQqZ8ihHXOnOEQuAdymBHnJEfSd+aELFSg1jN/V3iAf12HrylHlRJwIt6DTMmXpBDQ+YBg3Q3DIYdhRgQ==",
       "requires": {
         "bsert": "~0.0.10"
       }
@@ -167,9 +166,9 @@
       "integrity": "sha512-NHNwlac+WPy4t2LoNh8pXk8uaIGH3NSaIUbTTRXGpE2WEbq0te/tDykYHkFK57YKLPjv/aGHmbqvnGeVWDz57Q=="
     },
     "bsip": {
-      "version": "0.1.8",
-      "resolved": "https://registry.npmjs.org/bsip/-/bsip-0.1.8.tgz",
-      "integrity": "sha512-R6rRgLOWjSITqp1C9yzPuPfzKgXANP+5Ip6OoLCIhmaybaVywHhINNfO0L2zFKJgS+vfLHGFltip14bKvTNVGA==",
+      "version": "0.1.9",
+      "resolved": "https://registry.npmjs.org/bsip/-/bsip-0.1.9.tgz",
+      "integrity": "sha512-i7cVEfCthASPB3BYKS/pZN/D4kh4vToIlSAFcVBLNjzYl1UirT3E2PIGSfNnYR2qZ3UW1qnDavrWEHhLeSKt2A==",
       "requires": {
         "bsert": "~0.0.10",
         "loady": "~0.0.1",
@@ -177,9 +176,9 @@
       }
     },
     "bsock": {
-      "version": "0.1.8",
-      "resolved": "https://registry.npmjs.org/bsock/-/bsock-0.1.8.tgz",
-      "integrity": "sha512-+rdqLWVnbYFhUTvgDuzO3KlGYXWOVS2RhRgHrRx26wSiNgmyYJSX4hK+PwtI1hEc9cyIb28Qt/hgPgSrqPlDNw==",
+      "version": "0.1.9",
+      "resolved": "https://registry.npmjs.org/bsock/-/bsock-0.1.9.tgz",
+      "integrity": "sha512-/l9Kg/c5o+n/0AqreMxh2jpzDMl1ikl4gUxT7RFNe3A3YRIyZkiREhwcjmqxiymJSRI/Qhew357xGn1SLw/xEw==",
       "requires": {
         "bsert": "~0.0.10"
       }
@@ -194,9 +193,9 @@
       }
     },
     "bstring": {
-      "version": "0.3.8",
-      "resolved": "https://registry.npmjs.org/bstring/-/bstring-0.3.8.tgz",
-      "integrity": "sha512-OUM7JZMEbam+LA1ZwvkcuHoc+7MzL0uVFH3M3Fyd5Xx8E34eve1WPwWGMLrpZGZ30cpoGnZps0p1zbIY5fSJaw==",
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/bstring/-/bstring-0.3.9.tgz",
+      "integrity": "sha512-D95flI7SXL+UsQi9mW+hH+AK2AFfafIJi+3GbbyTAWMe2FqwR9keBxsjGiGd/JM+77Y9WsC+M4EhZVNVcym9jw==",
       "requires": {
         "bsert": "~0.0.10",
         "loady": "~0.0.1",
@@ -242,23 +241,23 @@
       }
     },
     "bweb": {
-      "version": "0.1.8",
-      "resolved": "https://registry.npmjs.org/bweb/-/bweb-0.1.8.tgz",
-      "integrity": "sha512-xGMDbVf3JnLka7VTWOiy5GMersZcAuUMtd97zs7OUA/rrt2Z8bWVAwzCVPFxVzYMreYu7M+W3NZCJSpUdd7umA==",
+      "version": "0.1.10",
+      "resolved": "https://registry.npmjs.org/bweb/-/bweb-0.1.10.tgz",
+      "integrity": "sha512-3Kkz/rfsyAWUS+8DV5XYhwcgVN4DfDewrP+iFTcpQfdZzcF6+OypAq7dHOtXV0sW7U/3msA/sEEqz0MHZ9ERWg==",
       "requires": {
         "bsert": "~0.0.10",
         "bsock": "~0.1.8"
       }
     },
     "goosig": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/goosig/-/goosig-0.1.0.tgz",
-      "integrity": "sha512-GsWbE8meGIbdOtetMeyALWhw1fF+fxSR40iLziZVI19GqSl8mYNBmZOdMIYsjx+oPfcENCPtoB72vwpKA205Gg==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/goosig/-/goosig-0.4.0.tgz",
+      "integrity": "sha512-x8LMPJFDjLUExQ1D83vt5r583RiZSRUX19xwJxVDWEv+PRCipxq0PRKCMN5lzNybI6zOkbbA4zfWwEiXk3oGsQ==",
       "requires": {
-        "bcrypto": "~3.1.0",
+        "bcrypto": "~4.3.0",
         "bsert": "~0.0.10",
         "loady": "~0.0.1",
-        "nan": "^2.13.1"
+        "nan": "^2.14.0"
       }
     },
     "hs-client": {
@@ -287,19 +286,19 @@
       }
     },
     "n64": {
-      "version": "0.2.9",
-      "resolved": "https://registry.npmjs.org/n64/-/n64-0.2.9.tgz",
-      "integrity": "sha512-Fr71HDRSClfgPloQupVBHTx5k8PXyw4yLBj3Q7/C4qhS4r5hWrjScuZg1qCDWqzHf0vxSq8lXbinb6T0oPLdHA=="
+      "version": "0.2.10",
+      "resolved": "https://registry.npmjs.org/n64/-/n64-0.2.10.tgz",
+      "integrity": "sha512-uH9geV4+roR1tohsrrqSOLCJ9Mh1iFcDI+9vUuydDlDxUS1UCAWUfuGb06p3dj3flzywquJNrGsQ7lHP8+4RVQ=="
     },
     "nan": {
-      "version": "2.13.2",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.13.2.tgz",
-      "integrity": "sha512-TghvYc72wlMGMVMluVo9WRJc0mB8KxxF/gZ4YYFy7V2ZQX9l7rgbPg7vjS9mt6U5HXODVFVI2bOduCzwOMv/lw=="
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
+      "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg=="
     },
     "unbound": {
-      "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/unbound/-/unbound-0.3.4.tgz",
-      "integrity": "sha512-jAI0xItAEXCGD3zFJdCj/eLZo1lAMuDSsWKincMUeKdDXO5HI4nxk0U+PBz0QFyGhTmj+O18Zpc0IUWzKKEUZA==",
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/unbound/-/unbound-0.3.5.tgz",
+      "integrity": "sha512-vnIkZGQswi7SVEnGI+25+oN9hLA7rc40zWi+xnzEwktNIZFtAC8PB/e5FMWgFoXUC4p2Jb/ZRNsZDcv3vivH+g==",
       "optional": true,
       "requires": {
         "loady": "~0.0.1",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "bfile": "~0.2.1",
     "bfilter": "~1.0.5",
     "bheep": "~0.1.5",
-    "binet": "~0.3.5",
+    "binet": "git+https://github.com/Handshake-Protocol/binet.git#1c3ba25dfca662b34325e05fc55b2ab0e884d8c1",
     "blgr": "~0.1.7",
     "blru": "~0.1.6",
     "blst": "~0.1.5",


### PR DESCRIPTION
Use a community managed [binet fork](https://github.com/Handshake-Protocol/binet) using a git repository similar to the proposed method in `bcoin` here: https://github.com/bcoin-org/bcoin/pull/910/

I am using a specific git hash instead of cutting a new release of binet because it is expected that more binet updates will be coming soon. We can cut a release when we have everything merged that we need.
