### PR TITLE
wallet: mitigate watch only wallet bug for getKey

### DIFF
--- a/lib/wallet/wallet.js
+++ b/lib/wallet/wallet.js
@@ -3483,9 +3483,6 @@ class Wallet extends EventEmitter {
     if (account.accountIndex & HD.common.HARDENED)
       account.accountIndex ^= HD.common.HARDENED;
 
-    // Update the path's account index as well.
-    path.account = account.accountIndex;
-
     return account.derivePath(path, this.master);
   }
 

--- a/lib/wallet/wallet.js
+++ b/lib/wallet/wallet.js
@@ -3468,6 +3468,24 @@ class Wallet extends EventEmitter {
     if (!account)
       return null;
 
+    // The account index in the db may be wrong.
+    // We must read it from the stored xpub to be
+    // sure of its correctness.
+    //
+    // For more details see:
+    // https://github.com/bcoin-org/bcoin/issues/698.
+    //
+    // TODO(boymanjor): remove index manipulation
+    // once the watch-only wallet bug is fixed.
+    account.accountIndex = account.accountKey.childIndex;
+
+    // Unharden the account index, if necessary.
+    if (account.accountIndex & HD.common.HARDENED)
+      account.accountIndex ^= HD.common.HARDENED;
+
+    // Update the path's account index as well.
+    path.account = account.accountIndex;
+
     return account.derivePath(path, this.master);
   }
 
@@ -3777,6 +3795,9 @@ class Wallet extends EventEmitter {
       //
       // For more details see:
       // https://github.com/bcoin-org/bcoin/issues/698.
+      //
+      // TODO(boymanjor): remove index manipulation
+      // once the watch-only wallet bug is fixed.
       path.account = account.accountKey.childIndex;
 
       // Unharden the account index, if necessary.


### PR DESCRIPTION
This PR mitigates a bug which potentially stores an incorrect
account index in the db of watch only wallets. This is only a
patch of a specific API endpoint. It is necessary for recent
work on ledger-app-hns. Specifically, we have implemented
on-device output verification and need to be able to retrieve
a reliable path to verify and skip change outputs.

Future work involves fixing the source of this issue. For more
details see: https://github.com/bcoin-org/bcoin/issues/698.