### PR TITLE
Use fullname (key@IP:port) for keys in HostList map

### DIFF
--- a/lib/net/hostlist.js
+++ b/lib/net/hostlist.js
@@ -1361,7 +1361,7 @@ class HostEntry {
    */
 
   key() {
-    return this.addr.hostname;
+    return this.addr.fullname();
   }
 
   /**

--- a/lib/net/hostlist.js
+++ b/lib/net/hostlist.js
@@ -911,7 +911,7 @@ class HostList {
    */
 
   pushLocal(addr, score) {
-    if (!addr.isRoutable())
+    if (!addr.isRoutable() && this.network.type !== 'regtest')
       return false;
 
     if (this.local.has(addr.hostname))

--- a/lib/net/hostlist.js
+++ b/lib/net/hostlist.js
@@ -454,7 +454,7 @@ class HostList {
   add(addr, src) {
     assert(addr.port !== 0);
 
-    let entry = this.map.get(addr.hostname);
+    let entry = this.map.get(addr.fullname());
 
     if (entry) {
       let penalty = 2 * 60 * 60;
@@ -610,12 +610,12 @@ class HostList {
 
   /**
    * Remove host from host list.
-   * @param {String} hostname
+   * @param {String} fullname
    * @returns {NetAddress}
    */
 
-  remove(hostname) {
-    const entry = this.map.get(hostname);
+  remove(fullname) {
+    const entry = this.map.get(fullname);
 
     if (!entry)
       return null;
@@ -655,11 +655,11 @@ class HostList {
 
   /**
    * Mark host as failed.
-   * @param {String} hostname
+   * @param {String} fullname
    */
 
-  markAttempt(hostname) {
-    const entry = this.map.get(hostname);
+  markAttempt(fullname) {
+    const entry = this.map.get(fullname);
     const now = this.network.now();
 
     if (!entry)
@@ -671,11 +671,11 @@ class HostList {
 
   /**
    * Mark host as successfully connected.
-   * @param {String} hostname
+   * @param {String} fullname
    */
 
-  markSuccess(hostname) {
-    const entry = this.map.get(hostname);
+  markSuccess(fullname) {
+    const entry = this.map.get(fullname);
     const now = this.network.now();
 
     if (!entry)
@@ -687,12 +687,12 @@ class HostList {
 
   /**
    * Mark host as successfully ack'd.
-   * @param {String} hostname
+   * @param {String} fullname
    * @param {Number} services
    */
 
-  markAck(hostname, services) {
-    const entry = this.map.get(hostname);
+  markAck(fullname, services) {
+    const entry = this.map.get(fullname);
 
     if (!entry)
       return;
@@ -914,12 +914,12 @@ class HostList {
     if (!addr.isRoutable() && this.network.type !== 'regtest')
       return false;
 
-    if (this.local.has(addr.hostname))
+    if (this.local.has(addr.fullname()))
       return false;
 
     const local = new LocalAddress(addr, score);
 
-    this.local.set(addr.hostname, local);
+    this.local.set(addr.fullname(), local);
 
     return true;
   }
@@ -966,7 +966,7 @@ class HostList {
    */
 
   markLocal(addr) {
-    const local = this.local.get(addr.hostname);
+    const local = this.local.get(addr.fullname());
 
     if (!local)
       return false;
@@ -1141,12 +1141,12 @@ class HostList {
     for (const addr of json.addrs) {
       const entry = HostEntry.fromJSON(addr, this.network);
 
-      let src = sources.get(entry.src.hostname);
+      let src = sources.get(entry.src.fullname());
 
       // Save some memory.
       if (!src) {
         src = entry.src;
-        sources.set(src.hostname, src);
+        sources.set(src.fullname(), src);
       }
 
       entry.src = src;
@@ -1356,7 +1356,7 @@ class HostEntry {
   }
 
   /**
-   * Get key suitable for a hash table (hostname).
+   * Get key suitable for a hash table (fullname).
    * @returns {String}
    */
 

--- a/lib/net/netaddress.js
+++ b/lib/net/netaddress.js
@@ -52,6 +52,8 @@ class NetAddress extends bio.Struct {
     this.raw = IP.ZERO_IP;
     this.key = ZERO_KEY;
 
+    this._fullname = null;
+
     if (options)
       this.fromOptions(options);
   }
@@ -275,7 +277,9 @@ class NetAddress extends bio.Struct {
    */
 
   fullname() {
-    return IP.toHostname(this.host, this.port, this.key);
+    if (!this._fullname)
+      this._fullname = IP.toHostname(this.host, this.port, this.key);
+    return this._fullname;
   }
 
   /**

--- a/lib/net/netaddress.js
+++ b/lib/net/netaddress.js
@@ -476,7 +476,7 @@ class NetAddress extends bio.Struct {
 
   format() {
     return '<NetAddress:'
-      + ` hostname=${this.hostname}`
+      + ` fullname=${this.fullname()}`
       + ` services=${this.services.toString(2)}`
       + ` date=${util.date(this.time)}`
       + '>';

--- a/lib/net/peer.js
+++ b/lib/net/peer.js
@@ -1951,7 +1951,7 @@ class Peer extends EventEmitter {
   inspect() {
     return '<Peer:'
       + ` handshake=${this.handshake}`
-      + ` host=${this.hostname()}`
+      + ` host=${this.fullname()}`
       + ` outbound=${this.outbound}`
       + ` ping=${this.minPing}`
       + '>';

--- a/lib/net/pool.js
+++ b/lib/net/pool.js
@@ -1524,7 +1524,7 @@ class Pool extends EventEmitter {
     const items = [];
 
     for (const addr of addrs) {
-      if (!peer.addrFilter.added(addr.hostname, 'ascii'))
+      if (!peer.addrFilter.added(addr.fullname(), 'ascii'))
         continue;
 
       items.push(addr);
@@ -1558,7 +1558,7 @@ class Pool extends EventEmitter {
     const services = this.options.getRequiredServices();
 
     for (const addr of addrs) {
-      peer.addrFilter.add(addr.hostname, 'ascii');
+      peer.addrFilter.add(addr.fullname(), 'ascii');
 
       if (!addr.isRoutable())
         continue;

--- a/lib/net/pool.js
+++ b/lib/net/pool.js
@@ -634,7 +634,7 @@ class Pool extends EventEmitter {
 
     if (!secp256k1.publicKeyVerify(addr.key)) {
       this.logger.info('Removing addr - invalid pubkey (%s).', addr.hostname);
-      this.hosts.remove(addr.hostname);
+      this.hosts.remove(addr.fullname());
       return;
     }
 
@@ -1111,7 +1111,7 @@ class Pool extends EventEmitter {
   createOutbound(addr) {
     const peer = Peer.fromOutbound(this.options, addr);
 
-    this.hosts.markAttempt(addr.hostname);
+    this.hosts.markAttempt(addr.fullname());
 
     this.bindPeer(peer);
 
@@ -1319,7 +1319,7 @@ class Pool extends EventEmitter {
     this.logger.info('Connected to %s.', peer.hostname());
 
     if (peer.outbound)
-      this.hosts.markSuccess(peer.hostname());
+      this.hosts.markSuccess(peer.fullname());
 
     this.emit('peer connect', peer);
   }
@@ -1363,7 +1363,7 @@ class Pool extends EventEmitter {
       this.sendSync(peer);
 
     if (peer.outbound) {
-      this.hosts.markAck(peer.hostname(), peer.services);
+      this.hosts.markAck(peer.fullname(), peer.services);
 
       // If we don't have an ack'd
       // loader yet consider it dead.
@@ -3426,7 +3426,7 @@ class Pool extends EventEmitter {
     this.logger.debug('Banning peer (%s).', addr.hostname);
 
     this.hosts.ban(addr.host);
-    this.hosts.remove(addr.hostname);
+    this.hosts.remove(addr.fullname());
 
     if (peer)
       peer.destroy();

--- a/lib/node/rpc.js
+++ b/lib/node/rpc.js
@@ -425,7 +425,7 @@ class RPC extends RPCBase {
         connected: peer.connected,
         addresses: [
           {
-            address: peer.hostname(),
+            address: peer.fullname(),
             connected: peer.outbound
               ? 'outbound'
               : 'inbound'

--- a/lib/protocol/networks.js
+++ b/lib/protocol/networks.js
@@ -852,7 +852,7 @@ regtest.identityKey = Buffer.from(
 
 regtest.selfConnect = true;
 
-regtest.requestMempool = true;
+regtest.requestMempool = false;
 
 regtest.claimPrefix = 'hns-regtest:';
 


### PR DESCRIPTION
Closes https://github.com/handshake-org/hsd/issues/315

This essentially implements Solution 1 as described in the issue. There still may be other attack vectors open, but this should mitigate the black-hole effects of gossiping bad ID keys.

We switch from indexing by `hostname` (`IP:port`) to `fullname` (`key@IP:port`) in some data structures:

#### `HostList`

This is the manager of all available hosts. Internally it has several maps and lists. This PR changes the main map functions `has`, `get` and `set` to index by `fullname` instead of `hostname`. This also required changing `HostEntry.key()` to return `fullname` instead of `hostname`. 

Banned peers are still indexed by IP _only_ -- new ID keys or ports will not allow an attacker to circumvent a ban.

#### `Peer.addrFilter`

This is a Bloom Filter used when sending and receiving `addr` messages to ensure that we don't send a peer an address it already knows about (they sent it to us, or we've already sent it to them in a previous message).

This change means that we will broadcast new ID keys for an address even if the IP and port for that address has already been sent or received. 

#### `PeerList` (`Pool.peers`)

Ok, so - this object DOES NOT change. It will continue to index peers by `hostname`. This will prevent us from connecting more than once to the same `hostname` (`IP:port`), even if we have multiple ID keys for that host.

https://github.com/handshake-org/hsd/blob/c554a6fc15594024b96a4ddc544ff54a0a7cb4f1/lib/net/pool.js#L3265-L3271

#### Other

- A few rpc calls and inspect functions have been modified to print out `fullname` instead of `hostname`.

- `NonceList` (`Pool.nonces`) will remain unchanged - these are the nonces we use in `version` packets to prevent self-connection. Indexing by `hostname` should be fine.

- `TimeData.known` (`Network.time`) will remain unchanged - this is a map of clock-time offsets we use to stay in sync with peers. We don't need ID keys for this since we won't be connecting to more than one peer at the same `IP:port`.

- `HostList.used` and `HostList.fresh` remain unchanged - these are arrays of maps/lists that serve as the "buckets" of hosts. The `used` bucket for each host is still determined ONLY by it's IP address (the murmur3 hash of the IP address or `NetAddress.raw`). The `fresh` bucket also salts that hash with the IP of the peer that _sent us the address_. However, within a single bucket, addresses are indexed by `fullname` (or `HostEntry.key()`). This means that two keys for the same IP address will end up in the same bucket as two distinct hosts.