### PR TITLE
Improve re-insertion of TXs from disconnected blocks into mempool

### DIFF
--- a/lib/mempool/mempool.js
+++ b/lib/mempool/mempool.js
@@ -416,6 +416,8 @@ class Mempool extends EventEmitter {
         continue;
       }
 
+      const view = await this.getCoinView(tx);
+
       let hasLocks = false;
 
       for (const {sequence} of tx.inputs) {
@@ -430,9 +432,17 @@ class Mempool extends EventEmitter {
         continue;
       }
 
+      // In this context "coinbase" means the TX spends from a coinbase output
+      // and so the maturity must be checked. Actual coinbase TXs are never
+      // allowed in the mempool and should not be inserted in the first place.
+      // This exact same check is performed in TX.checkInputs() along with
+      // several other tests we don't need here.
       if (entry.coinbase) {
-        remove.push(hash);
-        continue;
+        for (const {prevout} of tx.inputs) {
+          const inputEntry = view.getEntry(prevout);
+          if (height - inputEntry.height < this.network.coinbaseMaturity)
+            remove.push(hash);
+        }
       }
 
       let hasCovenants = false;

--- a/lib/mempool/mempool.js
+++ b/lib/mempool/mempool.js
@@ -405,9 +405,19 @@ class Mempool extends EventEmitter {
     const remove = [];
     const lockFlags = common.lockFlags.STANDARD_LOCKTIME_FLAGS;
 
-    this.dropClaims();
-    this.dropAirdrops();
     this.contracts.clear();
+
+    for (const entry of this.claims.values()) {
+      // The only thing that might make a Claim invalid when rewinding the
+      // blockchain is the inception time of the signatures in the DNSSEC proof.
+      if (this.chain.tip.time < entry.inception) {
+        // Claim is not still valid, remove from mempool and contract state.
+        this.untrackClaim(entry);
+      } else {
+        // Claim IS still valid, keep in mempool and re-add to contract state.
+        this.contracts.addName(entry.nameHash);
+      }
+    }
 
     for (const [hash, entry] of this.map) {
       const {tx} = entry;

--- a/lib/mempool/mempool.js
+++ b/lib/mempool/mempool.js
@@ -403,6 +403,7 @@ class Mempool extends EventEmitter {
     const hardened = await this.hasHardening();
     const mtp = await this.chain.getMedianTime(this.chain.tip);
     const remove = [];
+    const lockFlags = common.lockFlags.STANDARD_LOCKTIME_FLAGS;
 
     this.dropClaims();
     this.dropAirdrops();
@@ -418,16 +419,7 @@ class Mempool extends EventEmitter {
 
       const view = await this.getCoinView(tx);
 
-      let hasLocks = false;
-
-      for (const {sequence} of tx.inputs) {
-        if (!(sequence & consensus.SEQUENCE_DISABLE_FLAG)) {
-          hasLocks = true;
-          break;
-        }
-      }
-
-      if (hasLocks) {
+      if (!await this.verifyLocks(tx, view, lockFlags)) {
         remove.push(hash);
         continue;
       }

--- a/lib/mempool/mempool.js
+++ b/lib/mempool/mempool.js
@@ -408,9 +408,12 @@ class Mempool extends EventEmitter {
     this.contracts.clear();
 
     for (const entry of this.claims.values()) {
-      // The only thing that might make a Claim invalid when rewinding the
-      // blockchain is the inception time of the signatures in the DNSSEC proof.
-      if (this.chain.tip.time < entry.inception) {
+      // The only things that might make a Claim invalid when rewinding the
+      // blockchain is the inception time of the signatures in the DNSSEC proof
+      // and the historical block committed to by the covenant.
+      if (this.chain.tip.time < entry.inception
+          || entry.commitHeight > this.chain.tip.height
+          || !await this.chain.isMainHash(entry.commitHash)) {
         // Claim is not still valid, remove from mempool and contract state.
         this.untrackClaim(entry);
       } else {

--- a/lib/mempool/mempool.js
+++ b/lib/mempool/mempool.js
@@ -331,13 +331,6 @@ class Mempool extends EventEmitter {
    */
 
   async _removeBlock(block, txs) {
-    if (this.map.size === 0
-        && this.claims.size === 0
-        && this.airdrops.size === 0) {
-      this.tip = block.prevBlock;
-      return;
-    }
-
     const cb = txs[0];
 
     for (let i = 1; i < cb.inputs.length; i++) {

--- a/test/mempool-test.js
+++ b/test/mempool-test.js
@@ -567,6 +567,7 @@ describe('Mempool', function() {
 
       // Unconfirm block into mempool
       await mempool._removeBlock(entry2, block2.txs);
+      await mempool._handleReorg();
 
       // Mempool should contain both TXs
       assert(mempool.hasEntry(tx2.hash()));
@@ -649,6 +650,7 @@ describe('Mempool', function() {
       // Now the block gets disconnected
       await chain.disconnect(entry3);
       await mempool._removeBlock(entry3, block3.txs);
+      await mempool._handleReorg();
 
       // Coinbase spend is back in the mempool
       assert.strictEqual(mempool.map.size, 1);
@@ -725,6 +727,7 @@ describe('Mempool', function() {
       // Now the block gets disconnected
       await chain.disconnect(entry2);
       await mempool._removeBlock(entry2, block2.txs);
+      await mempool._handleReorg();
 
       // Spend is back in the mempool
       assert.strictEqual(mempool.map.size, 1);
@@ -860,6 +863,7 @@ describe('Mempool', function() {
       // Now the block gets disconnected
       await chain.disconnect(entry3);
       await mempool._removeBlock(entry3, block3.txs);
+      await mempool._handleReorg();
 
       // Bid is back in the mempool
       assert.strictEqual(mempool.map.size, 1);


### PR DESCRIPTION
Closes https://github.com/handshake-org/hsd/issues/306

Port of https://github.com/bcoin-org/bcoin/pull/917, although it hasn't been reviewed or merged yet over there. I think this is a bigger concern for Handshake since this codebase will represent 100% of the network, and chain reorgs are more likely on hsd in the early days.

The contextual checks for TXs with covenants re-entering mempool after a block disconnect has already been written in `_handleReorg()`, so for that case I just added a test.

The other cases ported over from bcoin are premature coinbase spends, and premature BIP68 sequence lock spends.

With these contextual checks in place, the "don't remove block if mempool empty" check can be safely removed.