### PR TITLE
Cleaning up Dockerfile with Best Practices

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,13 @@
 FROM node:alpine AS base
 RUN mkdir -p /code
 WORKDIR /code
-CMD "hsd"
+CMD ["hsd"]
 
-RUN apk upgrade --no-cache && \
-    apk add --no-cache bash unbound-dev gmp-dev
+RUN apk add --no-cache bash unbound-dev gmp-dev
 
 COPY package.json \
-     #package-lock.json \
-     /code/
+  #package-lock.json \
+  /code/
 
 # Install build dependencies and compile
 FROM base AS build


### PR DESCRIPTION
Removed the `apt update` command as the best practice way to use a 3rd party Docker image as base layer is to keep the package versions that come with it.  Also might consider pinning the versions of each package added in line 14 to known working versions in the case there's any breaking changes (unlikely with those specific packages so I left it alone.