### PR TITLE
node/rpc: getblock confirmation fixes

### DIFF
--- a/lib/node/rpc.js
+++ b/lib/node/rpc.js
@@ -2867,6 +2867,11 @@ class RPC extends RPCBase {
   async blockToJSON(entry, block, details) {
     const mtp = await this.chain.getMedianTime(entry);
     const next = await this.chain.getNextHash(entry.hash);
+
+    let confirmations = -1;
+    if (await this.chain.isMainChain(entry))
+      confirmations = this.chain.height - entry.height + 1;
+
     const txs = [];
 
     for (const tx of block.txs) {
@@ -2880,7 +2885,7 @@ class RPC extends RPCBase {
 
     return {
       hash: entry.hash.toString('hex'),
-      confirmations: this.chain.height - entry.height + 1,
+      confirmations: confirmations,
       strippedsize: block.getBaseSize(),
       size: block.getSize(),
       weight: block.getWeight(),
@@ -2898,9 +2903,11 @@ class RPC extends RPCBase {
       tx: txs,
       time: entry.time,
       mediantime: mtp,
+      nonce: entry.nonce,
       bits: entry.bits,
       difficulty: toDifficulty(entry.bits),
       chainwork: entry.chainwork.toString('hex', 64),
+      nTx: txs.length,
       previousblockhash: !entry.prevBlock.equals(consensus.ZERO_HASH)
         ? entry.prevBlock.toString('hex')
         : null,

--- a/lib/node/rpc.js
+++ b/lib/node/rpc.js
@@ -2836,9 +2836,13 @@ class RPC extends RPCBase {
     const mtp = await this.chain.getMedianTime(entry);
     const next = await this.chain.getNextHash(entry.hash);
 
+    let confirmations = -1;
+    if (await this.chain.isMainChain(entry))
+      confirmations = this.chain.height - entry.height + 1;
+
     return {
       hash: entry.hash.toString('hex'),
-      confirmations: this.chain.height - entry.height + 1,
+      confirmations: confirmations,
       height: entry.height,
       version: entry.version,
       versionHex: hex32(entry.version),
@@ -2849,7 +2853,8 @@ class RPC extends RPCBase {
       mask: entry.mask.toString('hex'),
       time: entry.time,
       mediantime: mtp,
-      bits: entry.bits,
+      nonce: entry.nonce,
+      bits: hex32(entry.bits),
       difficulty: toDifficulty(entry.bits),
       chainwork: entry.chainwork.toString('hex', 64),
       previousblockhash: !entry.prevBlock.equals(consensus.ZERO_HASH)

--- a/lib/node/rpc.js
+++ b/lib/node/rpc.js
@@ -2904,7 +2904,7 @@ class RPC extends RPCBase {
       time: entry.time,
       mediantime: mtp,
       nonce: entry.nonce,
-      bits: entry.bits,
+      bits: hex32(entry.bits),
       difficulty: toDifficulty(entry.bits),
       chainwork: entry.chainwork.toString('hex', 64),
       nTx: txs.length,

--- a/test/node-rpc-test.js
+++ b/test/node-rpc-test.js
@@ -1,0 +1,134 @@
+/**
+ * test/node-rpc-test.js - Node RPC tests for hsd
+ * Copyright (c) 2020, The Handshake Developers (MIT Licence)
+ * https://github.com/handshake-org/hsd
+ */
+
+/* eslint-env mocha */
+/* eslint prefer-arrow-callback: "off" */
+
+'use strict';
+
+const assert = require('bsert');
+const FullNode = require('../lib/node/fullnode');
+const {NodeClient} = require('hs-client');
+
+const ports = {
+  p2p: 49331,
+  node: 49332,
+  wallet: 49333
+};
+const node = new FullNode({
+  network: 'regtest',
+  apiKey: 'foo',
+  walletAuth: true,
+  memory: true,
+  workers: true,
+  workersSize: 2,
+  port: ports.p2p,
+  httpPort: ports.node
+});
+
+const nclient = new NodeClient({
+  port: ports.node,
+  apiKey: 'foo',
+  timeout: 15000
+});
+
+describe('RPC', function() {
+  this.timeout(15000);
+
+  before(async () => {
+    await node.open();
+    await nclient.open();
+  });
+
+  after(async () => {
+    await nclient.close();
+    await node.close();
+  });
+
+  describe('getblock', function () {
+    it('should rpc getblock', async () => {
+      const {chain} = await nclient.getInfo();
+      const info = await nclient.execute('getblock', [chain.tip]);
+
+      const properties = [
+        'hash', 'confirmations', 'strippedsize',
+        'size', 'weight', 'height', 'version',
+        'versionHex', 'merkleroot', 'witnessroot',
+        'treeroot', 'reservedroot', 'mask',
+        'coinbase', 'tx', 'time', 'mediantime',
+        'nonce', 'bits', 'difficulty', 'chainwork',
+        'nTx', 'previousblockhash', 'nextblockhash'
+      ];
+
+      for (const property of properties)
+        assert(property in info);
+
+      assert.deepEqual(chain.height, info.height);
+      assert.deepEqual(chain.tip, info.hash);
+      assert.deepEqual(chain.treeRoot, info.treeroot);
+    });
+
+    it('should return correct height', async () => {
+      const address = 'rs1qjjpnmnrzfvxgqlqf5j48j50jmq9pyqjz0a7ytz';
+
+      // Mine two blocks.
+      await nclient.execute('generatetoaddress', [2, address]);
+
+      const {chain} = await nclient.getInfo();
+      const info = await nclient.execute('getblock', [chain.tip]);
+
+      // Assert the heights match.
+      assert.deepEqual(chain.height, info.height);
+    });
+
+    it('should return confirmations (main chain)', async () => {
+      const {chain} = await nclient.getInfo();
+
+      const {genesis} = node.network;
+      const hash = genesis.hash.toString('hex');
+
+      const info = await nclient.execute('getblock', [hash]);
+      assert.deepEqual(chain.height, info.confirmations - 1);
+    });
+
+    it('should return confirmations (post reorg)', async () => {
+      // Get the current chain state
+      const {chain} = await nclient.getInfo();
+
+      // Get the chain entry associated with
+      // the genesis block.
+      const {genesis} = node.network;
+      let entry = await node.chain.getEntry(genesis.hash);
+
+      // Reorg from the genesis block.
+      for (let i = 0; i < chain.height + 1; i++) {
+        const block = await node.miner.mineBlock(entry);
+        await node.chain.add(block);
+        entry = await node.chain.getEntry(block.hash());
+      }
+
+      // Call getblock using the previous tip
+      const info = await nclient.execute('getblock', [chain.tip]);
+      assert.deepEqual(info.confirmations, -1);
+    });
+
+    it('should return confirmations (alternate)', async () => {
+      // Get a previous blockheight
+      const height = node.chain.height - 2;
+      assert(height > 0);
+
+      // Get the entry and mine on it.
+      const entry = await node.chain.getEntryByHeight(height);
+
+      const block = await node.miner.mineBlock(entry);
+      assert(await node.chain.add(block));
+
+      const hash = block.hash().toString('hex');
+      const info = await nclient.execute('getblock', [hash]);
+      assert.deepEqual(info.confirmations, -1);
+    });
+  });
+});


### PR DESCRIPTION
Update the node RPC methods `getblock` and `getblockheader` for returning the `confirmations` as `-1` if the block is not in the main chain. There is no way to tell if a block is not in the main chain from the API without these changes.

Closes https://github.com/handshake-org/hsd/issues/312

Port of:
- https://github.com/bcoin-org/bcoin/commit/b9ad073b9bca527b0e6faca8a9f1781d7c68d175
- https://github.com/bcoin-org/bcoin/commit/54b31293ced0f3652651156ea5b285619371ef17
- Additional tests in `test/node-rpc-test` for `signmessagewithprivkey` and `verifymessage`

These changes have already been merged into `bcoin`