### PR TITLE
bugfix: compute witnessRoot if a block is historical (below a checkpoint)

### DIFF
--- a/lib/blockchain/chain.js
+++ b/lib/blockchain/chain.js
@@ -373,7 +373,7 @@ class Chain extends AsyncEmitter {
             true);
         }
 
-        const witnessRoot = block.createMerkleRoot();
+        const witnessRoot = block.createWitnessRoot();
 
         if (!block.witnessRoot.equals(witnessRoot)) {
           throw new VerifyError(block,


### PR DESCRIPTION
Fixes a typo in the `Chain` codepath that minimally verifies blocks that pass `isHistorical()` i.e. are below a checkpoint. This code can not be executed without checkpoints saved in `networks.js` and without setting the `checkpoints: true` option. So, not super urgent for a little while on main net.

Normally we check block headers with `block.checkBody()` as seen here, plus a lot more verification:

https://github.com/handshake-org/hsd/blob/c554a6fc15594024b96a4ddc544ff54a0a7cb4f1/lib/primitives/block.js#L237-L251

Below checkpoints, only the headers are checked so the code in `Chain.verify()` should be like the snippet above.

Will add checkpoint tests soon, but wanted to get this on the board ASAP in case a checkpoint is needed early on in main net.

The effect of this bug is that nodes running with `checkpoints: true` will see _all_ incoming blocks as malleated (the header is valid but the block contents don't match the header). So they will not mark the block invalid but will ban the peer that sent it.