### PR TITLE
node/rpc: fix logger statement

### DIFF
--- a/lib/node/rpc.js
+++ b/lib/node/rpc.js
@@ -2608,7 +2608,7 @@ class RPC extends RPCBase {
       entry = await this.chain._add(block);
     } catch (err) {
       if (err.type === 'VerifyError') {
-        this.logger.warning('RPC block rejected: %s (%s).',
+        this.logger.warning('RPC block rejected: %x (%s).',
           block.hash(), err.reason);
         return `rejected: ${err.reason}`;
       }


### PR DESCRIPTION
Previously this log statement would log a `Buffer`, but it should actually log a `string`. ~~This pull request switches the `block.hash` method to using the `block.toHex` method.~~ This pull request uses the correct string formatting symbol in the logger statement so that a string is logged instead of a stringified `Buffer`.