### PR TITLE
experimental-testnet: update magic

### DIFF
--- a/lib/protocol/networks.js
+++ b/lib/protocol/networks.js
@@ -876,7 +876,7 @@ simnet.seeds = [
   'apms4wvfkere7s4mdhtlkd5szrvzp4ziezg6twyqnyjfkj4ag4vgq@165.22.151.242'
 ];
 
-simnet.magic = 0x473bd012;
+simnet.magic = 0x7461636f;
 
 simnet.port = 15038;
 


### PR DESCRIPTION
The new magic is `taco`, h/t @pinheadmz 

This will prevent problems with peers trying to sync the previous simnet.