### PR TITLE
[consensus] No transactions for the first two weeks

### DIFF
--- a/lib/blockchain/chain.js
+++ b/lib/blockchain/chain.js
@@ -2006,6 +2006,36 @@ class Chain extends AsyncEmitter {
       }
     }
 
+    // Transactions are not allowed in any block before
+    // a certain amount of chainwork has been accumulated.
+    // This a non-malleated, permanently invalid block
+    // and whoever sent it should be banned.
+    if (this.height < this.network.txStart) {
+      let invalid = false;
+
+      // No transactions allowed besides coinbase
+      if (block.txs.length > 1)
+        invalid = true;
+
+      // No claims or airdrops allowed in coinbase yet.
+      const cb = block.txs[0];
+      if (cb.outputs.length > 1)
+        invalid = true;
+
+      // Sanity check
+      if (!cb.outputs[0].covenant.isNone())
+        invalid = true;
+
+      if (invalid) {
+        this.setInvalid(block.hash());
+        throw new VerifyError(block,
+          'invalid',
+          'no-tx-allowed-yet',
+          100,
+          false);
+      }
+    }
+
     // Create a new chain entry.
     const entry = ChainEntry.fromBlock(block, prev);
 

--- a/lib/blockchain/chain.js
+++ b/lib/blockchain/chain.js
@@ -2018,7 +2018,7 @@ class Chain extends AsyncEmitter {
 
     // Transactions are not allowed in any block before
     // a certain amount of chainwork has been accumulated.
-    // This a non-malleated, permanently invalid block
+    // This is a non-malleated, permanently invalid block
     // and whoever sent it should be banned.
     if (prev.height + 1 < this.network.txStart) {
       let invalid = false;

--- a/lib/blockchain/chain.js
+++ b/lib/blockchain/chain.js
@@ -2020,7 +2020,7 @@ class Chain extends AsyncEmitter {
     // a certain amount of chainwork has been accumulated.
     // This a non-malleated, permanently invalid block
     // and whoever sent it should be banned.
-    if (this.height < this.network.txStart) {
+    if (prev.height + 1 < this.network.txStart) {
       let invalid = false;
 
       // No transactions allowed besides coinbase

--- a/lib/blockchain/chain.js
+++ b/lib/blockchain/chain.js
@@ -1686,6 +1686,16 @@ class Chain extends AsyncEmitter {
    */
 
   async saveAlternate(entry, block, prev, flags) {
+    // Do not accept forked chain older than the
+    // last checkpoint.
+    if (this.options.checkpoints) {
+      if (prev.height + 1 < this.network.lastCheckpoint)
+        throw new VerifyError(block,
+          'checkpoint',
+          'bad-fork-prior-to-checkpoint',
+          100);
+    }
+
     try {
       // Do as much verification
       // as we can before saving.

--- a/lib/mempool/mempool.js
+++ b/lib/mempool/mempool.js
@@ -985,6 +985,13 @@ class Mempool extends EventEmitter {
    */
 
   async addClaim(claim, id) {
+    if (this.chain.height < this.network.txStart) {
+      throw new VerifyError(claim,
+        'invalid',
+        'no-tx-allowed-yet',
+        0);
+    }
+
     const hash = claim.hash();
     const unlock = await this.locker.lock(hash);
     try {
@@ -1180,6 +1187,13 @@ class Mempool extends EventEmitter {
    */
 
   async addAirdrop(proof, id) {
+    if (this.chain.height < this.network.txStart) {
+      throw new VerifyError(proof,
+        'invalid',
+        'no-tx-allowed-yet',
+        0);
+    }
+
     const hash = proof.hash();
     const unlock = await this.locker.lock(hash);
     try {
@@ -1321,6 +1335,13 @@ class Mempool extends EventEmitter {
    */
 
   async addTX(tx, id) {
+    if (this.chain.height < this.network.txStart) {
+      throw new VerifyError(tx,
+        'invalid',
+        'no-tx-allowed-yet',
+        0);
+    }
+
     const hash = tx.hash();
     const unlock = await this.locker.lock(hash);
     try {

--- a/lib/mempool/mempool.js
+++ b/lib/mempool/mempool.js
@@ -985,7 +985,7 @@ class Mempool extends EventEmitter {
    */
 
   async addClaim(claim, id) {
-    if (this.chain.height < this.network.txStart) {
+    if (this.chain.height + 1 < this.network.txStart) {
       throw new VerifyError(claim,
         'invalid',
         'no-tx-allowed-yet',
@@ -1187,7 +1187,7 @@ class Mempool extends EventEmitter {
    */
 
   async addAirdrop(proof, id) {
-    if (this.chain.height < this.network.txStart) {
+    if (this.chain.height + 1 < this.network.txStart) {
       throw new VerifyError(proof,
         'invalid',
         'no-tx-allowed-yet',
@@ -1335,7 +1335,7 @@ class Mempool extends EventEmitter {
    */
 
   async addTX(tx, id) {
-    if (this.chain.height < this.network.txStart) {
+    if (this.chain.height + 1 < this.network.txStart) {
       throw new VerifyError(tx,
         'invalid',
         'no-tx-allowed-yet',

--- a/lib/protocol/network.js
+++ b/lib/protocol/network.js
@@ -61,6 +61,7 @@ class Network {
     this.requestMempool = options.requestMempool;
     this.claimPrefix = options.claimPrefix;
     this.time = new TimeData();
+    this.txStart = options.txStart;
 
     this.init();
   }

--- a/lib/protocol/networks.js
+++ b/lib/protocol/networks.js
@@ -215,6 +215,14 @@ main.pow.targetReset = false;
 main.pow.noRetargeting = false;
 
 /**
+ * Prohibit all transactions until
+ * sufficient chainwork has been accumulated.
+ * @const {Number}
+ */
+
+main.txStart = 14 * main.pow.blocksPerDay;
+
+/**
  * Name-related constants.
  * @enum {Number}
  * @default
@@ -223,10 +231,11 @@ main.pow.noRetargeting = false;
 main.names = {
   /**
    * Height at which the auction system activates.
+   * Must be greater or equal to txStart.
    * @const {Number}
    */
 
-  auctionStart: 10 * main.pow.blocksPerDay,
+  auctionStart: 14 * main.pow.blocksPerDay,
 
   /**
    * Interval at which names are rolled out.
@@ -601,6 +610,7 @@ testnet.pow.minActual = (testnet.pow.targetTimespan / 4) >>> 0;
 testnet.pow.maxActual = testnet.pow.targetTimespan * 4;
 testnet.pow.targetReset = true;
 testnet.pow.noRetargeting = false;
+testnet.txStart = 0;
 
 testnet.names = {
   auctionStart: (0.25 * testnet.pow.blocksPerDay) | 0,
@@ -749,6 +759,7 @@ regtest.pow.minActual = (regtest.pow.targetTimespan / 4) >>> 0;
 regtest.pow.maxActual = regtest.pow.targetTimespan * 4;
 regtest.pow.targetReset = true;
 regtest.pow.noRetargeting = true;
+regtest.txStart = 0;
 
 regtest.names = {
   auctionStart: 0,
@@ -901,6 +912,7 @@ simnet.pow.minActual = (simnet.pow.targetTimespan / 4) >>> 0;
 simnet.pow.maxActual = simnet.pow.targetTimespan * 4;
 simnet.pow.targetReset = false;
 simnet.pow.noRetargeting = false;
+simnet.txStart = 0;
 
 simnet.names = {
   auctionStart: 0,

--- a/lib/wallet/wallet.js
+++ b/lib/wallet/wallet.js
@@ -3215,6 +3215,8 @@ class Wallet extends EventEmitter {
     assert(mtx.isSane(), 'TX failed sanity check.');
     assert(mtx.verifyInputs(this.wdb.height + 1, this.network),
       'TX failed context check.');
+    assert(this.wdb.height + 1 >= this.network.txStart,
+      'Transactions are not allowed on network yet.');
 
     // Set the HD paths.
     if (options.paths === true)

--- a/test/chain-test.js
+++ b/test/chain-test.js
@@ -768,7 +768,8 @@ describe('Chain', function() {
 
   describe('Checkpoints', function() {
     before(async () => {
-      const entry = await chain.getEntry(chain.tip.height - 5);
+      const CHECKPOINT = chain.tip.height - 5;
+      const entry = await chain.getEntry(CHECKPOINT);
       assert(Buffer.isBuffer(entry.hash));
       assert(Number.isInteger(entry.height));
 
@@ -782,7 +783,8 @@ describe('Chain', function() {
     });
 
     it('will reject blocks before last checkpoint', async () => {
-      const entry = await chain.getEntry(chain.tip.height - 10);
+      const BEFORE_CHECKPOINT = chain.tip.height - 10;
+      const entry = await chain.getEntry(BEFORE_CHECKPOINT);
       const block = await cpu.mineBlock(entry);
 
       let err = null;
@@ -800,9 +802,9 @@ describe('Chain', function() {
     });
 
     it('will accept blocks after last checkpoint', async () => {
-      const entry = await chain.getEntry(chain.tip.height - 4);
+      const AFTER_CHECKPOINT = chain.tip.height - 4;
+      const entry = await chain.getEntry(AFTER_CHECKPOINT);
       const block = await cpu.mineBlock(entry);
-
       assert(await chain.add(block));
     });
   });

--- a/test/chain-test.js
+++ b/test/chain-test.js
@@ -112,9 +112,14 @@ chain.on('disconnect', (entry, block) => {
 describe('Chain', function() {
   this.timeout(45000);
 
-  it('should open chain and miner', async () => {
+  before(async () => {
     await chain.open();
     await miner.open();
+  });
+
+  after(async () => {
+    await miner.close();
+    await chain.close();
   });
 
   it('should add addrs to miner', async () => {
@@ -761,8 +766,44 @@ describe('Chain', function() {
       'mandatory-script-verify-flag-failed');
   });
 
-  it('should cleanup', async () => {
-    await miner.close();
-    await chain.close();
+  describe('Checkpoints', function() {
+    before(async () => {
+      const entry = await chain.getEntry(chain.tip.height - 5);
+      assert(Buffer.isBuffer(entry.hash));
+      assert(Number.isInteger(entry.height));
+
+      network.checkpointMap[entry.height] = entry.hash;
+      network.lastCheckpoint = entry.height;
+    });
+
+    after(async () => {
+      network.checkpointMap = {};
+      network.lastCheckpoint = 0;
+    });
+
+    it('will reject blocks before last checkpoint', async () => {
+      const entry = await chain.getEntry(chain.tip.height - 10);
+      const block = await cpu.mineBlock(entry);
+
+      let err = null;
+
+      try {
+        await chain.add(block);
+      } catch (e) {
+        err = e;
+      }
+
+      assert(err);
+      assert.equal(err.type, 'VerifyError');
+      assert.equal(err.reason, 'bad-fork-prior-to-checkpoint');
+      assert.equal(err.score, 100);
+    });
+
+    it('will accept blocks after last checkpoint', async () => {
+      const entry = await chain.getEntry(chain.tip.height - 4);
+      const block = await cpu.mineBlock(entry);
+
+      assert(await chain.add(block));
+    });
   });
 });

--- a/test/mempool-test.js
+++ b/test/mempool-test.js
@@ -31,6 +31,7 @@ const workers = new WorkerPool({
 });
 
 const chain = new Chain({
+  network: 'regtest',
   memory: true,
   workers
 });

--- a/test/txstart-test.js
+++ b/test/txstart-test.js
@@ -67,7 +67,7 @@ describe('Disable TXs', function() {
     node.network.txStart = RESET_TXSTART;
   });
 
-  it('should reject TX from mempool before txStart', async () => {
+  it('should reject tx from mempool before txStart', async () => {
     const tx = new TX({
       inputs: [new Input()],
       outputs: [new Output()]
@@ -160,7 +160,7 @@ describe('Disable TXs', function() {
     utxo = block.txs[0].hash();
   });
 
-  it('should add blocks until txStart is reached', async() => {
+  it('should add blocks until one block before txStart', async() => {
     for (let i = node.chain.height; i < node.network.txStart - 1; i++) {
       const block = await node.miner.mineBlock();
       assert(await node.chain.add(block));
@@ -169,7 +169,7 @@ describe('Disable TXs', function() {
     assert.strictEqual(node.chain.height + 1, node.network.txStart);
   });
 
-  it('should allow TX in mempool at txStart height', async () => {
+  it('should allow tx in mempool one block before txStart', async () => {
     lastTX = new TX({
       inputs: [new Input()],
       outputs: [new Output()]
@@ -182,9 +182,10 @@ describe('Disable TXs', function() {
     await node.mempool.addTX(lastTX);
     assert.strictEqual(node.mempool.map.size, 1);
     assert(node.mempool.has(lastTX.hash()));
+    assert.strictEqual(node.chain.height + 1, node.network.txStart);
   });
 
-  it('should allow claim in mempool at txStart height', async () => {
+  it('should allow claim in mempool one block before txStart', async () => {
     const claim = await wallet.fakeClaim('cloudflare');
 
     try {
@@ -195,15 +196,17 @@ describe('Disable TXs', function() {
     }
     assert.strictEqual(node.mempool.claims.size, 1);
     assert(node.mempool.hasClaim(claim.hash()));
+    assert.strictEqual(node.chain.height + 1, node.network.txStart);
   });
 
-  it('should allow airdrop in mempool at txStart height', async () => {
+  it('should allow airdrop in mempool one block before txStart', async () => {
     await node.mempool.addAirdrop(proof);
     assert.strictEqual(node.mempool.airdrops.size, 1);
     assert(node.mempool.hasAirdrop(proof.hash()));
+    assert.strictEqual(node.chain.height + 1, node.network.txStart);
   });
 
-  it('should accept a block full of goodies at txStart height', async() => {
+  it('should accept a block full of goodies at txStart', async() => {
     const block = await node.miner.mineBlock();
     try {
       ownership.ignore = true;

--- a/test/txstart-test.js
+++ b/test/txstart-test.js
@@ -110,6 +110,7 @@ describe('Disable TXs', function() {
 
     await assert.rejects(node.chain.add(block, VERIFY_NONE),
       {reason: 'no-tx-allowed-yet'});
+    assert(node.chain.hasInvalid(block));
   });
 
   it('should reject non-empty block before txStart', async () => {
@@ -133,6 +134,7 @@ describe('Disable TXs', function() {
 
     await assert.rejects(node.chain.add(block, VERIFY_NONE),
       {reason: 'no-tx-allowed-yet'});
+    assert(node.chain.hasInvalid(block));
   });
 
   it('should accept empty block before txStart', async () => {
@@ -152,7 +154,7 @@ describe('Disable TXs', function() {
     block.time = node.chain.tip.time + 3;
     block.bits = await node.chain.getTarget(block.time, node.chain.tip);
 
-    await node.chain.add(block, VERIFY_NONE);
+    assert(await node.chain.add(block, VERIFY_NONE));
 
     // Spend this output later
     utxo = block.txs[0].hash();

--- a/test/txstart-test.js
+++ b/test/txstart-test.js
@@ -1,0 +1,220 @@
+/* eslint-env mocha */
+/* eslint prefer-arrow-callback: "off" */
+
+'use strict';
+
+const assert = require('bsert');
+const fs = require('fs');
+const {resolve} = require('path');
+const FullNode = require('../lib/node/fullnode');
+const TX = require('../lib/primitives/tx');
+const Input = require('../lib/primitives/input');
+const Output = require('../lib/primitives/output');
+const MemWallet = require('./util/memwallet');
+const AirdropProof = require('../lib/primitives/airdropproof');
+const Block = require('../lib/primitives/block');
+const Address = require('../lib/primitives/address');
+const Script = require('../lib/script/script');
+const common = require('../lib/blockchain/common');
+const ownership = require('../lib/covenants/ownership');
+const VERIFY_NONE = common.flags.VERIFY_NONE;
+
+const node = new FullNode({
+  memory: true,
+  network: 'regtest',
+  plugins: [require('../lib/wallet/plugin')]
+});
+
+const RESET_TXSTART = node.network.txStart;
+
+// Ease up that mempool
+node.mempool.options.minRelay = 0;
+node.mempool.options.rejectAbsurdFees = false;
+node.miner.options.minWeight = 1000000;
+
+// Use a valid, working airdrop proof
+const FAUCET_PROOF_FILE = resolve(__dirname, 'data', 'faucet-proof.base64');
+const raw = Buffer.from(fs.readFileSync(FAUCET_PROOF_FILE, 'binary'), 'base64');
+const proof = AirdropProof.decode(raw);
+
+// We only need this for the fakeClaim
+const wallet = new MemWallet({network: 'regtest'});
+node.chain.on('connect', (entry, block) => {
+  wallet.addBlock(entry, block.txs);
+});
+wallet.getNameStatus = async (nameHash) => {
+  assert(Buffer.isBuffer(nameHash));
+  const height = node.chain.height + 1;
+  const state = await node.chain.getNextState();
+  const hardened = state.hasHardening();
+  return node.chain.db.getNameStatus(nameHash, height, hardened);
+};
+
+describe('txStart', function() {
+  let utxo, lastTX;
+
+  before(async () => {
+    node.network.txStart = 5;
+    await node.open();
+
+    // Start with one block for the fakeClaim
+    const block = await node.miner.mineBlock();
+    assert(await node.chain.add(block));
+  });
+
+  after(async () => {
+    await node.close();
+    node.network.txStart = RESET_TXSTART;
+  });
+
+  it('Should reject TX from mempool before txStart', async () => {
+    const tx = new TX({
+      inputs: [new Input()],
+      outputs: [new Output()]
+    });
+    tx.inputs[0].prevout.hash = Buffer.alloc(32, 0x01);
+
+    await assert.rejects(node.mempool.addTX(tx),
+      {reason: 'no-tx-allowed-yet'});
+  });
+
+  it('Should reject Claim from mempool before txStart', async () => {
+    const claim = await wallet.fakeClaim('cloudflare');
+
+    try {
+      ownership.ignore = true;
+      await assert.rejects(node.mempool.addClaim(claim),
+        {reason: 'no-tx-allowed-yet'});
+    } finally {
+      ownership.ignore = false;
+    }
+  });
+
+  it('Should reject Airdrop from mempool before txStart', async () => {
+    await assert.rejects(node.mempool.addAirdrop(proof),
+      {reason: 'no-tx-allowed-yet'});
+  });
+
+  it('Should reject block with >1 coinbase output before txStart', async () => {
+    const tx1 = new TX({
+      inputs: [new Input()],
+      outputs: [new Output(), new Output()]
+    });
+    tx1.locktime = node.chain.height + 1;
+
+    const block = new Block();
+    block.txs.push(tx1);
+    block.prevBlock = node.chain.tip.hash;
+    block.time = node.chain.tip.time + 1;
+    block.bits = await node.chain.getTarget(block.time, node.chain.tip);
+
+    await assert.rejects(node.chain.add(block, VERIFY_NONE),
+      {reason: 'no-tx-allowed-yet'});
+  });
+
+  it('Should reject non-empty block before txStart', async () => {
+    const tx1 = new TX({
+      inputs: [new Input()],
+      outputs: [new Output()]
+    });
+    tx1.locktime = node.chain.height + 1;
+
+    const tx2 = new TX({
+      inputs: [new Input()],
+      outputs: [new Output()]
+    });
+
+    const block = new Block();
+    block.txs.push(tx1);
+    block.txs.push(tx2);
+    block.prevBlock = node.chain.tip.hash;
+    block.time = node.chain.tip.time + 2;
+    block.bits = await node.chain.getTarget(block.time, node.chain.tip);
+
+    await assert.rejects(node.chain.add(block, VERIFY_NONE),
+      {reason: 'no-tx-allowed-yet'});
+  });
+
+  it('Should accept empty block before txStart', async () => {
+    // Create an address that takes literally nothing to spend
+    const addr = Address.fromScript(new Script());
+
+    const tx1 = new TX({
+      inputs: [new Input()],
+      outputs: [new Output()]
+    });
+    tx1.outputs[0].address = addr;
+    tx1.locktime = node.chain.height + 1;
+
+    const block = new Block();
+    block.txs.push(tx1);
+    block.prevBlock = node.chain.tip.hash;
+    block.time = node.chain.tip.time + 3;
+    block.bits = await node.chain.getTarget(block.time, node.chain.tip);
+
+    await node.chain.add(block, VERIFY_NONE);
+
+    // Spend this output later
+    utxo = block.txs[0].hash();
+  });
+
+  it('Should add blocks until txStart is reached', async() => {
+    for (let i = node.chain.height; i < node.network.txStart; i++) {
+      const block = await node.miner.mineBlock();
+      assert(await node.chain.add(block));
+    }
+  });
+
+  it('Should allow TX in mempool after txStart', async () => {
+    lastTX = new TX({
+      inputs: [new Input()],
+      outputs: [new Output()]
+    });
+    lastTX.inputs[0].prevout.hash = utxo;
+    lastTX.inputs[0].prevout.index = 0;
+    lastTX.inputs[0].witness.items[0] = Buffer.from([1, 1]);  // true
+    lastTX.inputs[0].witness.items[1] = Buffer.alloc(0);      // empty script
+
+    await node.mempool.addTX(lastTX);
+    assert.strictEqual(node.mempool.map.size, 1);
+    assert(node.mempool.has(lastTX.hash()));
+  });
+
+  it('Should allow Claim in mempool after txStart', async () => {
+    const claim = await wallet.fakeClaim('cloudflare');
+
+    try {
+      ownership.ignore = true;
+      await node.mempool.addClaim(claim);
+    } finally {
+      ownership.ignore = false;
+    }
+    assert.strictEqual(node.mempool.claims.size, 1);
+    assert(node.mempool.hasClaim(claim.hash()));
+  });
+
+  it('Should allow Airdrop in mempool after txStart', async () => {
+    await node.mempool.addAirdrop(proof);
+    assert.strictEqual(node.mempool.airdrops.size, 1);
+    assert(node.mempool.hasAirdrop(proof.hash()));
+  });
+
+  it('Should accept a block full of goodies after txStart', async() => {
+    const block = await node.miner.mineBlock();
+    try {
+      ownership.ignore = true;
+      assert(await node.chain.add(block));
+    } finally {
+      ownership.ignore = false;
+    }
+
+    assert.strictEqual(block.txs.length, 2);
+    assert.bufferEqual(block.txs[1].hash(), lastTX.hash());
+    assert.strictEqual(block.txs[0].outputs.length, 3);
+    assert(block.txs[0].outputs[0].covenant.isNone());
+    assert(block.txs[0].outputs[1].covenant.isClaim());
+    assert(block.txs[0].outputs[2].covenant.isNone());
+
+    assert.strictEqual(block.txs[0].outputs[2].value, proof.getValue() - proof.fee);
+  });
+});

--- a/test/wallet-test.js
+++ b/test/wallet-test.js
@@ -82,6 +82,13 @@ describe('Wallet', function() {
     await wdb.open();
   });
 
+  it('should add blocks to wdb to pass txStart', async () => {
+    // Because these tests are written for mainnet.
+    while (wdb.height < network.txStart) {
+      await wdb.addBlock(nextBlock(wdb), []);
+    }
+  });
+
   it('should generate new key and address', async () => {
     const wallet = await wdb.create();
 
@@ -1575,5 +1582,64 @@ describe('Wallet', function() {
   it('should cleanup', async () => {
     network.coinbaseMaturity = 2;
     await wdb.close();
+  });
+
+  describe('txStart', function() {
+    const network = Network.get('regtest');
+    const workers = new WorkerPool({ enabled });
+    const wdb = new WalletDB({ network, workers });
+
+    before(async () => {
+      await wdb.open();
+    });
+
+    after(async () => {
+      await wdb.close();
+    });
+
+    it('should only send a TX after network txStart', async () => {
+      // Create wallet and get one address
+      const wallet = await wdb.create();
+      const addr1 = await wallet.receiveAddress();
+
+      // Dummy address for outputs
+      const recAddr = Address.fromHash(Buffer.alloc(20, 1));
+
+      // Add one single, unconfirmed coin to wallet
+      const mtx1 = new MTX();
+      mtx1.addInput(dummyInput());
+      mtx1.addOutput(addr1, 10 * 1e8);
+      const tx1 = mtx1.toTX();
+      await wallet.txdb.add(tx1, null);
+
+      const ACTUAL_TXSTART = wallet.network.txStart;
+      const ACTUAL_HEIGHT = wdb.height;
+
+      try {
+        wallet.network.txStart = 6;
+        wdb.height = 4;
+
+        await assert.rejects(
+          wallet.send({outputs: [{address: recAddr, value: 10000}]}),
+          {message: 'Transactions are not allowed on network yet.'}
+        );
+      } finally {
+        wallet.network.txStart = ACTUAL_TXSTART;
+        wdb.height = ACTUAL_HEIGHT;
+      }
+
+      try {
+        // Transactions are allowed in the NEXT block
+        wallet.network.txStart = 6;
+        wdb.height = 5;
+
+        assert(
+          await wallet.send({outputs: [{address: recAddr, value: 10000}]})
+        );
+      } finally {
+        wallet.network.txStart = ACTUAL_TXSTART;
+        wdb.height = ACTUAL_HEIGHT;
+      }
+    });
   });
 });

--- a/test/wallet-test.js
+++ b/test/wallet-test.js
@@ -1584,7 +1584,7 @@ describe('Wallet', function() {
     await wdb.close();
   });
 
-  describe('txStart', function() {
+  describe('Disable TXs', function() {
     const network = Network.get('regtest');
     const workers = new WorkerPool({ enabled });
     const wdb = new WalletDB({ network, workers });
@@ -1597,7 +1597,7 @@ describe('Wallet', function() {
       await wdb.close();
     });
 
-    it('should only send a TX after network txStart', async () => {
+    it('should only send a tx after network txStart', async () => {
       // Create wallet and get one address
       const wallet = await wdb.create();
       const addr1 = await wallet.receiveAddress();


### PR DESCRIPTION
Before headers-first sync is implemented, full nodes are vulnerable to disk-fill attacks. The simplest solution to this is to reject forks prior to the latest checkpoint. See: https://github.com/bcoin-org/bcoin/pull/764.

This could be especially problematic for a low-work chain without any checkpoints.

In order to build up a decent amount of chainwork and give the developers a chance to release a patch with at least one buried block checkpoint, we've discussed eliminating all transactions for the first two weeks of mainnet.

This PR adds the consensus rule that rejects transactions from the mempool and blockchain for the first 14 days worth of blocks. This also means the original value for `auctionStart` had to be bumped from 10 to 14 days. I set the ban score for relaying transactions to 0, but including in a block to 100 (ban peer immediately).

Tests cover regular transactions as well as name Claims and Airdrop proofs.

The no-forks-prior-to-last-checkpoint rule is also implemented in this PR.

We should probably expect to release a patch for hsd before the 14 day window expires with a checkpoint from day 12 or something...