### PR TITLE
Never activate soft fork deployments (for now)

### DIFF
--- a/lib/protocol/networks.js
+++ b/lib/protocol/networks.js
@@ -392,8 +392,8 @@ main.deployments = {
   hardening: {
     name: 'hardening',
     bit: 0,
-    startTime: 1559347200, // June 1st, 2019
-    timeout: 1654041600, // June 1st, 2022
+    startTime: 0xffffffff,
+    timeout: 0,
     threshold: -1,
     window: -1,
     required: false,
@@ -402,8 +402,8 @@ main.deployments = {
   rollover: {
     name: 'rollover',
     bit: 1,
-    startTime: 1559347200, // June 1st, 2019
-    timeout: 1654041600, // June 1st, 2022
+    startTime: 0xffffffff,
+    timeout: 0,
     threshold: -1,
     window: -1,
     required: false,
@@ -635,8 +635,8 @@ testnet.deployments = {
   hardening: {
     name: 'hardening',
     bit: 0,
-    startTime: 1559347200, // June 1st, 2019
-    timeout: 1654041600, // June 1st, 2022
+    startTime: 0xffffffff,
+    timeout: 0,
     threshold: -1,
     window: -1,
     required: false,
@@ -645,8 +645,8 @@ testnet.deployments = {
   rollover: {
     name: 'rollover',
     bit: 1,
-    startTime: 1559347200, // June 1st, 2019
-    timeout: 1654041600, // June 1st, 2022
+    startTime: 0xffffffff,
+    timeout: 0,
     threshold: -1,
     window: -1,
     required: false,
@@ -783,8 +783,8 @@ regtest.deployments = {
   hardening: {
     name: 'hardening',
     bit: 0,
-    startTime: 1559347200, // June 1st, 2019
-    timeout: 1654041600, // June 1st, 2022
+    startTime: 0xffffffff,
+    timeout: 0,
     threshold: -1,
     window: -1,
     required: false,
@@ -793,8 +793,8 @@ regtest.deployments = {
   rollover: {
     name: 'rollover',
     bit: 1,
-    startTime: 1559347200, // June 1st, 2019
-    timeout: 1654041600, // June 1st, 2022
+    startTime: 0xffffffff,
+    timeout: 0,
     threshold: -1,
     window: -1,
     required: false,
@@ -935,8 +935,8 @@ simnet.deployments = {
   hardening: {
     name: 'hardening',
     bit: 0,
-    startTime: 1559347200, // June 1st, 2019
-    timeout: 1654041600, // June 1st, 2022
+    startTime: 0xffffffff,
+    timeout: 0,
     threshold: -1,
     window: -1,
     required: false,
@@ -945,8 +945,8 @@ simnet.deployments = {
   rollover: {
     name: 'rollover',
     bit: 1,
-    startTime: 1559347200, // June 1st, 2019
-    timeout: 1654041600, // June 1st, 2022
+    startTime: 0xffffffff,
+    timeout: 0,
     threshold: -1,
     window: -1,
     required: false,

--- a/lib/protocol/networks.js
+++ b/lib/protocol/networks.js
@@ -392,8 +392,8 @@ main.deployments = {
   hardening: {
     name: 'hardening',
     bit: 0,
-    startTime: 0xffffffff,
-    timeout: 0,
+    startTime: 0xffffffff, // Feb 7, 2106 (Never, or to be decided)
+    timeout: 0,            // Jan 1, 1970 (Always fail)
     threshold: -1,
     window: -1,
     required: false,
@@ -402,8 +402,8 @@ main.deployments = {
   rollover: {
     name: 'rollover',
     bit: 1,
-    startTime: 0xffffffff,
-    timeout: 0,
+    startTime: 0xffffffff, // Feb 7, 2106 (Never, or to be decided)
+    timeout: 0,            // Jan 1, 1970 (Always fail)
     threshold: -1,
     window: -1,
     required: false,
@@ -635,8 +635,8 @@ testnet.deployments = {
   hardening: {
     name: 'hardening',
     bit: 0,
-    startTime: 0xffffffff,
-    timeout: 0,
+    startTime: 0xffffffff, // Feb 7, 2106 (Never, or to be decided)
+    timeout: 0,            // Jan 1, 1970 (Always fail)
     threshold: -1,
     window: -1,
     required: false,
@@ -645,8 +645,8 @@ testnet.deployments = {
   rollover: {
     name: 'rollover',
     bit: 1,
-    startTime: 0xffffffff,
-    timeout: 0,
+    startTime: 0xffffffff, // Feb 7, 2106 (Never, or to be decided)
+    timeout: 0,            // Jan 1, 1970 (Always fail)
     threshold: -1,
     window: -1,
     required: false,
@@ -783,8 +783,8 @@ regtest.deployments = {
   hardening: {
     name: 'hardening',
     bit: 0,
-    startTime: 0xffffffff,
-    timeout: 0,
+    startTime: 0xffffffff, // Feb 7, 2106 (Never, or to be decided)
+    timeout: 0,            // Jan 1, 1970 (Always fail)
     threshold: -1,
     window: -1,
     required: false,
@@ -793,8 +793,8 @@ regtest.deployments = {
   rollover: {
     name: 'rollover',
     bit: 1,
-    startTime: 0xffffffff,
-    timeout: 0,
+    startTime: 0xffffffff, // Feb 7, 2106 (Never, or to be decided)
+    timeout: 0,            // Jan 1, 1970 (Always fail)
     threshold: -1,
     window: -1,
     required: false,
@@ -935,8 +935,8 @@ simnet.deployments = {
   hardening: {
     name: 'hardening',
     bit: 0,
-    startTime: 0xffffffff,
-    timeout: 0,
+    startTime: 0xffffffff, // Feb 7, 2106 (Never, or to be decided)
+    timeout: 0,            // Jan 1, 1970 (Always fail)
     threshold: -1,
     window: -1,
     required: false,
@@ -945,8 +945,8 @@ simnet.deployments = {
   rollover: {
     name: 'rollover',
     bit: 1,
-    startTime: 0xffffffff,
-    timeout: 0,
+    startTime: 0xffffffff, // Feb 7, 2106 (Never, or to be decided)
+    timeout: 0,            // Jan 1, 1970 (Always fail)
     threshold: -1,
     window: -1,
     required: false,

--- a/test/bip9-chain-test.js
+++ b/test/bip9-chain-test.js
@@ -1,0 +1,122 @@
+/* eslint-env mocha */
+/* eslint prefer-arrow-callback: "off" */
+
+'use strict';
+
+const assert = require('bsert');
+const Chain = require('../lib/blockchain/chain');
+const Miner = require('../lib/mining/miner');
+const Network = require('../lib/protocol/network');
+const common = require('../lib/blockchain/common');
+const thresholdStates = common.thresholdStates;
+
+const network = Network.get('regtest');
+const deployments = network.deployments;
+const activationThreshold = network.activationThreshold;
+const minerWindow = network.minerWindow;
+
+const ACTUAL_START = deployments.hardening.startTime;
+const ACTUAL_TIMEOUT = deployments.hardening.timeout;
+
+const chain = new Chain({
+  memory: true,
+  network
+});
+const miner = new Miner({
+  chain: chain
+});
+
+async function addBIP9Blocks(number, setHardeningBit) {
+  for (let i = 0; i < number; i++) {
+    const entry = await chain.getEntry(chain.tip.hash);
+    const job = await miner.cpu.createJob(entry);
+    if (setHardeningBit)
+      job.attempt.version |= (1 << deployments.hardening.bit);
+    else
+      job.attempt.version = 0;
+    job.refresh();
+    const block = await job.mineAsync();
+    await chain.add(block);
+  }
+};
+
+async function getHardeningState() {
+  const prev = chain.tip;
+  const state = await chain.getState(prev, deployments.hardening);
+  return state;
+};
+
+async function hasHardening() {
+  const state = await chain.getDeployments(chain.tip.time, chain.tip);
+  return state.hasHardening();
+}
+
+describe('BIP9 activation', function() {
+  before(async () => {
+    deployments.hardening.startTime = 0;
+    deployments.hardening.timeout = 0xffffffff;
+
+    await chain.open();
+    await miner.cpu.open();
+  });
+
+  after(async () => {
+    await chain.close();
+    await miner.cpu.close();
+
+    deployments.hardening.startTime = ACTUAL_START;
+    deployments.hardening.timeout = ACTUAL_TIMEOUT;
+  });
+
+  it('should start as DEFINED', async () => {
+    const state = await getHardeningState(chain.tip);
+    assert.strictEqual(state, thresholdStates.DEFINED);
+    assert(!await hasHardening());
+  });
+
+  it('should advance from DEFINED to STARTED', async () => {
+    // This is minus two because block 0 counts as the "first" block.
+    await addBIP9Blocks(minerWindow - 2, true);
+    const state1 = await getHardeningState(chain.tip);
+    assert.strictEqual(state1, thresholdStates.DEFINED);
+    await addBIP9Blocks(1, true);
+    const state2 = await getHardeningState(chain.tip);
+    assert.strictEqual(state2, thresholdStates.STARTED);
+    assert(!await hasHardening());
+  });
+
+  it('should add blocks: does not reach LOCKED_IN', async () => {
+    // Not enough miner support signaled.
+    await addBIP9Blocks(minerWindow - activationThreshold, true);
+    await addBIP9Blocks(activationThreshold - 1, false);
+    const state1 = await getHardeningState(chain.tip);
+    assert.strictEqual(state1, thresholdStates.STARTED);
+    await addBIP9Blocks(1, false);
+    const state2 = await getHardeningState(chain.tip);
+    assert.strictEqual(state2, thresholdStates.STARTED);
+    assert(!await hasHardening());
+  });
+
+  it('should add blocks: reaches LOCKED_IN status', async () => {
+    // Miner support threshold reached.
+    await addBIP9Blocks(minerWindow - activationThreshold, false);
+    await addBIP9Blocks(activationThreshold - 1, true);
+    const state1 = await getHardeningState(chain.tip);
+    assert.strictEqual(state1, thresholdStates.STARTED);
+    await addBIP9Blocks(1, true);
+    const state2 = await getHardeningState(chain.tip);
+    assert.strictEqual(state2, thresholdStates.LOCKED_IN);
+    assert(!await hasHardening());
+  });
+
+  it('should add blocks: reaches ACTIVE status', async () => {
+    // Note that signal bits are unnecessary after lock-in.
+    await addBIP9Blocks(minerWindow - 1, false);
+    const state1 = await getHardeningState(chain.tip);
+    assert.strictEqual(state1, thresholdStates.LOCKED_IN);
+    await addBIP9Blocks(1, false);
+    const state2 = await getHardeningState(chain.tip);
+    assert.strictEqual(state2, thresholdStates.ACTIVE);
+    assert(await hasHardening());
+  });
+});


### PR DESCRIPTION
`hsd` ships on day 1 with two soft forks defined:
- `hardening`: a rule to reject 1024-bit RSA keys from Airdrop proofs
- `rollover`: a rule to require all DNSSEC Claims be signed by the 2017 ICANN key-signing-key, rejecting the 2010 key

Both of these soft forks are designed to activate based on [BIP9 (versionbits)](https://github.com/bitcoin/bips/blob/master/bip-0009.mediawiki)signaling by miners. BIP9 defines the miner-signaling window with `startTime` and `timeout` as UNIX timestamps.

Currently, the start times for main net are set for June 1, 2019. This means that when mainnet launches, both soft forks will activate after three 2-week (aka `minerWindow`) periods:

`DEFINED`->`STARTED`->`LOCKED_IN`->`ACTIVE`

...and so both rules will be enforced at height `6049` (I might be off by one)

At this time we do not know when these soft forks will be necessary to enforce. From the whitepaper:

> In the case that 1024 bit RSA is compromised, we turn to miner consensus to resolve the issue. This allows the blockchain to support RSA-1024 until a practical attack is demonstrated against it.
> ...
> Our primary concern is that ICANN may decide to revoke KSK-2010 at some point by publishing its corresponding private key. To deal with this issue, a final consensus rule can be added to disable KSK-2010 once a separate proof is published which demonstrates that KSK-2017 is now active. 


So this PR is pretty simple: we postpone the `startTime` of our two soft forks until `0xffffffff` (02/07/2106 @ 6:28am UTC) which gives us ample time to accept the initial chain rules. When a soft fork is necessary to deploy, the community can set the `startTime` to a practical value and hopefully miners will upgrade, signal support, and activate the new rules in a timely manner.

Generic BIP9 tests are added, adopted from https://github.com/bcoin-org/bcoin/pull/724 which adds BIP9 signaling statistics to `rpc getblockchaininfo`. I didn't add the new rpc functionality to this PR to keep review simple.


