### PR TITLE
wallet: port various fixes and improvements from bcoin

### DIFF
--- a/lib/node/spvnode.js
+++ b/lib/node/spvnode.js
@@ -7,7 +7,6 @@
 'use strict';
 
 const assert = require('bsert');
-const {Lock} = require('bmutex');
 const NameState = require('../covenants/namestate');
 const Chain = require('../blockchain/chain');
 const Pool = require('../net/pool');
@@ -112,10 +111,6 @@ class SPVNode extends Node {
       noUnbound: this.config.bool('rs-no-unbound')
     });
 
-    this.rescanJob = null;
-    this.scanLock = new Lock();
-    this.watchLock = new Lock();
-
     this.init();
   }
 
@@ -133,9 +128,6 @@ class SPVNode extends Node {
       this.http.on('error', err => this.error(err));
 
     this.pool.on('tx', (tx) => {
-      if (this.rescanJob)
-        return;
-
       this.emit('tx', tx);
     });
 
@@ -144,15 +136,6 @@ class SPVNode extends Node {
     });
 
     this.chain.on('connect', async (entry, block) => {
-      if (this.rescanJob) {
-        try {
-          await this.watchBlock(entry, block);
-        } catch (e) {
-          this.error(e);
-        }
-        return;
-      }
-
       this.emit('connect', entry, block);
     });
 
@@ -220,64 +203,11 @@ class SPVNode extends Node {
    * Scan for any missed transactions.
    * Note that this will replay the blockchain sync.
    * @param {Number|Hash} start - Start block.
-   * @param {Bloom} filter
-   * @param {Function} iter - Iterator.
    * @returns {Promise}
    */
 
-  async scan(start, filter, iter) {
-    const unlock = await this.scanLock.lock();
-    const height = this.chain.height;
-
-    try {
-      await this.chain.replay(start);
-
-      if (this.chain.height < height) {
-        // We need to somehow defer this.
-        // await this.connect();
-        // this.startSync();
-        // await this.watchUntil(height, iter);
-      }
-    } finally {
-      unlock();
-    }
-  }
-
-  /**
-   * Watch the blockchain until a certain height.
-   * @param {Number} height
-   * @param {Function} iter
-   * @returns {Promise}
-   */
-
-  watchUntil(height, iter) {
-    return new Promise((resolve, reject) => {
-      this.rescanJob = new RescanJob(resolve, reject, height, iter);
-    });
-  }
-
-  /**
-   * Handled watched block.
-   * @param {ChainEntry} entry
-   * @param {MerkleBlock} block
-   * @returns {Promise}
-   */
-
-  async watchBlock(entry, block) {
-    const unlock = await this.watchLock.lock();
-    try {
-      if (entry.height < this.rescanJob.height) {
-        await this.rescanJob.iter(entry, block.txs);
-        return;
-      }
-      this.rescanJob.resolve();
-      this.rescanJob = null;
-    } catch (e) {
-      this.rescanJob.reject(e);
-      this.rescanJob = null;
-    } finally {
-      unlock();
-    }
+  async scan(start) {
+    throw new Error('Not implemented.');
   }
 
   /**
@@ -410,19 +340,6 @@ class SPVNode extends Node {
     state.maybeExpire(height, network);
 
     return state;
-  }
-}
-
-/*
- * Helpers
- */
-
-class RescanJob {
-  constructor(resolve, reject, height, iter) {
-    this.resolve = resolve;
-    this.reject = reject;
-    this.height = height;
-    this.iter = iter;
   }
 }
 

--- a/lib/wallet/node.js
+++ b/lib/wallet/node.js
@@ -49,7 +49,6 @@ class WalletNode extends Node {
       memory: this.config.bool('memory'),
       maxFiles: this.config.uint('max-files'),
       cacheSize: this.config.mb('cache-size'),
-      checkpoints: this.config.bool('checkpoints'),
       wipeNoReally: this.config.bool('wipe-no-really'),
       spv: this.config.bool('spv')
     });

--- a/lib/wallet/nodeclient.js
+++ b/lib/wallet/nodeclient.js
@@ -36,18 +36,18 @@ class NodeClient extends AsyncEmitter {
    */
 
   init() {
-    this.node.on('connect', (entry, block) => {
+    this.node.chain.on('connect', async (entry, block) => {
       if (!this.opened)
         return;
 
-      this.emit('block connect', entry, block.txs);
+      await this.emitAsync('block connect', entry, block.txs);
     });
 
-    this.node.on('disconnect', (entry, block) => {
+    this.node.chain.on('disconnect', async (entry, block) => {
       if (!this.opened)
         return;
 
-      this.emit('block disconnect', entry);
+      await this.emitAsync('block disconnect', entry);
     });
 
     this.node.on('tx', (tx) => {

--- a/lib/wallet/nodeclient.js
+++ b/lib/wallet/nodeclient.js
@@ -217,6 +217,9 @@ class NodeClient extends AsyncEmitter {
    */
 
   async rescan(start) {
+    if (this.node.spv)
+      return this.node.chain.reset(start);
+
     return this.node.chain.scan(start, this.filter, (entry, txs) => {
       return this.emitAsync('block rescan', entry, txs);
     });

--- a/lib/wallet/plugin.js
+++ b/lib/wallet/plugin.js
@@ -50,7 +50,6 @@ class Plugin extends EventEmitter {
       memory: this.config.bool('memory', node.memory),
       maxFiles: this.config.uint('max-files'),
       cacheSize: this.config.mb('cache-size'),
-      witness: this.config.bool('witness'),
       wipeNoReally: this.config.bool('wipe-no-really'),
       spv: node.spv
     });

--- a/lib/wallet/plugin.js
+++ b/lib/wallet/plugin.js
@@ -51,7 +51,6 @@ class Plugin extends EventEmitter {
       maxFiles: this.config.uint('max-files'),
       cacheSize: this.config.mb('cache-size'),
       witness: this.config.bool('witness'),
-      checkpoints: this.config.bool('checkpoints'),
       wipeNoReally: this.config.bool('wipe-no-really'),
       spv: node.spv
     });

--- a/lib/wallet/walletdb.js
+++ b/lib/wallet/walletdb.js
@@ -2062,14 +2062,6 @@ class WalletDB extends EventEmitter {
       return 0;
     }
 
-    if (this.options.checkpoints && !this.state.marked) {
-      if (tip.height <= this.network.lastCheckpoint) {
-        // Sync the state to the new tip.
-        await this.setTip(tip);
-        return 0;
-      }
-    }
-
     let total = 0;
 
     for (const tx of txs) {
@@ -2302,7 +2294,6 @@ class WalletOptions {
     this.compression = true;
 
     this.spv = false;
-    this.checkpoints = false;
     this.wipeNoReally = false;
 
     if (options)
@@ -2374,11 +2365,6 @@ class WalletOptions {
     if (options.spv != null) {
       assert(typeof options.spv === 'boolean');
       this.spv = options.spv;
-    }
-
-    if (options.checkpoints != null) {
-      assert(typeof options.checkpoints === 'boolean');
-      this.checkpoints = options.checkpoints;
     }
 
     if (options.wipeNoReally != null) {

--- a/lib/wallet/walletdb.js
+++ b/lib/wallet/walletdb.js
@@ -2062,12 +2062,12 @@ class WalletDB extends EventEmitter {
       return 0;
     }
 
-    // Sync the state to the new tip.
-    await this.setTip(tip);
-
     if (this.options.checkpoints && !this.state.marked) {
-      if (tip.height <= this.network.lastCheckpoint)
+      if (tip.height <= this.network.lastCheckpoint) {
+        // Sync the state to the new tip.
+        await this.setTip(tip);
         return 0;
+      }
     }
 
     let total = 0;
@@ -2076,6 +2076,9 @@ class WalletDB extends EventEmitter {
       if (await this._addTX(tx, tip))
         total += 1;
     }
+
+    // Sync the state to the new tip.
+    await this.setTip(tip);
 
     if (total > 0) {
       this.logger.info('Connected WalletDB block %x (tx=%d).',

--- a/test/wallet-test.js
+++ b/test/wallet-test.js
@@ -9,6 +9,7 @@ const Network = require('../lib/protocol/network');
 const util = require('../lib/utils/util');
 const blake2b = require('bcrypto/lib/blake2b');
 const random = require('bcrypto/lib/random');
+const FullNode = require('../lib/node/fullnode');
 const WalletDB = require('../lib/wallet/walletdb');
 const WorkerPool = require('../lib/workers/workerpool');
 const Address = require('../lib/primitives/address');
@@ -20,6 +21,7 @@ const Outpoint = require('../lib/primitives/outpoint');
 const Script = require('../lib/script/script');
 const PrivateKey = require('../lib/hd/private.js');
 const policy = require('../lib/protocol/policy');
+const {forValue} = require('./util/common');
 
 const KEY1 = 'xprv9s21ZrQH143K3Aj6xQBymM31Zb4BVc7wxqfUhMZrzewdDVCt'
   + 'qUP9iWfcHgJofs25xbaUpCps9GDXj83NiWvQCAkWQhVj5J4CorfnpKX94AZ';
@@ -1638,6 +1640,63 @@ describe('Wallet', function() {
       const bal = await alice.getBalance();
       assert.equal(bal.confirmed, amount);
       assert.equal(bal.unconfirmed, amount);
+    });
+  });
+
+  describe('Node Integration', function() {
+    const ports = {p2p: 49331, node: 49332, wallet: 49333};
+    let node, chain, miner, wdb = null;
+
+    beforeEach(async () => {
+      node = new FullNode({
+        memory: true,
+        network: 'regtest',
+        workers: true,
+        workersSize: 2,
+        plugins: [require('../lib/wallet/plugin')],
+        port: ports.p2p,
+        httpPort: ports.node,
+        env: {
+          'BCOIN_WALLET_HTTP_PORT': ports.wallet.toString()
+        }
+      });
+
+      chain = node.chain;
+      miner = node.miner;
+      wdb = node.require('walletdb').wdb;
+      await node.open();
+    });
+
+    afterEach(async () => {
+      await node.close();
+    });
+
+    async function mineBlock(tip) {
+      const job = await miner.createJob(tip);
+      const block = await job.mineAsync();
+      chain.add(block);
+    }
+
+    it('should not stack in-memory block queue (oom)', async () => {
+      let height = 0;
+
+      const addBlock = wdb.addBlock.bind(wdb);
+      wdb.addBlock = async (entry, txs) => {
+        await new Promise(resolve => setTimeout(resolve, 100));
+        await addBlock(entry, txs);
+      };
+
+      async function raceForward() {
+        await mineBlock();
+
+        await forValue(node.chain, 'height', height + 1);
+        assert.equal(wdb.height, height);
+
+        height += 1;
+      }
+
+      for (let i = 0; i < 10; i++)
+        await raceForward();
     });
   });
 });

--- a/test/wallet-test.js
+++ b/test/wallet-test.js
@@ -1576,4 +1576,68 @@ describe('Wallet', function() {
     network.coinbaseMaturity = 2;
     await wdb.close();
   });
+
+  describe('Corruption', function() {
+    let workers = null;
+    let wdb = null;
+
+    beforeEach(async () => {
+      workers = new WorkerPool({
+        enabled: true,
+        size: 2
+      });
+
+      wdb = new WalletDB({ workers });
+      await workers.open();
+      await wdb.open();
+    });
+
+    afterEach(async () => {
+      await wdb.close();
+      await workers.close();
+    });
+
+    it('should not write tip with error in txs', async () => {
+      const alice = await wdb.create();
+      const addr = await alice.receiveAddress();
+
+      const fund = new MTX();
+      fund.addInput(dummyInput());
+      fund.addOutput(addr, 5460 * 10);
+
+      wdb._addTX = async () => {
+        throw new Error('Some assertion.');
+      };
+
+      await assert.rejects(async () => {
+        await wdb.addBlock(nextBlock(wdb), [fund.toTX()]);
+      }, {
+        message: 'Some assertion.'
+      });
+
+      assert.equal(wdb.height, 0);
+
+      const bal = await alice.getBalance();
+      assert.equal(bal.confirmed, 0);
+      assert.equal(bal.unconfirmed, 0);
+    });
+
+    it('should write tip without error in txs', async () => {
+      const alice = await wdb.create();
+      const addr = await alice.receiveAddress();
+
+      const fund = new MTX();
+      fund.addInput(dummyInput());
+      const amount = 5460 * 10;
+      fund.addOutput(addr, amount);
+
+      await wdb.addBlock(nextBlock(wdb), [fund.toTX()]);
+
+      assert.equal(wdb.height, 1);
+
+      const bal = await alice.getBalance();
+      assert.equal(bal.confirmed, amount);
+      assert.equal(bal.unconfirmed, amount);
+    });
+  });
 });


### PR DESCRIPTION
This is a port of the following bcoin PRs:

https://github.com/bcoin-org/bcoin/pull/931 wallet: set tip after txs have been added

https://github.com/bcoin-org/bcoin/pull/932 Prevent out-of-memory crash during sync with wallet as plugin 

https://github.com/bcoin-org/bcoin/pull/934 wallet: remove checkpoints that skip transactions

and also I applied:

https://github.com/handshake-org/hsd/pull/181 wallet: remove dead option

to one other place (`lib/wallet/plugin.js').

What we're doing here is removing dead code, keeping walletDB in sync with the chain without filling up memory, and preventing possible walletDB corruption after a crash.
