### PR TITLE
getproof - dos prevention using sliding window counter

### DIFF
--- a/etc/sample.conf
+++ b/etc/sample.conf
@@ -61,6 +61,7 @@ bip37: false
 listen: true
 max-outbound: 8
 max-inbound: 30
+max-proof-rps: 100
 brontide-max-outbound: 4
 brontide-max-inbound: 10
 

--- a/lib/net/peer.js
+++ b/lib/net/peer.js
@@ -29,6 +29,7 @@ const NetAddress = require('./netaddress');
 const Network = require('../protocol/network');
 const {BrontideStream} = require('./brontide');
 const AirdropProof = require('../primitives/airdropproof');
+const SlidingWindow = require('./slidingwindow');
 const services = common.services;
 const invTypes = InvItem.types;
 const packetTypes = packets.types;
@@ -152,6 +153,7 @@ class Peer extends EventEmitter {
     this.nameMap = new BufferMap();
     this.totalProofs = 0;
 
+    this.proofWindow = null;
     this.init();
   }
 
@@ -550,6 +552,11 @@ class Peer extends EventEmitter {
     this.invTimer = setInterval(() => {
       this.flushInv();
     }, Peer.INV_INTERVAL);
+
+    this.proofWindow = new SlidingWindow({
+      limit: this.options.maxProofRPS
+    });
+    this.proofWindow.start();
   }
 
   /**
@@ -962,6 +969,10 @@ class Peer extends EventEmitter {
     if (this.invTimer != null) {
       clearInterval(this.invTimer);
       this.invTimer = null;
+    }
+
+    if (this.proofWindow != null) {
+      this.proofWindow.stop();
     }
 
     if (this.stallTimer != null) {
@@ -1960,6 +1971,13 @@ class Peer extends EventEmitter {
       'Sending proof (%s).',
       this.fullname());
 
+    this.proofWindow.increase(1);
+    if (!this.proofWindow.allow()) {
+      this.logger.debug('proof: rate limit exceeded (%s).', this.hostname());
+      this.ban();
+      return;
+    }
+
     this.send(new packets.ProofPacket(root, key, proof));
   }
 
@@ -2147,6 +2165,7 @@ class PeerOptions {
     this.compact = false;
     this.headers = false;
     this.banScore = common.BAN_SCORE;
+    this.proofPRS = 100;
 
     this.nonces = null;
     this.type = null;
@@ -2232,6 +2251,11 @@ class PeerOptions {
     if (options.banScore != null) {
       assert(typeof options.banScore === 'number');
       this.banScore = options.banScore;
+    }
+
+    if (options.maxProofRPS != null) {
+      assert(typeof options.maxProofRPS === 'number');
+      this.maxProofRPS = options.maxProofRPS;
     }
 
     if (options.nonces != null) {

--- a/lib/net/peer.js
+++ b/lib/net/peer.js
@@ -1973,7 +1973,7 @@ class Peer extends EventEmitter {
 
     this.proofWindow.increase(1);
     if (!this.proofWindow.allow()) {
-      this.logger.debug('proof: rate limit exceeded (%s).', this.hostname());
+      this.logger.debug('proof: rate limit exceeded (%s).', this.fullname());
       this.ban();
       return;
     }

--- a/lib/net/pool.js
+++ b/lib/net/pool.js
@@ -4348,6 +4348,7 @@ class PoolOptions {
     this.identityKey = secp256k1.privateKeyGenerate();
     this.banScore = common.BAN_SCORE;
     this.banTime = common.BAN_TIME;
+    this.maxProofRPS = 100;
     this.feeRate = -1;
     this.seeds = this.network.seeds;
     this.nodes = [];
@@ -4570,6 +4571,11 @@ class PoolOptions {
     if (options.banTime != null) {
       assert(typeof this.options.banTime === 'number');
       this.banTime = this.options.banTime;
+    }
+
+    if (options.maxProofRPS != null) {
+      assert(typeof options.maxProofRPS === 'number');
+      this.maxProofRPS = options.maxProofRPS;
     }
 
     if (options.feeRate != null) {

--- a/lib/net/slidingwindow.js
+++ b/lib/net/slidingwindow.js
@@ -1,0 +1,74 @@
+'use strict';
+
+const assert = require('bsert');
+const AsyncEmitter = require('bevent');
+
+class SlidingWindow extends AsyncEmitter {
+  /**
+   * Create a sliding window counter
+   * e.g:
+   * ```
+   * new SlidingWindow({
+   *   window: 1000,
+   *   limit: 100
+   * })
+   * ```
+   * creates a sliding window which allows 100 requests per second
+   * @property {Number} window - window period in milliseconds
+   * @property {Number} limit - max requests allowed
+   * @property {Timeout} timeout - sliding window timeout
+   * @property {Number} current - current window counter
+   * @property {Number} previous - previous window counter
+   * @property {Number} timestamp - current window start time in milliseconds
+   */
+
+  constructor(options) {
+    super();
+
+    this.window = options.window || 1000;
+    this.limit = options.limit || 100;
+
+    this.timeout = null;
+    this.current = 0;
+    this.previous = 0;
+    this.timestamp = 0;
+  }
+
+  start() {
+    this.timestamp = Date.now();
+    this.timeout = setTimeout(() => this.reset(), this.window);
+  }
+
+  stop() {
+    this.timestamp = 0;
+    clearTimeout(this.timeout);
+  }
+
+  async reset() {
+    this.previous = this.current;
+    this.current = 0;
+    this.timestamp = Date.now();
+    this.emit('reset');
+  }
+
+  score() {
+    const ms = Date.now() - this.timestamp;
+    let weight = 1 - (ms / this.window);
+
+    if (weight < 0)
+      weight = 0;
+
+    return this.previous * weight + this.current;
+  }
+
+  increase(count) {
+    assert((count >>> 0) === count);
+    this.current += count;
+  }
+
+  allow() {
+    return this.score() < this.limit;
+  }
+}
+
+module.exports = SlidingWindow;

--- a/lib/node/fullnode.js
+++ b/lib/node/fullnode.js
@@ -94,6 +94,7 @@ class FullNode extends Node {
       identityKey: this.identityKey,
       maxOutbound: this.config.uint('max-outbound'),
       maxInbound: this.config.uint('max-inbound'),
+      maxProofRPS: this.config.uint('max-proof-rps'),
       brontideMaxOutbound: this.config.uint('brontide-max-outbound'),
       brontideMaxInbound: this.config.uint('brontide-max-inbound'),
       createSocket: this.config.func('create-socket'),

--- a/test/peering-test.js
+++ b/test/peering-test.js
@@ -200,6 +200,7 @@ describe('Peering', function() {
     });
 
     it('should gossip blocks over standard and brontide', async () => {
+      // Keep track of seen blocks for each node.
       const seen = {
         standard: false,
         encrypted: false,

--- a/test/slidingwindow-test.js
+++ b/test/slidingwindow-test.js
@@ -1,0 +1,132 @@
+/* eslint-env mocha */
+/* eslint prefer-arrow-callback: "off" */
+
+'use strict';
+
+const assert = require('bsert');
+const base32 = require('bs32');
+
+const rules = require('../lib/covenants/rules');
+const SlidingWindow = require('../lib/net/slidingwindow');
+const FullNode = require('../lib/node/fullnode');
+const packets = require('../lib/net/packets');
+const packetTypes = packets.types;
+
+const common = require('../test/util/common');
+
+async function sleep(time) {
+  return new Promise(resolve => setTimeout(resolve, time));
+}
+
+describe('SlidingWindow (Unit)', function() {
+  const window = new SlidingWindow({
+    window: 10,
+    limit: 100
+  });
+
+  beforeEach(() => {
+    window.start();
+  });
+
+  afterEach(() => {
+    window.stop();
+  });
+
+  it('should process max requests in window', async () => {
+    for (let i=0; i < window.limit-1; i++)
+      window.increase(1);
+
+    assert.ok(window.allow());
+  });
+
+  it('should reject after max requests in window', async () => {
+    window.increase(1);
+    assert.ok(!window.allow());
+  });
+
+  it('should reset after window timeout', async () => {
+    let reset = false;
+
+    window.once('reset', () => {
+      reset = true;
+    });
+
+    await sleep(window.window);
+    assert.ok(reset === true);
+  });
+});
+
+describe('SlidingWindow (Functional)', function() {
+  it('should rate limit getproof to max-proof-rps ', async () => {
+    const maxProofRPS = 20;
+
+    const one = new FullNode({
+      'memory': true,
+      'network': 'regtest',
+      'listen': true,
+      'max-proof-rps': maxProofRPS,
+      'host': '127.0.1.1',
+      'http-host': '127.0.1.1',
+      'rs-host': '127.0.1.1',
+      'ns-host': '127.0.1.1',
+      'seeds': []
+    });
+
+    assert.equal(one.pool.options.maxProofRPS, 20);
+
+    const key = base32.encode(one.pool.hosts.address.key);
+
+    const two = new FullNode({
+      'memory': true,
+      'network': 'regtest',
+      'host': '127.0.0.2',
+      'http-host': '127.0.0.2',
+      'rs-host': '127.0.0.2',
+      'ns-host': '127.0.0.2',
+      'seeds': [],
+      'only': [`${key}@127.0.1.1`]
+    });
+
+    await one.open();
+    await one.connect();
+
+    await two.open();
+    await two.connect();
+
+    await common.event(one.pool, 'peer open');
+
+    assert.equal(one.pool.peers.size(), 1);
+    assert.equal(one.pool.peers.brontide.inbound, 1);
+    assert.equal(two.pool.peers.size(), 1);
+    assert.equal(two.pool.peers.brontide.outbound, 1);
+
+    const hash = rules.hashString('handshake');
+
+    let seen = false;
+    one.pool.on('ban', () => {
+      seen = true;
+    });
+
+    let packets = 0;
+    one.pool.on('packet', (packet) => {
+      if (packet.type === packetTypes.GETPROOF)
+        packets++;
+    });
+
+    let count = 0;
+    while (!seen) {
+      count++;
+      try {
+        await two.pool.resolve(hash) ;
+      } catch (e) {
+        break;
+      }
+    }
+
+    assert.strictEqual(packets, maxProofRPS);
+    assert.strictEqual(count, maxProofRPS);
+
+    await one.close();
+    await two.close();
+  });
+});


### PR DESCRIPTION
An alternative approach to solving the dynamic DOS prevention for `getproof` p2p messages, using the Sliding Window Counter algorithim:

https://blog.cloudflare.com/counting-things-a-lot-of-different-things/

https://github.com/RussellLuo/slidingwindow

It is much simpler to reason about because you only need to keep track of current and previous windows.

Assume that we need to limit to 100 requests per second, in the simplest case:

< 1s >
-------
| 100 |  
-------

all 100 requests fall in the same window, so no more can be allowed.

In the second case:

<1s> <0.5s>
------------
| 50 | 50 |
-----------

50 requests fall in the previous window, 50 in the first half of the current window (0.5s). Since the current window is not yet done, we need to appromixate a score with the current knowledge.

We calculate an approximate score as 50 * (1-0.5) + 50 = 75, so in the next 0.5s we allow 100-75 = 25 requests and no more. If the previous window were empty, we could have allowed 50 more, where as if it was completely full, we can not allow any more. This is close to the our goal of only allowing 100 requests per second on average.