### PR TITLE
pool: fix refill peers

### DIFF
--- a/lib/net/pool.js
+++ b/lib/net/pool.js
@@ -3456,7 +3456,7 @@ class Pool extends EventEmitter {
    */
 
   fillOutbound() {
-    const need = this.options.maxOutbound - this.peers.outbound;
+    const need = this.options.maxOutbound - this.peers.standard.outbound;
 
     if (!this.peers.load)
       this.addLoader();
@@ -3465,7 +3465,7 @@ class Pool extends EventEmitter {
       return;
 
     this.logger.debug('Refilling peers (%d/%d).',
-      this.peers.outbound,
+      this.peers.standard.outbound,
       this.options.maxOutbound);
 
     for (let i = 0; i < need; i++)


### PR DESCRIPTION
After the recent standard + brontide update, the `Refilling peers` message was broken. Investigated and found one more usage where `peers.outbound` was being used. Fixed.