### PR TITLE
pool: refactor fill outbound logic

### DIFF
--- a/lib/net/peer.js
+++ b/lib/net/peer.js
@@ -2384,10 +2384,36 @@ class RequestEntry {
   }
 }
 
+/**
+ * Get the peer type based on a
+ * NetAddress.
+ * @param {NetAddress}
+ * @returns {Number}
+ */
+
+function getTypeByAddr(addr) {
+  if (addr.hasKey())
+    return peerTypes.BRONTIDE;
+  return peerTypes.STANDARD;
+}
+
+/**
+ * Test if the peer type is known.
+ * @param {Number}
+ * @returns {Boolean}
+ */
+
+function isKnownPeerType(type) {
+  assert(typeof type === 'number');
+  return type in peerTypesByVal;
+}
+
 /*
  * Expose
  */
 
+Peer.getTypeByAddr = getTypeByAddr;
+Peer.isKnownPeerType = isKnownPeerType;
 Peer.peerTypes = peerTypes;
 Peer.peerTypesByVal = peerTypesByVal;
 Peer.PeerOptions = PeerOptions;

--- a/lib/net/pool.js
+++ b/lib/net/pool.js
@@ -1167,7 +1167,7 @@ class Pool extends EventEmitter {
 
   createOutbound(addr) {
     const options = new PeerOptions(this.options);
-    options.type = getTypeByAddr(addr);
+    options.type = Peer.getTypeByAddr(addr);
 
     const peer = Peer.fromOutbound(options, addr);
 
@@ -3419,6 +3419,8 @@ class Pool extends EventEmitter {
     if (typeof type !== 'number')
       type = peerTypes.STANDARD;
 
+    assert(Peer.isKnownPeerType(type));
+
     // Hang back if we don't
     // have a loader peer yet.
     if (!this.peers.load)
@@ -5250,19 +5252,6 @@ class NameRequest {
 /*
  * Helpers
  */
-
-/**
- * Get the peer type based on a
- * NetAddress.
- * @param {NetAddress}
- * @returns {Number}
- */
-
-function getTypeByAddr(addr) {
-  if (addr.hasKey())
-    return peerTypes.BRONTIDE;
-  return peerTypes.STANDARD;
-}
 
 /**
  * Return a random number between

--- a/lib/net/pool.js
+++ b/lib/net/pool.js
@@ -3442,16 +3442,15 @@ class Pool extends EventEmitter {
    */
 
   fillOutbound() {
-    const {maxOutbound, brontideMaxOutbound} = this.options;
+    if (!this.peers.load)
+      this.addLoader();
 
+    const {maxOutbound, brontideMaxOutbound} = this.options;
     const need = maxOutbound - this.peers.standard.outbound;
     const brontideNeed = brontideMaxOutbound - this.peers.brontide.outbound;
 
     if (need <= 0 && brontideNeed <= 0)
       return;
-
-    if (!this.peers.load)
-      this.addLoader();
 
     this.logger.debug('Refilling standard peers (%d/%d).',
       this.peers.standard.outbound,

--- a/lib/net/pool.js
+++ b/lib/net/pool.js
@@ -3452,19 +3452,23 @@ class Pool extends EventEmitter {
     if (need <= 0 && brontideNeed <= 0)
       return;
 
-    this.logger.debug('Refilling standard peers (%d/%d).',
-      this.peers.standard.outbound,
-      maxOutbound);
+    if (need > 0) {
+      this.logger.debug('Refilling standard peers (%d/%d).',
+        this.peers.standard.outbound,
+        maxOutbound);
 
-    for (let i = 0; i < need; i++)
-      this.addOutbound(peerTypes.STANDARD);
+      for (let i = 0; i < need; i++)
+        this.addOutbound(peerTypes.STANDARD);
+    }
 
-    this.logger.debug('Refilling brontide peers (%d/%d).',
-      this.peers.brontide.outbound,
-      brontideMaxOutbound);
+    if (brontideNeed > 0) {
+      this.logger.debug('Refilling brontide peers (%d/%d).',
+        this.peers.brontide.outbound,
+        brontideMaxOutbound);
 
-    for (let i = 0; i < brontideNeed; i++)
-      this.addOutbound(peerTypes.BRONTIDE);
+      for (let i = 0; i < brontideNeed; i++)
+        this.addOutbound(peerTypes.BRONTIDE);
+    }
   }
 
   /**

--- a/lib/net/pool.js
+++ b/lib/net/pool.js
@@ -3407,7 +3407,8 @@ class Pool extends EventEmitter {
   /**
    * Create an outbound non-loader peer. These primarily
    * exist for transaction relaying.
-   * @type {Number} - preferred connection type
+   * @type {Number?} - preferred connection type,
+   *   defaults to standard.
    * @private
    */
 
@@ -3415,23 +3416,8 @@ class Pool extends EventEmitter {
     if (!this.opened)
       return;
 
-    const needOutbound =
-      this.peers.standard.outbound >= this.options.maxOutbound;
-    const needBrontideOutbound =
-      this.peers.brontide >= this.options.brontideMaxOutbound;
-
-    if (needOutbound && needBrontideOutbound)
-      return;
-
-    // Try to connect to a brontide peer 20% of
-    // the time when a the outbound brontide peers
-    // are not full.
-    if (type == null) {
-      if (needBrontideOutbound && random(10) < 2)
-        type = peerTypes.BRONTIDE;
-      else
-        type = peerTypes.STANDARD;
-    }
+    if (typeof type !== 'number')
+      type = peerTypes.STANDARD;
 
     // Hang back if we don't
     // have a loader peer yet.
@@ -3456,20 +3442,30 @@ class Pool extends EventEmitter {
    */
 
   fillOutbound() {
-    const need = this.options.maxOutbound - this.peers.standard.outbound;
+    const {maxOutbound, brontideMaxOutbound} = this.options;
+
+    const need = maxOutbound - this.peers.standard.outbound;
+    const brontideNeed = brontideMaxOutbound - this.peers.brontide.outbound;
+
+    if (need <= 0 && brontideNeed <= 0)
+      return;
 
     if (!this.peers.load)
       this.addLoader();
 
-    if (need <= 0)
-      return;
-
-    this.logger.debug('Refilling peers (%d/%d).',
+    this.logger.debug('Refilling standard peers (%d/%d).',
       this.peers.standard.outbound,
-      this.options.maxOutbound);
+      maxOutbound);
 
     for (let i = 0; i < need; i++)
-      this.addOutbound();
+      this.addOutbound(peerTypes.STANDARD);
+
+    this.logger.debug('Refilling brontide peers (%d/%d).',
+      this.peers.brontide.outbound,
+      brontideMaxOutbound);
+
+    for (let i = 0; i < brontideNeed; i++)
+      this.addOutbound(peerTypes.BRONTIDE);
   }
 
   /**


### PR DESCRIPTION
Refactor of `Pool.fillOutbound` and `Pool.addOutbound`. This duplicates the original logic for adding peers but now for both standard and brontide connections. The random element of sometimes not attempting to connect to brontide peers was removed, as the safety from not dos'ing yourself should come from a low outbound count, not waiting longer before trying to connect to peers. This way a node can quickly connect to another brontide based peer quickly if one drops, which is important for spv nodes doing name resolution. It is also important for nodes that only connect to brontide based peers.