### PR TITLE
net/hostlist: enable dns seeds

### DIFF
--- a/lib/net/hostlist.js
+++ b/lib/net/hostlist.js
@@ -10,7 +10,7 @@ const assert = require('bsert');
 const path = require('path');
 const fs = require('bfile');
 const IP = require('binet');
-const dns = require('bdns');
+const rdns = require('bns/lib/rdns');
 const Logger = require('blgr');
 const murmur3 = require('mrmr');
 const List = require('blst');
@@ -1003,10 +1003,8 @@ class HostList {
   async discoverSeeds() {
     const jobs = [];
 
-    // XXX
-    // Disabled for now.
-    // for (const seed of this.dnsSeeds)
-    //   jobs.push(this.populateSeed(seed));
+    for (const seed of this.dnsSeeds)
+      jobs.push(this.populateSeed(seed));
 
     return Promise.all(jobs);
   }
@@ -1020,10 +1018,8 @@ class HostList {
   async discoverNodes() {
     const jobs = [];
 
-    // XXX
-    // Disabled for now.
-    // for (const node of this.dnsNodes)
-    //   jobs.push(this.populateNode(node));
+    for (const node of this.dnsNodes)
+      jobs.push(this.populateNode(node));
 
     return Promise.all(jobs);
   }
@@ -1534,7 +1530,7 @@ class HostListOptions {
   constructor(options) {
     this.network = Network.primary;
     this.logger = Logger.global;
-    this.resolve = dns.lookup;
+    this.resolve = rdns.lookup;
     this.host = '0.0.0.0';
     this.port = this.network.port;
     this.services = common.LOCAL_SERVICES;


### PR DESCRIPTION
Enable peer discovery through DNS seeds in the `HostList`. This must recursively resolve through ICANN.

- It is a chicken or the egg problem to resolve through Handshake, the chain must be synced first and this is important to find peers for the initial block download
- The host machine's `resolve.conf` may be configured to use Handshake, so this must recursively resolve without using the host's resolver