### PR TITLE
softforks: opt in, by default no, vote with config

### DIFF
--- a/lib/blockchain/chain.js
+++ b/lib/blockchain/chain.js
@@ -3187,11 +3187,12 @@ class Chain extends AsyncEmitter {
 
     for (const deployment of this.network.deploys) {
       const state = await this.getState(prev, deployment);
+      const accept = this.options.bip9[deployment.name];
 
-      if (state === thresholdStates.LOCKED_IN
-          || state === thresholdStates.STARTED) {
+      if (state === thresholdStates.LOCKED_IN)
         version |= 1 << deployment.bit;
-      }
+      else if (state === thresholdStates.STARTED && accept)
+        version |= 1 << deployment.bit;
     }
 
     version >>>= 0;
@@ -3402,6 +3403,7 @@ class ChainOptions {
     this.indexTX = false;
     this.indexAddress = false;
     this.forceFlags = false;
+    this.bip9 = {};
 
     this.entryCache = 5000;
     this.maxOrphans = 20;
@@ -3510,6 +3512,11 @@ class ChainOptions {
     if (options.checkpoints != null) {
       assert(typeof options.checkpoints === 'boolean');
       this.checkpoints = options.checkpoints;
+    }
+
+    if (options.bip9 != null) {
+      assert(typeof options.bip9 === 'object');
+      this.bip9 = options.bip9;
     }
 
     if (this.spv || this.memory)

--- a/lib/node/fullnode.js
+++ b/lib/node/fullnode.js
@@ -55,7 +55,11 @@ class FullNode extends Node {
       checkpoints: this.config.bool('checkpoints'),
       entryCache: this.config.uint('entry-cache'),
       indexTX: this.config.bool('index-tx'),
-      indexAddress: this.config.bool('index-address')
+      indexAddress: this.config.bool('index-address'),
+      bip9: {
+        hardening: this.config.bool('bip9-hardening'),
+        rollover: this.config.bool('bip9-rollover')
+      }
     });
 
     // Fee estimation.


### PR DESCRIPTION
This PR is meant to make soft fork activation on the network opt in by default. The full nodes will currently opt in by default, which is potentially risky behavior as it takes power away from users.

Two new configuration flags are defined:

- `--bip9-hardening`
- `--bip9-rollover`

These are set as booleans and are `null` (falsy) by default.

It is also meant to alleviate any concerns with https://github.com/handshake-org/hsd/pull/337 in regards to the soft forks activating too early. Now miners will be able to restart their software with a new configuration flag to signal for the softforks when using the `getwork` RPC or `hstratum`.

Will follow up with tests if this approach is concept ack'd
