### PR TITLE
miner: don't signal for softforks by default

### DIFF
--- a/lib/mining/miner.js
+++ b/lib/mining/miner.js
@@ -127,8 +127,9 @@ class Miner extends EventEmitter {
     if (!address)
       address = this.getAddress();
 
+    // Use getblocktemplate to signal for bip9.
     if (version === -1)
-      version = await this.chain.computeBlockVersion(tip);
+      version = 0;
 
     const mtp = await this.chain.getMedianTime(tip);
     const time = Math.max(this.network.now(), mtp + 1);


### PR DESCRIPTION
This PR is an alternative to https://github.com/handshake-org/hsd/pull/346. Now the bip9 bits are never set in `miner.createBlock`.

The idea is encourage users to use `getblocktemplate` over `getwork`. The `getwork` codepath hits the change in this PR.

https://github.com/handshake-org/hsd/blob/8252c97e890148c56903c3178c9d3869318a285e/lib/node/rpc.js#L2589

