### PR TITLE
test: increase rpc, http timeouts

### DIFF
--- a/test/auction-rpc-test.js
+++ b/test/auction-rpc-test.js
@@ -40,6 +40,7 @@ class TestUtil {
     this.node.use(plugin);
 
     this.nclient = new NodeClient({
+      timeout: 15000,
       host: options.host,
       port: options.nport
     });

--- a/test/wallet-http-test.js
+++ b/test/wallet-http-test.js
@@ -61,7 +61,7 @@ const {
 // TODO: convert to using hs-client methods
 // when the new version is published
 describe('Wallet HTTP', function() {
-  this.timeout(15000);
+  this.timeout(20000);
 
   before(async () => {
     await node.open();


### PR DESCRIPTION
Tests on circle ci were failing because of node client timeout as well as http test timeout. Fixed.