### PR TITLE
peer: fix sliding window timer

### DIFF
--- a/lib/net/slidingwindow.js
+++ b/lib/net/slidingwindow.js
@@ -36,12 +36,12 @@ class SlidingWindow extends AsyncEmitter {
 
   start() {
     this.timestamp = Date.now();
-    this.timeout = setTimeout(() => this.reset(), this.window);
+    this.timeout = setInterval(() => this.reset(), this.window);
   }
 
   stop() {
     this.timestamp = 0;
-    clearTimeout(this.timeout);
+    clearInterval(this.timeout);
   }
 
   async reset() {

--- a/test/slidingwindow-test.js
+++ b/test/slidingwindow-test.js
@@ -55,6 +55,8 @@ describe('SlidingWindow (Unit)', function() {
 });
 
 describe('SlidingWindow (Functional)', function() {
+  this.timeout(3000);
+
   it('should rate limit getproof to max-proof-rps', async () => {
     const maxProofRPS = 20;
     const seen = {count: 0};
@@ -128,6 +130,74 @@ describe('SlidingWindow (Functional)', function() {
     assert.equal(err.message, 'Timed out.');
     assert.strictEqual(packets, maxProofRPS);
     assert.strictEqual(count, maxProofRPS);
+
+    await one.close();
+    await two.close();
+  });
+
+  it('should reset getproof counter on window timeout', async () => {
+    const maxProofRPS = 20;
+    const seen = {count: 0};
+
+    const one = new FullNode({
+      'memory': true,
+      'network': 'regtest',
+      'listen': true,
+      'max-proof-rps': maxProofRPS,
+      'seeds': []
+    });
+
+    one.pool.on('peer open', () => {
+      seen.count++;
+    });
+
+    assert.equal(one.pool.options.maxProofRPS, 20);
+
+    const two = new FullNode({
+      'memory': true,
+      'network': 'regtest',
+      'http-port': 10000,
+      'rs-port': 10001,
+      'ns-port': 10002,
+      'seeds': [],
+      'only': ['127.0.0.1'] // one is using default ports.
+    });
+
+    two.pool.on('peer open', () => {
+      seen.count++;
+    });
+
+    await one.open();
+    await one.connect();
+
+    await two.open();
+    await two.connect();
+
+    await common.forValue(seen, 'count', 2);
+
+    assert.equal(one.pool.peers.size(), 1);
+    assert.equal(one.pool.peers.inbound, 1);
+    assert.equal(two.pool.peers.size(), 1);
+    assert.equal(two.pool.peers.outbound, 1);
+
+    const hash = rules.hashString('handshake');
+
+    let packets = 0;
+    one.pool.on('packet', (packet) => {
+      if (packet.type === packetTypes.GETPROOF)
+        packets++;
+    });
+
+    let count = 0;
+    while (count < 25) {
+      count++;
+      await two.pool.resolve(hash);
+      if (count % 10 === 0)
+        await sleep(1000);
+    }
+
+    assert.strictEqual(packets, 25);
+    assert.strictEqual(count, 25);
 
     await one.close();
     await two.close();


### PR DESCRIPTION
The sliding window timer should be a `setInvterval` since it needs to `reset` _every_ second. There was only a unit test for this and unfortunately it was covering only the first `reset`.  Fixed and added a integration test. The current test sleeps for a second after 10 requests, giving the window enough time to `reset` and accommodate requests which are spaced out across multiple sliding windows.