### PR TITLE
chain: don't check coinbase TX in SPV mode

### DIFF
--- a/lib/blockchain/chain.js
+++ b/lib/blockchain/chain.js
@@ -2027,14 +2027,16 @@ class Chain extends AsyncEmitter {
       if (block.txs.length > 1)
         invalid = true;
 
-      // No claims or airdrops allowed in coinbase yet.
-      const cb = block.txs[0];
-      if (cb.outputs.length > 1)
-        invalid = true;
+      if (!this.options.spv) {
+        // No claims or airdrops allowed in coinbase yet.
+        const cb = block.txs[0];
+        if (cb.outputs.length > 1)
+          invalid = true;
 
-      // Sanity check
-      if (!cb.outputs[0].covenant.isNone())
-        invalid = true;
+        // Sanity check
+        if (!cb.outputs[0].covenant.isNone())
+          invalid = true;
+      }
 
       if (invalid) {
         this.setInvalid(block.hash());


### PR DESCRIPTION
Sorry, the txStart rules I wrote will cause SPV node to throw 😬.

This won't matter after we cross the txStart threshold, and SPV nodes won't do much good until then anyway.

```
[debug] (net) Error: Cannot read property 'outputs' of undefined (165.22.151.242:12038)
    at Chain.connect (/Users/matthewzipkin/Desktop/work/hsd/lib/blockchain/chain.js:2032:14)
    at Chain._add (/Users/matthewzipkin/Desktop/work/hsd/lib/blockchain/chain.js:1972:30)
    at async Chain.add (/Users/matthewzipkin/Desktop/work/hsd/lib/blockchain/chain.js:1900:14)
    at async Pool._addBlock (/Users/matthewzipkin/Desktop/work/hsd/lib/net/pool.js:2409:15)
    at async Pool._handleMerkleBlock (/Users/matthewzipkin/Desktop/work/hsd/lib/net/pool.js:2979:7)
    at async Pool.handleMerkleBlock (/Users/matthewzipkin/Desktop/work/hsd/lib/net/pool.js:2921:14)
    at async Pool.handlePacket (/Users/matthewzipkin/Desktop/work/hsd/lib/net/pool.js:1353:9)
    at async Peer.handlePacket (/Users/matthewzipkin/Desktop/work/hsd/lib/net/peer.js:1546:7)
    at async Peer.readPacket (/Users/matthewzipkin/Desktop/work/hsd/lib/net/peer.js:1483:11)
    at async Parser.<anonymous> (/Users/matthewzipkin/Desktop/work/hsd/lib/net/peer.js:184:9)
[info] (net) Removed loader peer (165.22.151.242:12038).```