### PR TITLE
Fixes for running remote wallet server

### DIFF
--- a/lib/wallet/client.js
+++ b/lib/wallet/client.js
@@ -77,8 +77,8 @@ class WalletClient extends NodeClient {
     return super.rescan(start);
   }
 
-  async getNameStatus() {
-    const json = await super.getNameStatus();
+  async getNameStatus(nameHash) {
+    const json = await super.getNameStatus(nameHash);
     return NameState.fromJSON(json);
   }
 }

--- a/lib/wallet/client.js
+++ b/lib/wallet/client.js
@@ -88,13 +88,30 @@ class WalletClient extends NodeClient {
  */
 
 function parseEntry(data) {
+  // 32  hash
+  // 4   height
+  // 4   nonce
+  // 8   time
+  // 32  prev
+  // 32  tree
+  // 24  extranonce
+  // 32  reserved
+  // 32  witness
+  // 32  merkle
+  // 4   version
+  // 4   bits
+  // 32  mask
+  // 32  chainwork
+  // 304 TOTAL
+
   assert(Buffer.isBuffer(data));
-  assert(data.length >= 36 + 4 + 8);
+  // Just enough to read the three data below
+  assert(data.length >= 44);
 
   return {
     hash: data.slice(0, 32),
-    height: data.readUInt32LE(36),
-    time: data.readUInt32LE(36 + 4)
+    height: data.readUInt32LE(32),
+    time: data.readUInt32LE(40)
   };
 }
 


### PR DESCRIPTION
`wallet: fix ChainEntry parsing in remote wallet NodeClient`:

Without this patch, `hs-wallet` running in a separate process will not be able to `rescan`. As it receives `'block rescan'` events from the full node, it parses them incorrectly, thinking each blocks' height is wrong and cancelling the process. I think this may have been leftover from rearranging the block headers for the new proof-of-work.

`wallet: pass nameHash to getNameStatus in remote wallet NodeClient`:

Parameter was missing so trying to send a bid with remote wallet would throw an assertion error in `hs-client`:

https://github.com/pinheadmz/hs-client/blob/aa246e2f43c5ab8c3e4cf022c17e17dd4d7aa6e2/lib/node.js#L260

```js
  getNameStatus(nameHash) {
    assert(Buffer.isBuffer(nameHash));
    return this.call('get name', nameHash);
  }
```