### PR TITLE
Attach network default clearnet p2p port (and null ID key) to hosts received from DNS seeds.

### DIFF
--- a/lib/net/hostlist.js
+++ b/lib/net/hostlist.js
@@ -1072,10 +1072,9 @@ class HostList {
       return addrs;
     }
 
-    const {port, key} = target;
-
     for (const host of hosts) {
-      const addr = NetAddress.fromHost(host, port, key, this.network);
+      const addr =
+        NetAddress.fromHost(host, this.network.port, null, this.network);
       addrs.push(addr);
     }
 


### PR DESCRIPTION
Closes #359 

Fixes two bugs. It's a bit weird since how we manage getting hosts from a DNS seed is by adding a port to the seed. We won't use that port (DNS lookup ignores that port, and does it's DNS thing on port 53 anyway) but it is inherited by all the hosts we receive from the DNS seed, which are otherwise just IP addresses in A/AAAA records.

There is also I think some leftover code from before the Brontide refactor, where we would attach the ID key of the DNS seed to all the hosts we received as A/AAAA records. I'm not sure how that was supposed to work, but it seems cleaner now to set the key to `null`.

This fix will have to be upgraded in the future if we switch to `SRV` records like in [BOLT-10](https://github.com/lightningnetwork/lightning-rfc/blob/master/10-dns-bootstrap.md) but for now, the DNS seeds are clearnet, legacy DNS resolvers that provide boring old fashioned A/AAAA records for peers without Brontide information.

to reproduce:

```
$ hsd --prefix=~/.hsd/dnsseed-test --seeds=seed.easyhandshake.com

...
[info] (node) Node is loaded.
[warning] (net) Could not find enough peers.
[warning] (net) Hitting DNS seeds...
[info] (hostlist) Resolving host: seed.easyhandshake.com.
[info] (net) Resolved 73 hosts from DNS seeds.
[debug] (net) Connecting to [2001:0:348b:fb58:c4d:3bfa:98a5:61f6]:12038.
[info] (net) Adding loader peer ([2001:0:348b:fb58:c4d:3bfa:98a5:61f6]:12038).
[debug] (net) Connecting to [2601:482:8002:2024:7531:8f8b:3508:1072]:12038.
[debug] (net) Connecting to 170.52.153.17:12038.
[debug] (net) Connecting to 64.227.51.86:12038.
[debug] (net) Connecting to 216.165.95.133:12038.
[debug] (net) Connecting to 24.201.194.199:12038.
[debug] (net) Connecting to [2601:341:c180:3a80:182e:dea3:a267:bb1e]:12038.
[debug] (net) Connecting to 95.165.154.226:12038.
[debug] (net) Error: Socket Error: EHOSTUNREACH ([2001:0:348b:fb58:c4d:3bfa:98a5:61f6]:12038)
[info] (net) Removed loader peer ([2001:0:348b:fb58:c4d:3bfa:98a5:61f6]:12038).
```