### PR TITLE
node RPC: fix logger format for block hashes

### DIFF
--- a/lib/node/rpc.js
+++ b/lib/node/rpc.js
@@ -1156,7 +1156,7 @@ class RPC extends RPCBase {
       entry = await this.chain.add(block);
     } catch (err) {
       if (err.type === 'VerifyError') {
-        this.logger.warning('RPC block rejected: %s (%s).',
+        this.logger.warning('RPC block rejected: %x (%s).',
           block.hash(), err.reason);
         return [false, err.reason];
       }
@@ -1164,7 +1164,7 @@ class RPC extends RPCBase {
     }
 
     if (!entry) {
-      this.logger.warning('RPC block rejected: %s (bad-prevblk).',
+      this.logger.warning('RPC block rejected: %x (bad-prevblk).',
         block.hash());
       return [false, 'bad-prevblk'];
     }
@@ -2605,7 +2605,7 @@ class RPC extends RPCBase {
   }
 
   async _addBlock(block) {
-    this.logger.info('Handling submitted block: %s.', block.hash());
+    this.logger.info('Handling submitted block: %x.', block.hash());
 
     let entry;
     try {
@@ -2620,7 +2620,7 @@ class RPC extends RPCBase {
     }
 
     if (!entry) {
-      this.logger.warning('RPC block rejected: %s (bad-prevblk).',
+      this.logger.warning('RPC block rejected: %x (bad-prevblk).',
         block.hash());
       return 'rejected: bad-prevblk';
     }


### PR DESCRIPTION
### Current

```
[info] (rpc) Handling submitted block: m���>n<,˩�pc��
                                                     e�k��W��(e��d.
[warning] (rpc) RPC block rejected: 6d1a97f7a63e6e3c002ccba9d07063e7a9c80b65ad6b93d457969b2865d3f264 (high-hash).
```

### Fixed

```
[debug] (rpc) Handling RPC call: submitblock.
[info] (rpc) Handling submitted block: 6d1a97f7a63e6e3c002ccba9d07063e7a9c80b65ad6b93d457969b2865d3f264.
[warning] (rpc) RPC block rejected: 6d1a97f7a63e6e3c002ccba9d07063e7a9c80b65ad6b93d457969b2865d3f264 (high-hash).
```