### PR TITLE
add BIP9 signaling statistics to rpc getblockchaininfo

### DIFF
--- a/lib/blockchain/chain.js
+++ b/lib/blockchain/chain.js
@@ -3162,6 +3162,46 @@ class Chain extends AsyncEmitter {
   }
 
   /**
+   * Get signalling statistics for BIP9/versionbits soft fork
+   * @param {ChainEntry} prev - Previous chain entry.
+   * @param {String} id - Deployment id.
+   * @returns {Promise} - Returns JSON object.
+   */
+
+  async getBIP9Stats(prev, deployment) {
+    const bit = deployment.bit;
+    let window = this.network.minerWindow;
+    let threshold = this.network.activationThreshold;
+
+    // Deployments like `segsignal` (BIP91) have custom window & threshold
+    if (deployment.window !== -1)
+      window = deployment.window;
+
+    if (deployment.threshold !== -1)
+      threshold = deployment.threshold;
+
+    let count = 0;
+    let block = prev;
+
+    while((block.height + 1) % window !== 0) {
+      if (block.hasBit(bit))
+        count++;
+
+      block = await this.getPrevious(block);
+      if(!block)
+        break;
+    }
+
+    return {
+      period: window,
+      threshold: threshold,
+      elapsed: (prev.height + 1) % window,
+      count: count,
+      possible: (window - threshold) >= ((prev.height + 1) % window) - count
+    };
+  }
+
+  /**
    * Compute the version for a new block (BIP9: versionbits).
    * @see https://github.com/bitcoin/bips/blob/master/bip-0009.mediawiki
    * @param {ChainEntry} prev - Previous chain entry (usually the tip).

--- a/lib/blockchain/chain.js
+++ b/lib/blockchain/chain.js
@@ -3169,6 +3169,10 @@ class Chain extends AsyncEmitter {
    */
 
   async getBIP9Stats(prev, deployment) {
+    const state = await this.getState(prev, deployment);
+    if (state !== thresholdStates.STARTED)
+      throw new Error(`Deployment "${deployment.name}" not in STARTED state.`);
+
     const bit = deployment.bit;
     let window = this.network.minerWindow;
     let threshold = this.network.activationThreshold;

--- a/lib/blockchain/chain.js
+++ b/lib/blockchain/chain.js
@@ -3025,7 +3025,7 @@ class Chain extends AsyncEmitter {
    * await chain.isActive(tip, deployments.segwit);
    * @see https://github.com/bitcoin/bips/blob/master/bip-0009.mediawiki
    * @param {ChainEntry} prev - Previous chain entry.
-   * @param {String} id - Deployment id.
+   * @param {Object} deployment - Deployment.
    * @returns {Promise} - Returns Number.
    */
 
@@ -3040,7 +3040,7 @@ class Chain extends AsyncEmitter {
    * await chain.getState(tip, deployments.segwit);
    * @see https://github.com/bitcoin/bips/blob/master/bip-0009.mediawiki
    * @param {ChainEntry} prev - Previous chain entry.
-   * @param {String} id - Deployment id.
+   * @param {Object} deployment - Deployment.
    * @returns {Promise} - Returns Number.
    */
 
@@ -3164,7 +3164,7 @@ class Chain extends AsyncEmitter {
   /**
    * Get signalling statistics for BIP9/versionbits soft fork
    * @param {ChainEntry} prev - Previous chain entry.
-   * @param {String} id - Deployment id.
+   * @param {Obejct} deployment - Deployment.
    * @returns {Promise} - Returns JSON object.
    */
 

--- a/lib/node/rpc.js
+++ b/lib/node/rpc.js
@@ -2667,6 +2667,11 @@ class RPC extends RPCBase {
         startTime: deployment.startTime,
         timeout: deployment.timeout
       };
+
+      if (status === 'started') {
+        forks[deployment.name].statistics =
+          await this.chain.getBIP9Stats(tip, deployment);
+      }
     }
 
     return forks;

--- a/test/bip9-chain-test.js
+++ b/test/bip9-chain-test.js
@@ -1,0 +1,144 @@
+/* eslint-env mocha */
+/* eslint prefer-arrow-callback: "off" */
+
+'use strict';
+
+const assert = require('bsert');
+const Chain = require('../lib/blockchain/chain');
+const Miner = require('../lib/mining/miner');
+const Network = require('../lib/protocol/network');
+const common = require('../lib/blockchain/common');
+const thresholdStates = common.thresholdStates;
+
+const network = Network.get('regtest');
+const deployments = network.deployments;
+const activationThreshold = network.activationThreshold;
+const minerWindow = network.minerWindow;
+
+const ACTUAL_START = deployments.hardening.startTime;
+const ACTUAL_TIMEOUT = deployments.hardening.timeout;
+
+const chain = new Chain({
+  memory: true,
+  network
+});
+const miner = new Miner({
+  chain: chain
+});
+
+async function addBIP9Blocks(number, setHardeningBit) {
+  for (let i = 0; i < number; i++) {
+    const entry = await chain.getEntry(chain.tip.hash);
+    const job = await miner.cpu.createJob(entry);
+    if (setHardeningBit)
+      job.attempt.version |= (1 << deployments.hardening.bit);
+    else
+      job.attempt.version = 0;
+    job.refresh();
+    const block = await job.mineAsync();
+    await chain.add(block);
+  }
+};
+
+async function getHardeningState() {
+  const prev = chain.tip;
+  const state = await chain.getState(prev, deployments.hardening);
+  return state;
+};
+
+async function hasHardening() {
+  const state = await chain.getDeployments(chain.tip.time, chain.tip);
+  return state.hasHardening();
+}
+
+describe('BIP9 activation', function() {
+  before(async () => {
+    deployments.hardening.startTime = 0;
+    deployments.hardening.timeout = 0xffffffff;
+
+    await chain.open();
+    await miner.cpu.open();
+  });
+
+  after(async () => {
+    await chain.close();
+    await miner.cpu.close();
+
+    deployments.hardening.startTime = ACTUAL_START;
+    deployments.hardening.timeout = ACTUAL_TIMEOUT;
+  });
+
+  it('should start as DEFINED', async () => {
+    const state = await getHardeningState(chain.tip);
+    assert.strictEqual(state, thresholdStates.DEFINED);
+    assert(!await hasHardening());
+  });
+
+  it('should advance from DEFINED to STARTED', async () => {
+    // This is minus two because block 0 counts as the "first" block.
+    await addBIP9Blocks(minerWindow - 2, true);
+    const state1 = await getHardeningState(chain.tip);
+    assert.strictEqual(state1, thresholdStates.DEFINED);
+    await addBIP9Blocks(1, true);
+    const state2 = await getHardeningState(chain.tip);
+    assert.strictEqual(state2, thresholdStates.STARTED);
+    assert(!await hasHardening());
+  });
+
+  it('should add blocks: does not reach LOCKED_IN', async () => {
+    // Not enough miner support signaled.
+    await addBIP9Blocks(minerWindow - activationThreshold, true);
+    await addBIP9Blocks(activationThreshold - 1, false);
+    const state1 = await getHardeningState(chain.tip);
+    assert.strictEqual(state1, thresholdStates.STARTED);
+
+    // Activation is impossible this period
+    const stats1 = await chain.getBIP9Stats(chain.tip, deployments.hardening);
+    assert.deepStrictEqual(stats1, {
+      period: minerWindow,
+      threshold: activationThreshold,
+      elapsed: minerWindow - 1,
+      count: minerWindow - activationThreshold,
+      possible: false
+    });
+
+    await addBIP9Blocks(1, false);
+    const state2 = await getHardeningState(chain.tip);
+    assert.strictEqual(state2, thresholdStates.STARTED);
+    assert(!await hasHardening());
+  });
+
+  it('should add blocks: reaches LOCKED_IN status', async () => {
+    // Miner support threshold reached.
+    await addBIP9Blocks(minerWindow - activationThreshold, false);
+    await addBIP9Blocks(activationThreshold - 1, true);
+    const state1 = await getHardeningState(chain.tip);
+    assert.strictEqual(state1, thresholdStates.STARTED);
+
+    // Activation is possible this period
+    const stats1 = await chain.getBIP9Stats(chain.tip, deployments.hardening);
+    assert.deepStrictEqual(stats1, {
+      period: minerWindow,
+      threshold: activationThreshold,
+      elapsed: minerWindow - 1,
+      count: activationThreshold - 1,
+      possible: true
+    });
+
+    await addBIP9Blocks(1, true);
+    const state2 = await getHardeningState(chain.tip);
+    assert.strictEqual(state2, thresholdStates.LOCKED_IN);
+    assert(!await hasHardening());
+  });
+
+  it('should add blocks: reaches ACTIVE status', async () => {
+    // Note that signal bits are unnecessary after lock-in.
+    await addBIP9Blocks(minerWindow - 1, false);
+    const state1 = await getHardeningState(chain.tip);
+    assert.strictEqual(state1, thresholdStates.LOCKED_IN);
+    await addBIP9Blocks(1, false);
+    const state2 = await getHardeningState(chain.tip);
+    assert.strictEqual(state2, thresholdStates.ACTIVE);
+    assert(await hasHardening());
+  });
+});

--- a/test/bip9-chain-test.js
+++ b/test/bip9-chain-test.js
@@ -141,4 +141,11 @@ describe('BIP9 activation', function() {
     assert.strictEqual(state2, thresholdStates.ACTIVE);
     assert(await hasHardening());
   });
+
+  it('should throw error if not STARTED', async () => {
+    await assert.rejects(
+      chain.getBIP9Stats(chain.tip, deployments.hardening),
+      {message: 'Deployment "hardening" not in STARTED state.'}
+    );
+  });
 });


### PR DESCRIPTION
Port of https://github.com/bcoin-org/bcoin/pull/724
which is a port of bitcoin/bitcoin#9571

Test is ported from https://github.com/handshake-org/hsd/pull/332

adds a subsection to soft fork deployments indicating amount of miner signaling and a boolean if activation is "still possible" this period, given the signaling thus far and the time remaining in the window:

```
"statistics": {
      "period": 2016,
      "threshold": 1916,
      "elapsed": 377,
      "count": 290,
      "possible": true
    }
```

- [x] TODO: fix test to cover RPC call