### PR TITLE
mempool: fix airdrop typo

### DIFF
--- a/lib/blockchain/chain.js
+++ b/lib/blockchain/chain.js
@@ -531,7 +531,7 @@ class Chain extends AsyncEmitter {
 
       const output = cb.outputs[i];
 
-      // Aidrop proof.
+      // Airdrop proof.
       if (!output.covenant.isClaim()) {
         let proof;
         try {

--- a/lib/mempool/mempool.js
+++ b/lib/mempool/mempool.js
@@ -614,7 +614,7 @@ class Mempool extends EventEmitter {
     if (this.size <= threshold) {
       return !(this.hasEntry(added)
                || this.hasClaim(added)
-               || this.hasAidrop(added));
+               || this.hasAirdrop(added));
     }
 
     this.logger.debug(
@@ -650,7 +650,7 @@ class Mempool extends EventEmitter {
     if (this.size <= threshold) {
       return !(this.hasEntry(added)
                || this.hasClaim(added)
-               || this.hasAidrop(added));
+               || this.hasAirdrop(added));
     }
 
     const pq = new Heap(cmpRateClaim);
@@ -670,7 +670,7 @@ class Mempool extends EventEmitter {
     if (this.size <= threshold) {
       return !(this.hasEntry(added)
                || this.hasClaim(added)
-               || this.hasAidrop(added));
+               || this.hasAirdrop(added));
     }
 
     const pqa = new Heap(cmpRateAirdrop);
@@ -689,7 +689,7 @@ class Mempool extends EventEmitter {
 
     return !(this.hasEntry(added)
              || this.hasClaim(added)
-             || this.hasAidrop(added));
+             || this.hasAirdrop(added));
   }
 
   /**
@@ -1254,7 +1254,7 @@ class Mempool extends EventEmitter {
     }
 
     if (!proof.isSane())
-      throw new VerifyError(proof, 'invalid', 'bad-aidrop-proof', 100);
+      throw new VerifyError(proof, 'invalid', 'bad-airdrop-proof', 100);
 
     if (this.chain.height + 1 >= this.network.goosigStop) {
       const key = proof.getKey();

--- a/lib/mining/cpuminer.js
+++ b/lib/mining/cpuminer.js
@@ -593,7 +593,7 @@ class CPUJob {
 
   /**
    * Add a airdrop proof to the block.
-   * @param {AidropProof} proof
+   * @param {AirdropProof} proof
    */
 
   addAirdrop(proof) {
@@ -602,7 +602,7 @@ class CPUJob {
 
   /**
    * Add a airdrop proof to the block.
-   * @param {AidropProof} proof
+   * @param {AirdropProof} proof
    */
 
   pushAirdrop(proof) {

--- a/lib/mining/template.js
+++ b/lib/mining/template.js
@@ -795,7 +795,7 @@ class BlockAirdrop {
 
   /**
    * Instantiate block entry from transaction.
-   * @param {AidropProof} proof
+   * @param {AirdropProof} proof
    * @returns {BlockAirdrop}
    */
 


### PR DESCRIPTION
I was using the airdrop error messages for something and noticed a typo in one of the cases. When I went to fix it, I noticed a bunch of other "aidrop" typos. This PR fixes them all.

Edit: upon further review it seems this PR actually affects behavior.

The mempool defines a `Mempool.hasAirdrop` function but refers to it everywhere as `Mempool.hasAidrop`. This is only used in the `Mempool.limitSize` function which appears to guarantee the mempool does not exceed the max size. So it seems that if the mempool were to exceed the size limit, we'd get some sort of "`this.hasAidrop is not a function` error which would bubble up to unknown effect.