### PR TITLE
Add new HTTP and RPC calls to get corresponding BlindValue from txdb for given blind

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,8 @@
 
 ### Wallet API changes
 
-- Adds new wallet rpc `getblindvalue` which accepts a blind (hash) and returns a
-`BlindValue` in JSON format if it is found in the txdb.
+- Adds new wallet rpc `getblindvalue` and HTTP endpoint `GET /wallet/:id/blindvalue/:blind`
+which accept a blind (hash) and returns a `BlindValue` in JSON format if it is found in the txdb.
 
 ## v2.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,17 @@
 # HSD Release Notes & Changelog
 
-## vX.Y.Z
+## unreleased
 
 ### Wallet API changes
 
-Creating a watch-only wallet now requires an `account-key` (or `accountKey`)
+- Adds new wallet rpc `getblindvalue` which accepts a blind (hash) and returns a
+`BlindValue` in JSON format if it is found in the txdb.
+
+## v2.0.0
+
+### Wallet API changes
+
+- Creating a watch-only wallet now requires an `account-key` (or `accountKey`)
 argument. This is to prevent hsd from generating keys and addresses the user
 can not spend from.
 

--- a/lib/wallet/http.js
+++ b/lib/wallet/http.js
@@ -1009,6 +1009,21 @@ class HTTP extends Server {
       });
     });
 
+    // Retrieve BlindValue
+    this.get('/wallet/:id/blindvalue/:blind', async (req, res) => {
+      const valid = Validator.fromRequest(req);
+      const blind = valid.buf('blind');
+
+      assert(blind, 'Blind is required.');
+
+      const bv = await req.wallet.getBlind(blind);
+
+      if (!bv)
+        return res.json(400);
+
+      return res.json(200, bv);
+    });
+
     // Create Open
     this.post('/wallet/:id/open', async (req, res) => {
       const valid = Validator.fromRequest(req);

--- a/lib/wallet/rpc.js
+++ b/lib/wallet/rpc.js
@@ -188,6 +188,7 @@ class RPC extends RPCBase {
     this.add('sendfinalize', this.sendFinalize);
     this.add('sendrevoke', this.sendRevoke);
     this.add('importnonce', this.importNonce);
+    this.add('getblindvalue', this.getBlindValue);
     this.add('createopen', this.createOpen);
     this.add('createbid', this.createBid);
     this.add('createreveal', this.createReveal);
@@ -2391,6 +2392,25 @@ class RPC extends RPCBase {
     const blind = await wallet.generateBlind(nameHash, address, value);
 
     return blind.toString('hex');
+  }
+
+  async getBlindValue(args, help) {
+    if (help || args.length !== 1)
+      throw new RPCError(errs.MISC_ERROR, 'getblindvalue "blind"');
+
+    const wallet = this.wallet;
+    const valid = new Validator(args);
+    const blind = valid.buf(0);
+
+    if (!blind)
+      throw new RPCError(errs.TYPE_ERROR, 'Invalid hex string.');
+
+    const bv = await wallet.getBlind(blind);
+
+    if (!bv)
+      throw new RPCError(errs.MISC_ERROR, 'Blind value not found.');
+
+    return bv;
   }
 }
 


### PR DESCRIPTION
An imported wallet may "forget" the blinded value of a bid since it is not recoverable from the seed and blockchain data. This new rpc call queries the txdb for the preimage (BlindValue) for a hash (blind). It will be useful to inform the user that the bid value is missing before the user tries to sendreveal and ends up with a "Blind value not found" error. Wallet applications can test this rpc call and inform the user they need to run `importnonce`.

Related:
https://github.com/handshake-org/hsd/issues/378
https://github.com/kyokan/bob-wallet/issues/110
