### PR TITLE
Specify the lockup period in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,7 +303,7 @@ $ hsw-rpc sendclaim example
 
 This will create and broadcast the proof to all of your peers, ultimately
 ending up in a miner's mempool. Your claim should be mined within 5-20 minutes.
-Once mined, you must wait 43,200 blocks – about a 30 days – before your claim is considered
+Once the transaction is mined, you must wait about 30 days (43,200 blocks) before your claim is considered
 "mature".
 
 Once the claim has reached maturity, you are able to bypass the auction process

--- a/README.md
+++ b/README.md
@@ -303,7 +303,7 @@ $ hsw-rpc sendclaim example
 
 This will create and broadcast the proof to all of your peers, ultimately
 ending up in a miner's mempool. Your claim should be mined within 5-20 minutes.
-Once the transaction is mined, you must wait about 30 days (43,200 blocks) before your claim is considered
+Once the transaction is mined, you must wait about 30 days (4,320 blocks) before your claim is considered
 "mature".
 
 Once the claim has reached maturity, you are able to bypass the auction process

--- a/README.md
+++ b/README.md
@@ -303,7 +303,7 @@ $ hsw-rpc sendclaim example
 
 This will create and broadcast the proof to all of your peers, ultimately
 ending up in a miner's mempool. Your claim should be mined within 5-20 minutes.
-Once mined, you must wait several blocks before your claim is considered
+Once mined, you must wait 43,200 blocks – about a 30 days – before your claim is considered
 "mature".
 
 Once the claim has reached maturity, you are able to bypass the auction process


### PR DESCRIPTION
Someone claiming their name was confused by the phrase "you must wait several blocks".  They thought claiming would take less than an hour. This copy is more clear.

For reference, the lockupPeriod is specified in networks.js:
https://github.com/handshake-org/hsd/blob/bbac8dd943767da62e46e52f93227b3da1048e17/lib/protocol/networks.js#L266