### PR TITLE
bin: add sigint listener for safer shutdown

### DIFF
--- a/bin/node
+++ b/bin/node
@@ -46,6 +46,10 @@ process.on('unhandledRejection', (err, promise) => {
   throw err;
 });
 
+process.on('SIGINT', async () => {
+  await node.close();
+});
+
 (async () => {
   await node.ensure();
   await node.open();

--- a/bin/spvnode
+++ b/bin/spvnode
@@ -63,6 +63,10 @@ process.on('unhandledRejection', (err, promise) => {
   throw err;
 });
 
+process.on('SIGINT', async () => {
+  await node.close();
+});
+
 (async () => {
   await node.ensure();
   await node.open();

--- a/bin/wallet
+++ b/bin/wallet
@@ -38,6 +38,10 @@ process.on('unhandledRejection', (err, promise) => {
   throw err;
 });
 
+process.on('SIGINT', async () => {
+  await node.close();
+});
+
 (async () => {
   await node.ensure();
   await node.open();


### PR DESCRIPTION
Adds a listener in `bin/{node,spvnode,wallet}` on the `process` for `SIGINT` which then safely shuts down the node using `node.close`.

Port of https://github.com/bcoin-org/bcoin/commit/b18a8a3f13e147b607887b4adeadf49c8d7532fa.