### PR TITLE
Wallet: enable importing names and "watch" for auction activity without bidding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # HSD Release Notes & Changelog
 
-## vX.Y.Z
+## unreleased
+
+### Wallet API changes
+
+- Adds new wallet rpc `importname` that enables user to "watch" a name and track
+its auction progress without bidding on it directly.
+
+## v2.0.0
 
 ### Wallet API changes
 

--- a/lib/wallet/rpc.js
+++ b/lib/wallet/rpc.js
@@ -143,6 +143,7 @@ class RPC extends RPCBase {
     this.add('importaddress', this.importAddress);
     this.add('importprunedfunds', this.importPrunedFunds);
     this.add('importpubkey', this.importPubkey);
+    this.add('importname', this.importName);
     this.add('keypoolrefill', this.keyPoolRefill);
     this.add('listaccounts', this.listAccounts);
     this.add('listaddressgroupings', this.listAddressGroupings);
@@ -886,6 +887,28 @@ class RPC extends RPCBase {
 
     if (rescan)
       await this.wdb.rescan(0);
+
+    return null;
+  }
+
+  async importName(args, help) {
+    if (help || args.length < 1 || args.length > 2) {
+      throw new RPCError(errs.MISC_ERROR,
+        'importname "name" ( height )');
+    }
+
+    const wallet = this.wallet;
+    const valid = new Validator(args);
+    const name = valid.str(0);
+    const height = valid.u32(1);
+
+    if (!name || !rules.verifyName(name))
+      throw new RPCError(errs.TYPE_ERROR, 'Invalid name.');
+
+    await wallet.importName(name);
+
+    if (height != null)
+      await this.wdb.rescan(height);
 
     return null;
   }

--- a/lib/wallet/txdb.js
+++ b/lib/wallet/txdb.js
@@ -1856,8 +1856,17 @@ class TXDB {
         }
 
         case types.OPEN: {
-          if (!path)
+          if (!path) {
+            // Are we "watching" this name?
+            const map = await this.wdb.getNameMap(nameHash);
+            if (!map || !map.wids.has(this.wid))
+              break;
+
+            const name = covenant.get(2);
+            ns.set(name, height);
+            updated = true;
             break;
+          }
 
           if (ns.isNull()) {
             const name = covenant.get(2);

--- a/lib/wallet/wallet.js
+++ b/lib/wallet/wallet.js
@@ -1066,6 +1066,40 @@ class Wallet extends EventEmitter {
   }
 
   /**
+   * Import a name.
+   * Rescanning must be invoked manually.
+   * @param {String} name
+   * @returns {Promise}
+   */
+
+  async importName(name) {
+    const unlock = await this.writeLock.lock();
+    try {
+      return await this._importName(name);
+    } finally {
+      unlock();
+    }
+  }
+
+  /**
+   * Import a name without a lock.
+   * @private
+   * @param {String} name
+   * @returns {Promise}
+   */
+
+  async _importName(name) {
+    const nameHash = rules.hashName(name);
+
+    if (await this.txdb.hasNameState(nameHash))
+      throw new Error('Name already exists.');
+
+    const b = this.db.batch();
+    await this.wdb.addNameMap(b, nameHash, this.wid);
+    await b.write();
+  }
+
+  /**
    * Fill a transaction with inputs, estimate
    * transaction size, calculate fee, and add a change output.
    * @see MTX#selectCoins

--- a/test/wallet-importname-test.js
+++ b/test/wallet-importname-test.js
@@ -222,5 +222,14 @@ describe('Wallet Import Name', function() {
       for (const bid of charlieBids)
         assert(!bid.own);
     });
+
+    it('should not re-import name', async () => {
+      await wclient.execute('selectwallet', ['charlie']);
+
+      await assert.rejects(
+        wclient.execute('importname', [name, 0]),
+        {message: 'Name already exists.'}
+      );
+    });
   });
 });

--- a/test/wallet-importname-test.js
+++ b/test/wallet-importname-test.js
@@ -1,0 +1,189 @@
+/* eslint-env mocha */
+/* eslint prefer-arrow-callback: "off" */
+
+'use strict';
+
+const assert = require('bsert');
+const Network = require('../lib/protocol/network');
+const FullNode = require('../lib/node/fullnode');
+const Address = require('../lib/primitives/address');
+const rules = require('../lib/covenants/rules');
+
+const network = Network.get('regtest');
+
+const node = new FullNode({
+  memory: true,
+  network: 'regtest',
+  plugins: [require('../lib/wallet/plugin')]
+});
+
+const {wdb} = node.require('walletdb');
+
+const name = rules.grindName(5, 1, network);
+const nameHash = rules.hashName(name);
+const wrongName = rules.grindName(5, 1, network);
+const wrongNameHash = rules.hashName(wrongName);
+
+let alice, bob, aliceReceive, bobReceive;
+
+async function mineBlocks(n, addr) {
+  addr = addr ? addr : new Address().toString('regtest');
+  for (let i = 0; i < n; i++) {
+    const block = await node.miner.mineBlock(null, addr);
+    await node.chain.add(block);
+  }
+}
+
+describe('Wallet Import Name', function() {
+  before(async () => {
+    await node.open();
+
+    alice = await wdb.create();
+    bob = await wdb.create();
+
+    aliceReceive = await alice.receiveAddress();
+    bobReceive = await bob.receiveAddress();
+  });
+
+  after(async () => {
+    await node.close();
+  });
+
+  it('should fund both wallets', async () => {
+    await mineBlocks(2, aliceReceive);
+    await mineBlocks(2, bobReceive);
+
+    // Wallet rescan is an effective way to ensure that
+    // wallet and chain are synced before proceeding.
+    await wdb.rescan(0);
+
+    const aliceBal = await alice.getBalance();
+    const bobBal = await bob.getBalance();
+    assert(aliceBal.confirmed === 2000 * 2 * 1e6);
+    assert(bobBal.confirmed === 2000 * 2 * 1e6);
+  });
+
+  it('should open name from Alice\'s wallet', async () => {
+    // Alice an Bob are not tracking this name
+    const ns1 = await alice.getNameStateByName(name);
+    assert(ns1 === null);
+    const ns2 = await bob.getNameStateByName(name);
+    assert(ns2 === null);
+
+    await alice.sendOpen(name, false);
+    await alice.sendOpen(wrongName, false);
+
+    await mineBlocks(network.names.treeInterval);
+    await wdb.rescan(0);
+
+    // Alice is now tracking, Bob is not
+    const ns3 = await alice.getNameStateByName(name);
+    assert(ns3);
+    const ns4 = await bob.getNameStateByName(name);
+    assert(ns4 === null);
+  });
+
+  it('should not re-import an existing name', async () => {
+    await assert.rejects(
+      alice.importName(name),
+      {message: 'Name already exists.'}
+    );
+  });
+
+  it('should bid on names from Alice\'s wallet', async () => {
+    // Sanity check: bids are allowed starting in the NEXT block
+    await assert.rejects(
+      alice.sendBid(name, 100001, 200001),
+      {message: 'Name has not reached the bidding phase yet.'}
+    );
+    await mineBlocks(1);
+    await wdb.rescan(0);
+
+    // Send 1 bid, confirm
+    await alice.sendBid(name, 100001, 200001);
+    await mineBlocks(1);
+
+    // Send 2 bids in one block, confirm
+    await alice.sendBid(name, 100002, 200002);
+    await alice.sendBid(name, 100003, 200003);
+    await mineBlocks(1);
+
+    // Send 3 bids in one block, confirm
+    await alice.sendBid(name, 100004, 200004);
+    await alice.sendBid(name, 100005, 200005);
+    await alice.sendBid(name, 100006, 200006);
+    await mineBlocks(1);
+
+    // One block with some bids for another name
+    await alice.sendBid(wrongName, 100007, 200007);
+    await alice.sendBid(wrongName, 100008, 200008);
+    await mineBlocks(1);
+
+    // Still in the bidding phase with one block left
+    const ns = await node.chain.db.getNameStateByName(name);
+    assert(ns.isBidding(node.chain.height + 1, network));
+
+    await wdb.rescan(0);
+
+    // Alice is tracking auction, Bob is not
+    const aliceBids = await alice.getBidsByName(name);
+    assert.strictEqual(aliceBids.length, 6);
+    for (const bid of aliceBids)
+      assert(bid.own);
+
+    const bobBids = await bob.getBidsByName(name);
+    assert.strictEqual(bobBids.length, 0);
+  });
+
+  it('should import name into Bob\'s wallet', async () => {
+    await bob.importName(name);
+
+    // Bob's wallet still has no name data for this name
+    const ns1 = await bob.getNameStateByName(name);
+    assert(ns1 === null);
+
+    // The WalletDB knows Alice & Bob are watching this name
+    const map1 = await wdb.getNameMap(nameHash);
+    assert(map1.wids.has(alice.wid));
+    assert(map1.wids.has(bob.wid));
+
+    // Only Alice is watching the other name
+    const map2 = await wdb.getNameMap(wrongNameHash);
+    assert(map1.wids.has(alice.wid));
+    assert(!map2.wids.has(bob.wid));
+  });
+
+  it('should not track bids for imported name before OPEN', async () => {
+    // Rescan covers bidding phase but does not include OPEN transaction
+    await wdb.rescan(6);
+
+    // Alice is tracking auction, Bob is not
+    const aliceBids = await alice.getBidsByName(name);
+    assert.strictEqual(aliceBids.length, 6);
+    for (const bid of aliceBids)
+      assert(bid.own);
+
+    const bobBids = await bob.getBidsByName(name);
+    assert.strictEqual(bobBids.length, 0);
+  });
+
+  it('should start tracking bids after seeing OPEN', async () => {
+    await wdb.rescan(0);
+
+    // After a sufficient rescan, Bob now has all auction data
+    const ns2 = await bob.getNameStateByName(name);
+    assert(ns2);
+
+    // ...even though he hasn't placed a bid yet
+    const bobBids = await bob.getBidsByName(name);
+    assert.strictEqual(bobBids.length, 6);
+    for (const bid of bobBids)
+      assert(!bid.own);
+
+    // Sanity check: only the "right" name was imported
+    const ns3 = await bob.getNameStateByName(wrongName);
+    assert(ns3 === null);
+    const ns4 = await alice.getNameStateByName(wrongName);
+    assert(ns4);
+  });
+});


### PR DESCRIPTION
This enables a user to import a name into their wallet in a similar way to importing an address or public key. A rescan is still required to recover any auction activity and in particular the OPEN for a name MUST be rescanned or the wallet will not record a `nameState` or track any bids.

The WalletDB global `name->wid` map is used as a "watch" marker to determine if a name's OPEN should be added to the txdb.

The new rpc command takes a rescan height parameter:

```
hsw-rpc importname sad 2016
```

Wallet applications should check the state of a name and use a name's `height - 1` as the rescan height. Assuming the auction is still in bidding phase, this will initiate a wallet rescan of maximum 5 days.



See https://github.com/kyokan/bob-wallet/issues/108