### PR TITLE
wallet: return wdb height in rpc getwalletinfo

### DIFF
--- a/lib/wallet/rpc.js
+++ b/lib/wallet/rpc.js
@@ -757,7 +757,8 @@ class RPC extends RPCBase {
       keypoololdest: 0,
       keypoolsize: 0,
       unlocked_until: wallet.master.until,
-      paytxfee: Amount.coin(this.wdb.feeRate, true)
+      paytxfee: Amount.coin(this.wdb.feeRate, true),
+      height: this.wdb.height
     };
   }
 

--- a/test/wallet-rpc-test.js
+++ b/test/wallet-rpc-test.js
@@ -318,5 +318,11 @@ describe('Wallet RPC Methods', function() {
 
       assert.strictEqual(verify, true);
     });
+
+    it('should get wallet info', async () => {
+      const info = await wclient.execute('getwalletinfo', []);
+      assert.strictEqual(info.walletid, 'primary');
+      assert.strictEqual(info.height, node.chain.height);
+    });
   });
 });


### PR DESCRIPTION
This will be especially useful when a rescan is in progress. Clients can poll the value and compare to the Full Node's chain height. There is currently no other way to know when a rescan is "done".

We could also add event emitters when the wdb adds a block, but there's no really great way for the wallet to know when it is in sync with the chain since they are essentially separate processes with different state.