### PR TITLE
rpc: add extra_nonce to block's JSON.

### DIFF
--- a/lib/node/rpc.js
+++ b/lib/node/rpc.js
@@ -2923,6 +2923,7 @@ class RPC extends RPCBase {
       time: entry.time,
       mediantime: mtp,
       nonce: entry.nonce,
+      extranonce: entry.extraNonce.toString('hex'),
       bits: hex32(entry.bits),
       difficulty: toDifficulty(entry.bits),
       chainwork: entry.chainwork.toString('hex', 64),

--- a/lib/node/rpc.js
+++ b/lib/node/rpc.js
@@ -2873,6 +2873,7 @@ class RPC extends RPCBase {
       time: entry.time,
       mediantime: mtp,
       nonce: entry.nonce,
+      extranonce: entry.extraNonce.toString('hex'),
       bits: hex32(entry.bits),
       difficulty: toDifficulty(entry.bits),
       chainwork: entry.chainwork.toString('hex', 64),


### PR DESCRIPTION
This feels like it should belong here, as I don't know if there is any other way to query the extra_nonce from blocks. 