### PR TITLE
node rpc: validateresource

### DIFF
--- a/lib/dns/resource.js
+++ b/lib/dns/resource.js
@@ -349,11 +349,11 @@ class Resource extends Struct {
   }
 
   fromJSON(json) {
-    assert(json && typeof json === 'object');
-    assert(Array.isArray(json.records));
+    assert(json && typeof json === 'object', 'Invalid json.');
+    assert(Array.isArray(json.records), 'Invalid records.');
 
     for (const item of json.records) {
-      assert(item && typeof item === 'object');
+      assert(item && typeof item === 'object', 'Invalid record.');
 
       const RD = stringToClass(item.type);
 
@@ -437,13 +437,19 @@ class DS extends Struct {
   }
 
   fromJSON(json) {
-    assert(json && typeof json === 'object');
-    assert(json.type === 'DS');
-    assert((json.keyTag & 0xffff) === json.keyTag);
-    assert((json.algorithm & 0xff) === json.algorithm);
-    assert((json.digestType & 0xff) === json.digestType);
-    assert(typeof json.digest === 'string');
-    assert((json.digest.length >>> 1) <= 255);
+    assert(json && typeof json === 'object', 'Invalid DS record.');
+    assert(json.type === 'DS',
+      'Invalid DS record. Property "type" must be "DS".');
+    assert((json.keyTag & 0xffff) === json.keyTag,
+      'Invalid DS record. Property "keyTag" must be a uint16.');
+    assert((json.algorithm & 0xff) === json.algorithm,
+      'Invalid DS record. Property "algorithm" must be a uint8.');
+    assert((json.digestType & 0xff) === json.digestType,
+      'Invalid DS record. Property "digestType" must be a uint8.');
+    assert(typeof json.digest === 'string',
+      'Invalid DS record. Property "digest" must be a String.');
+    assert((json.digest.length >>> 1) <= 255,
+      'Invalid DS record. Property "digest" is too large.');
 
     this.keyTag = json.keyTag;
     this.algorithm = json.algorithm;
@@ -495,9 +501,12 @@ class NS extends Struct {
   }
 
   fromJSON(json) {
-    assert(json && typeof json === 'object');
-    assert(json.type === 'NS');
-    assert(isName(json.ns));
+    assert(json && typeof json === 'object',
+      'Invalid NS record.');
+    assert(json.type === 'NS',
+      'Invalid NS record. Property "type" must be "NS".');
+    assert(isName(json.ns),
+      'Invalid NS record. Property "ns" must be a valid name.');
 
     this.ns = json.ns;
 
@@ -554,10 +563,13 @@ class GLUE4 extends Struct {
   }
 
   fromJSON(json) {
-    assert(json && typeof json === 'object');
-    assert(json.type === 'GLUE4');
-    assert(isName(json.ns));
-    assert(IP.isIPv4String(json.address));
+    assert(json && typeof json === 'object', 'Invalid GLUE4 record.');
+    assert(json.type === 'GLUE4',
+      'Invalid GLUE4 record. Property "type" must be "GLUE4".');
+    assert(isName(json.ns),
+      'Invalid GLUE4 record. Property "ns" must be a valid name.');
+    assert(IP.isIPv4String(json.address),
+      'Invalid GLUE4 record. Property "address" must be a IPv4 address.');
 
     this.ns = json.ns;
     this.address = IP.normalize(json.address);
@@ -615,10 +627,13 @@ class GLUE6 extends Struct {
   }
 
   fromJSON(json) {
-    assert(json && typeof json === 'object');
-    assert(json.type === 'GLUE6');
-    assert(isName(json.ns));
-    assert(IP.isIPv6String(json.address));
+    assert(json && typeof json === 'object', 'Invalid GLUE6 record.');
+    assert(json.type === 'GLUE6',
+      'Invalid GLUE6 record. Property "type" must be "GLUE6".');
+    assert(isName(json.ns),
+      'Invalid GLUE6 record. Property "ns" must be a valid name.');
+    assert(IP.isIPv6String(json.address),
+      'Invalid GLUE6 record. Property "address" must be a IPv6 address.');
 
     this.ns = json.ns;
     this.address = IP.normalize(json.address);
@@ -677,9 +692,11 @@ class SYNTH4 extends Struct {
   }
 
   fromJSON(json) {
-    assert(json && typeof json === 'object');
-    assert(json.type === 'SYNTH4');
-    assert(IP.isIPv4String(json.address));
+    assert(json && typeof json === 'object', 'Invalid SYNTH4 record.');
+    assert(json.type === 'SYNTH4',
+      'Invalid SYNTH4 record. Property "type" must be "SYNTH4".');
+    assert(IP.isIPv4String(json.address),
+      'Invalid SYNTH4 record. Property "address" must be a IPv4 address.');
 
     this.address = IP.normalize(json.address);
 
@@ -737,9 +754,11 @@ class SYNTH6 extends Struct {
   }
 
   fromJSON(json) {
-    assert(json && typeof json === 'object');
-    assert(json.type === 'SYNTH6');
-    assert(IP.isIPv6String(json.address));
+    assert(json && typeof json === 'object', 'Invalid SYNTH6 record.');
+    assert(json.type === 'SYNTH6',
+      'Invalid SYNTH6 record. Property "type" must be "SYNTH6".');
+    assert(IP.isIPv6String(json.address),
+      'Invalid SYNTH6 record. Property "address" must be a IPv6 address.');
 
     this.address = IP.normalize(json.address);
 
@@ -812,13 +831,18 @@ class TXT extends Struct {
   }
 
   fromJSON(json) {
-    assert(json && typeof json === 'object');
-    assert(json.type === 'TXT');
-    assert(Array.isArray(json.txt));
+    assert(json && typeof json === 'object',
+      'Invalid TXT record.');
+    assert(json.type === 'TXT',
+      'Invalid TXT record. Property "type" must be "TXT".');
+    assert(Array.isArray(json.txt),
+      'Invalid TXT record. Property "txt" must be an Array.');
 
     for (const txt of json.txt) {
-      assert(typeof txt === 'string');
-      assert(txt.length <= 255);
+      assert(typeof txt === 'string',
+        'Invalid TXT record. Entries in "txt" Array must be strings.');
+      assert(txt.length <= 255,
+        'Invalid TXT record. Entries in "txt" Array must be <= 255 in length.');
 
       this.txt.push(txt);
     }

--- a/lib/dns/resource.js
+++ b/lib/dns/resource.js
@@ -439,17 +439,17 @@ class DS extends Struct {
   fromJSON(json) {
     assert(json && typeof json === 'object', 'Invalid DS record.');
     assert(json.type === 'DS',
-      'Invalid DS record. Property "type" must be "DS".');
+      'Invalid DS record. Type must be "DS".');
     assert((json.keyTag & 0xffff) === json.keyTag,
-      'Invalid DS record. Property "keyTag" must be a uint16.');
+      'Invalid DS record. KeyTag must be a uint16.');
     assert((json.algorithm & 0xff) === json.algorithm,
-      'Invalid DS record. Property "algorithm" must be a uint8.');
+      'Invalid DS record. Algorithm must be a uint8.');
     assert((json.digestType & 0xff) === json.digestType,
-      'Invalid DS record. Property "digestType" must be a uint8.');
+      'Invalid DS record. DigestType must be a uint8.');
     assert(typeof json.digest === 'string',
-      'Invalid DS record. Property "digest" must be a String.');
+      'Invalid DS record. Digest must be a String.');
     assert((json.digest.length >>> 1) <= 255,
-      'Invalid DS record. Property "digest" is too large.');
+      'Invalid DS record. Digest is too large.');
 
     this.keyTag = json.keyTag;
     this.algorithm = json.algorithm;
@@ -504,9 +504,9 @@ class NS extends Struct {
     assert(json && typeof json === 'object',
       'Invalid NS record.');
     assert(json.type === 'NS',
-      'Invalid NS record. Property "type" must be "NS".');
+      'Invalid NS record. Type must be "NS".');
     assert(isName(json.ns),
-      'Invalid NS record. Property "ns" must be a valid name.');
+      'Invalid NS record. ns must be a valid name.');
 
     this.ns = json.ns;
 
@@ -565,11 +565,11 @@ class GLUE4 extends Struct {
   fromJSON(json) {
     assert(json && typeof json === 'object', 'Invalid GLUE4 record.');
     assert(json.type === 'GLUE4',
-      'Invalid GLUE4 record. Property "type" must be "GLUE4".');
+      'Invalid GLUE4 record. Type must be "GLUE4".');
     assert(isName(json.ns),
-      'Invalid GLUE4 record. Property "ns" must be a valid name.');
+      'Invalid GLUE4 record. ns must be a valid name.');
     assert(IP.isIPv4String(json.address),
-      'Invalid GLUE4 record. Property "address" must be a IPv4 address.');
+      'Invalid GLUE4 record. Address must be a valid IPv4 address.');
 
     this.ns = json.ns;
     this.address = IP.normalize(json.address);
@@ -629,11 +629,11 @@ class GLUE6 extends Struct {
   fromJSON(json) {
     assert(json && typeof json === 'object', 'Invalid GLUE6 record.');
     assert(json.type === 'GLUE6',
-      'Invalid GLUE6 record. Property "type" must be "GLUE6".');
+      'Invalid GLUE6 record. Type must be "GLUE6".');
     assert(isName(json.ns),
-      'Invalid GLUE6 record. Property "ns" must be a valid name.');
+      'Invalid GLUE6 record. ns must be a valid name.');
     assert(IP.isIPv6String(json.address),
-      'Invalid GLUE6 record. Property "address" must be a IPv6 address.');
+      'Invalid GLUE6 record. Address must be a valid IPv6 address.');
 
     this.ns = json.ns;
     this.address = IP.normalize(json.address);
@@ -694,9 +694,9 @@ class SYNTH4 extends Struct {
   fromJSON(json) {
     assert(json && typeof json === 'object', 'Invalid SYNTH4 record.');
     assert(json.type === 'SYNTH4',
-      'Invalid SYNTH4 record. Property "type" must be "SYNTH4".');
+      'Invalid SYNTH4 record. Type must be "SYNTH4".');
     assert(IP.isIPv4String(json.address),
-      'Invalid SYNTH4 record. Property "address" must be a IPv4 address.');
+      'Invalid SYNTH4 record. Address must be a valid IPv4 address.');
 
     this.address = IP.normalize(json.address);
 
@@ -756,9 +756,9 @@ class SYNTH6 extends Struct {
   fromJSON(json) {
     assert(json && typeof json === 'object', 'Invalid SYNTH6 record.');
     assert(json.type === 'SYNTH6',
-      'Invalid SYNTH6 record. Property "type" must be "SYNTH6".');
+      'Invalid SYNTH6 record. Type must be "SYNTH6".');
     assert(IP.isIPv6String(json.address),
-      'Invalid SYNTH6 record. Property "address" must be a IPv6 address.');
+      'Invalid SYNTH6 record. Address must be a valid IPv6 address.');
 
     this.address = IP.normalize(json.address);
 
@@ -834,15 +834,15 @@ class TXT extends Struct {
     assert(json && typeof json === 'object',
       'Invalid TXT record.');
     assert(json.type === 'TXT',
-      'Invalid TXT record. Property "type" must be "TXT".');
+      'Invalid TXT record. Type must be "TXT".');
     assert(Array.isArray(json.txt),
-      'Invalid TXT record. Property "txt" must be an Array.');
+      'Invalid TXT record. txt must be an Array.');
 
     for (const txt of json.txt) {
       assert(typeof txt === 'string',
-        'Invalid TXT record. Entries in "txt" Array must be strings.');
+        'Invalid TXT record. Entries in txt Array must be type String.');
       assert(txt.length <= 255,
-        'Invalid TXT record. Entries in "txt" Array must be <= 255 in length.');
+        'Invalid TXT record. Entries in txt Array must be <= 255 in length.');
 
       this.txt.push(txt);
     }

--- a/lib/node/rpc.js
+++ b/lib/node/rpc.js
@@ -241,6 +241,7 @@ class RPC extends RPCBase {
     this.add('grindname', this.grindName);
     this.add('sendrawclaim', this.sendRawClaim);
     this.add('sendrawairdrop', this.sendRawAirdrop);
+    this.add('validateresource', this.validateResource);
 
     // Compat
     // this.add('getnameinfo', this.getNameInfo);
@@ -2475,6 +2476,27 @@ class RPC extends RPCBase {
     this.node.relayAirdrop(proof);
 
     return proof.hash().toString('hex');
+  }
+
+  async validateResource(args, help) {
+    if (help || args.length < 1 || args.length > 2)
+      throw new RPCError(errs.MISC_ERROR, 'validateresource'
+        + ' \'{"records": [{...}]}\'');
+
+    const valid = new Validator(args);
+    const data = valid.obj(0);
+
+    if (!data)
+      throw new RPCError(errs.TYPE_ERROR, 'Invalid resource object.');
+
+    let resource;
+    try {
+      resource = Resource.fromJSON(data);
+    } catch (e) {
+      throw new RPCError(errs.PARSE_ERROR, e.message);
+    }
+
+    return resource.toJSON();
   }
 
   /*

--- a/test/node-rpc-test.js
+++ b/test/node-rpc-test.js
@@ -130,5 +130,95 @@ describe('RPC', function() {
       const info = await nclient.execute('getblock', [hash]);
       assert.deepEqual(info.confirmations, -1);
     });
+
+    it('should validateresource (valid)', async () => {
+      const records = [
+        [{type: 'NS', ns: 'ns1.handshake.org.'}],
+        [{type: 'DS', keyTag: 0xffff, algorithm: 0xff, digestType: 0xff, digest: '00'.repeat(32)}],
+        [{type: 'TXT', txt: ['i like turtles', 'then who phone']}],
+        [{type: 'GLUE4', ns: 'ns1.nam.ek.', address: '192.168.0.1'}],
+        [{type: 'GLUE6', ns: 'ns2.nam.ek.', address: '::'}],
+        [{type: 'SYNTH4', address: '192.168.0.1'}],
+        [{type: 'SYNTH6', address: '::'}]
+      ];
+
+      for (const record of records) {
+        const data = {records: record};
+        const info = await nclient.execute('validateresource', [data]);
+        assert.deepEqual(info, data);
+      }
+    });
+
+    it('should validateresource (invalid)', async () => {
+      const records = [
+        [
+          // No trailing dot
+          [{type: 'NS', ns: 'ns1.handshake.org'}],
+          'Invalid NS record. Property "ns" must be a valid name.'
+        ],
+        [
+          [{type: 'DS', keyTag: 0xffffff}],
+          'Invalid DS record. Property "keyTag" must be a uint16.'
+        ],
+        [
+          [{type: 'DS', keyTag: 0xffff, algorithm: 0xffff}],
+          'Invalid DS record. Property "algorithm" must be a uint8.'
+        ],
+        [
+          [{type: 'DS', keyTag: 0xffff, algorithm: 0xff, digestType: 0xffff}],
+          'Invalid DS record. Property "digestType" must be a uint8.'
+        ],
+        [
+          [{type: 'DS', keyTag: 0xffff, algorithm: 0xff, digestType: 0xff, digest: Buffer.alloc(0)}],
+          'Invalid DS record. Property "digest" must be a String.'
+        ],
+        [
+          [{type: 'DS', keyTag: 0xffff, algorithm: 0xff, digestType: 0xff, digest: '00'.repeat(256)}],
+          'Invalid DS record. Property "digest" is too large.'
+        ],
+        [
+          [{type: 'TXT', txt: 'foobar'}],
+          'Invalid TXT record. Property "txt" must be an Array.'
+        ],
+        [
+          [{type: 'TXT', txt: ['0'.repeat(256)]}],
+          'Invalid TXT record. Entries in "txt" Array must be <= 255 in length.'
+        ],
+        [
+          [{type: 'GLUE4', ns: 'ns1.nam.ek', address: '192.168.0.1'}],
+          'Invalid GLUE4 record. Property "ns" must be a valid name.'
+        ],
+        [
+          [{type: 'GLUE4', ns: 'ns1.nam.ek.', address: '::'}],
+          'Invalid GLUE4 record. Property "address" must be a IPv4 address.'
+        ],
+        [
+          [{type: 'GLUE6', ns: 'ns1.nam.ek', address: '::'}],
+          'Invalid GLUE6 record. Property "ns" must be a valid name.'
+        ],
+        [
+          [{type: 'GLUE6', ns: 'ns1.nam.ek.', address: '0.0.0.0'}],
+          'Invalid GLUE6 record. Property "address" must be a IPv6 address.'
+        ],
+        [
+          [{type: 'SYNTH4', address: '::'}],
+          'Invalid SYNTH4 record. Property "address" must be a IPv4 address.'
+        ],
+        [
+          [{type: 'SYNTH6', address: '127.0.0.1'}],
+          'Invalid SYNTH6 record. Property "address" must be a IPv6 address.'
+        ]
+      ];
+
+      for (const [record, reason] of records) {
+        try {
+          const data = {records: record};
+          await nclient.execute('validateresource', [data]);
+          assert.fail();
+        } catch (e) {
+          assert.equal(e.message, reason);
+        }
+      }
+    });
   });
 });

--- a/test/node-rpc-test.js
+++ b/test/node-rpc-test.js
@@ -154,59 +154,63 @@ describe('RPC', function() {
         [
           // No trailing dot
           [{type: 'NS', ns: 'ns1.handshake.org'}],
-          'Invalid NS record. Property "ns" must be a valid name.'
+          'Invalid NS record. ns must be a valid name.'
         ],
         [
           [{type: 'DS', keyTag: 0xffffff}],
-          'Invalid DS record. Property "keyTag" must be a uint16.'
+          'Invalid DS record. KeyTag must be a uint16.'
         ],
         [
           [{type: 'DS', keyTag: 0xffff, algorithm: 0xffff}],
-          'Invalid DS record. Property "algorithm" must be a uint8.'
+          'Invalid DS record. Algorithm must be a uint8.'
         ],
         [
           [{type: 'DS', keyTag: 0xffff, algorithm: 0xff, digestType: 0xffff}],
-          'Invalid DS record. Property "digestType" must be a uint8.'
+          'Invalid DS record. DigestType must be a uint8.'
         ],
         [
           [{type: 'DS', keyTag: 0xffff, algorithm: 0xff, digestType: 0xff, digest: Buffer.alloc(0)}],
-          'Invalid DS record. Property "digest" must be a String.'
+          'Invalid DS record. Digest must be a String.'
         ],
         [
           [{type: 'DS', keyTag: 0xffff, algorithm: 0xff, digestType: 0xff, digest: '00'.repeat(256)}],
-          'Invalid DS record. Property "digest" is too large.'
+          'Invalid DS record. Digest is too large.'
         ],
         [
           [{type: 'TXT', txt: 'foobar'}],
-          'Invalid TXT record. Property "txt" must be an Array.'
+          'Invalid TXT record. txt must be an Array.'
+        ],
+        [
+          [{type: 'TXT', txt: [{}]}],
+          'Invalid TXT record. Entries in txt Array must be type String.'
         ],
         [
           [{type: 'TXT', txt: ['0'.repeat(256)]}],
-          'Invalid TXT record. Entries in "txt" Array must be <= 255 in length.'
+          'Invalid TXT record. Entries in txt Array must be <= 255 in length.'
         ],
         [
           [{type: 'GLUE4', ns: 'ns1.nam.ek', address: '192.168.0.1'}],
-          'Invalid GLUE4 record. Property "ns" must be a valid name.'
+          'Invalid GLUE4 record. ns must be a valid name.'
         ],
         [
           [{type: 'GLUE4', ns: 'ns1.nam.ek.', address: '::'}],
-          'Invalid GLUE4 record. Property "address" must be a IPv4 address.'
+          'Invalid GLUE4 record. Address must be a valid IPv4 address.'
         ],
         [
           [{type: 'GLUE6', ns: 'ns1.nam.ek', address: '::'}],
-          'Invalid GLUE6 record. Property "ns" must be a valid name.'
+          'Invalid GLUE6 record. ns must be a valid name.'
         ],
         [
           [{type: 'GLUE6', ns: 'ns1.nam.ek.', address: '0.0.0.0'}],
-          'Invalid GLUE6 record. Property "address" must be a IPv6 address.'
+          'Invalid GLUE6 record. Address must be a valid IPv6 address.'
         ],
         [
           [{type: 'SYNTH4', address: '::'}],
-          'Invalid SYNTH4 record. Property "address" must be a IPv4 address.'
+          'Invalid SYNTH4 record. Address must be a valid IPv4 address.'
         ],
         [
           [{type: 'SYNTH6', address: '127.0.0.1'}],
-          'Invalid SYNTH6 record. Property "address" must be a IPv6 address.'
+          'Invalid SYNTH6 record. Address must be a valid IPv6 address.'
         ]
       ];
 


### PR DESCRIPTION
This PR adds a new Node RPC method called `validateresource`. It is useful for users who are in the process of creating their resource JSON to use with `sendupdate`. This PR adds error messages in the `fromJSON` methods of each of the records found in `lib/dns/resource.js`.

The RPC accepts a single object with the `records` property, which must be an array of objects.
Eventually, it could also accept a `version` property if another Resource version is implemented.

The error messages note the invalid JSON property name and the record type. This is so that good error messages can be returned to users. The error messages could be made generic (not including the record type in the error message) but that would mean that the RPC method handler itself would have to hold logic similar to `Resource.fromJSON` and keep track of which `record` failed its `fromJSON`. I don't like this approach as much since any new resource type will require its `fromJSON` logic to be added to the RPC method handler but am willing to update this PR if people are strongly opinionated in that way.

Closes https://github.com/handshake-org/hsd/issues/139