### PR TITLE
http: add endpoint for balance by address.

### DIFF
--- a/lib/blockchain/chain.js
+++ b/lib/blockchain/chain.js
@@ -899,7 +899,6 @@ class Chain extends AsyncEmitter {
       if (!covenant.isName())
         continue;
 
-      debugger;
       const nameHash = covenant.getHash(0);
       const start = covenant.getU32(1);
       const ns = await view.getNameState(this.db, nameHash);

--- a/lib/blockchain/chain.js
+++ b/lib/blockchain/chain.js
@@ -899,6 +899,7 @@ class Chain extends AsyncEmitter {
       if (!covenant.isName())
         continue;
 
+      debugger;
       const nameHash = covenant.getHash(0);
       const start = covenant.getU32(1);
       const ns = await view.getNameState(this.db, nameHash);

--- a/lib/node/http.js
+++ b/lib/node/http.js
@@ -21,6 +21,7 @@ const Claim = require('../primitives/claim');
 const Address = require('../primitives/address');
 const Network = require('../protocol/network');
 const pkg = require('../pkg');
+const rules = require('../covenants/rules');
 
 /**
  * HTTP
@@ -163,6 +164,37 @@ class HTTP extends Server {
         },
         memory: this.logger.memoryUsage()
       });
+    });
+
+    // Balance by address
+    this.get('/balance/:address', async (req, res) => {
+      const valid = Validator.fromRequest(req);
+      const address = valid.str('address');
+
+      enforce(address, 'Address is required.');
+      enforce(!this.chain.options.spv, 'Cannot get balance in SPV mode.');
+
+      const addr = Address.fromString(address, this.network);
+      const coins = await this.node.getCoinsByAddress(addr);
+      const result = {
+        height: this.chain.height,
+        balance: 0,
+        coins: [],
+        lockedBalance: 0,
+        lockedCoins: []
+      };
+
+      for (const coin of coins) {
+        if (coin.covenant.type === rules.types.NONE) {
+          result.balance += coin.value;
+          result.coins.push(coin.getJSON(this.network));
+        } else {
+          result.lockedBalance += coin.value;
+          result.lockedCoins.push(coin.getJSON(this.network));
+        }
+      }
+
+      res.json(200, result);
     });
 
     // UTXO by address

--- a/test/node-http-test.js
+++ b/test/node-http-test.js
@@ -120,7 +120,6 @@ describe('Node HTTP', function() {
         // Fund address & verify balance.
         const nextInterval = treeInterval;
         const addedReward = nextInterval * consensus.BASE_REWARD;
-
         const oBalance = await nclient.get(`/balance/${cbAddress}`);
         await mineBlocks(nextInterval, cbAddress);
         const nBalance = await nclient.get(`/balance/${cbAddress}`);
@@ -164,7 +163,6 @@ describe('Node HTTP', function() {
         // Mine to next interval & verify balance.
         const nextInterval = treeInterval + 1;
         const addedReward = nextInterval * consensus.BASE_REWARD;
-
         const oBalance = await nclient.get(`/balance/${cbAddress}`);
         await node.sendTX(mtx.toTX());
         await mineBlocks(nextInterval, cbAddress);
@@ -179,7 +177,7 @@ describe('Node HTTP', function() {
 
       {
         // Create bid.
-        const coins = await nclient.getCoinsByAddresses([cbAddress])
+        const coins = await nclient.getCoinsByAddresses([cbAddress]);
         coins.sort((a, b) => a.height - b.height);
         const covenants = coins.filter((coin) => {
           return coin.covenant.type === types.OPEN;
@@ -206,7 +204,6 @@ describe('Node HTTP', function() {
         // Mine to next interval & verify balance.
         const nextInterval = treeInterval;
         const addedReward = nextInterval * consensus.BASE_REWARD;
-
         const oBalance = await nclient.get(`/balance/${cbAddress}`);
         await node.sendTX(mtx.toTX());
         await mineBlocks(nextInterval, cbAddress);
@@ -218,7 +215,6 @@ describe('Node HTTP', function() {
         assert.equal(oBalance.lockedBalance + lockup, nBalance.lockedBalance);
         assert.equal(oBalance.lockedCoins.length, nBalance.lockedCoins.length);
       }
-
     });
   });
 


### PR DESCRIPTION
This endpoint allows users to query the balance of an arbitrary
address. It includes the current height of the chain, the unlocked
and locked balances, and arrays of the unlocked and locked coins.