### PR TITLE
node rpc: gettxoutset

### DIFF
--- a/lib/blockchain/chain.js
+++ b/lib/blockchain/chain.js
@@ -2606,6 +2606,15 @@ class Chain extends AsyncEmitter {
   }
 
   /**
+   * Get all coins.
+   * @returns {Promise} - Returns {@link Coin}[].
+   */
+
+  getCoins() {
+    return this.db.getCoins();
+  }
+
+  /**
    * Get all transaction hashes to an address.
    * @param {Address[]} addrs
    * @returns {Promise} - Returns {@link Hash}[].

--- a/lib/blockchain/chaindb.js
+++ b/lib/blockchain/chaindb.js
@@ -1109,6 +1109,30 @@ class ChainDB {
   }
 
   /**
+   * Get all coins.
+   * @returns {Promise} - Returns {@link Coin}.
+   */
+
+  async getCoins() {
+    const iter = this.db.iterator({
+      gte: layout.c.min(),
+      lte: layout.c.max(),
+      values: true
+    });
+
+    const coins = [];
+
+    await iter.each((key, value) => {
+      const entry = CoinEntry.decode(value);
+      const [hash, index] = layout.c.decode(key);
+      const coin = entry.toCoin({hash, index});
+      coins.push(coin);
+    });
+
+    return coins;
+  }
+
+  /**
    * Check whether coins are still unspent. Necessary for bip30.
    * @see https://bitcointalk.org/index.php?topic=67738.0
    * @param {TX} tx

--- a/lib/node/rpc.js
+++ b/lib/node/rpc.js
@@ -175,6 +175,7 @@ class RPC extends RPCBase {
     this.add('getrawmempool', this.getRawMempool);
     this.add('gettxout', this.getTXOut);
     this.add('gettxoutsetinfo', this.getTXOutSetInfo);
+    this.add('gettxoutset', this.getTXOutSet);
     this.add('pruneblockchain', this.pruneBlockchain);
     this.add('verifychain', this.verifyChain);
 
@@ -1075,6 +1076,19 @@ class RPC extends RPCBase {
       total_amount: Amount.coin(this.chain.db.state.value, true),
       total_burned: Amount.coin(this.chain.db.state.burned, true)
     };
+  }
+
+  async getTXOutSet(args, help) {
+    if (help || args.length !== 0)
+      throw new RPCError(errs.MISC_ERROR, 'gettxoutset');
+
+    const json = [];
+    const coins = await this.chain.getCoins();
+
+    for (const coin of coins)
+      json.push(coin.toJSON());
+
+    return json;
   }
 
   async pruneBlockchain(args, help) {


### PR DESCRIPTION
This pull request adds a new node RPC called `gettxoutset`. It returns all `Coins` and I implemented it so that I can observe the UTXO set easily.

While its currently not causing a denial of service, it could far in the future. According to a block explorer, there are currently about 67 million Bitcoin UTXOs. There are currently only 187,035 Handshake UTXOs as of Saturday, April 18th.

https://www.blockchain.com/charts/utxo-count

Using https://github.com/handshake-org/hs-client/pull/27
Note: the timeout and limit are arbitrarily much larger than they need to be
```bash
$ ./bin/hsd-cli rpc --timeout 100000 --limit 1342177280 gettxoutset > coins.json
$ jq '. | length' < coins.json
187035
```