### PR TITLE
deps: update blgr

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -89,9 +89,8 @@
       }
     },
     "blgr": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/blgr/-/blgr-0.1.7.tgz",
-      "integrity": "sha512-+jSaU2jnYqF+ec9e8nzjfjU7QhZIntkDNG8/AEwoxW7J3mmwvmUfAI5lm9BFYs1OzT+1UgIZTFHa2qWjTBURfw==",
+      "version": "git+ssh://git@github.com/Handshake-Protocol/blgr.git#e93352fd79eb63710613f691046a5d58c3fdc063",
+      "from": "git+ssh://git@github.com/Handshake-Protocol/blgr.git#v0.1.8",
       "requires": {
         "bsert": "~0.0.10"
       }

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "bfilter": "~1.0.5",
     "bheep": "~0.1.5",
     "binet": "~0.3.5",
-    "blgr": "~0.1.7",
+    "blgr": "ssh://git@github.com:Handshake-Protocol/blgr.git#v0.1.8",
     "blru": "~0.1.6",
     "blst": "~0.1.5",
     "bmutex": "~0.1.6",


### PR DESCRIPTION
This pull request updates the blgr dependency so that it includes https://github.com/bcoin-org/blgr/pull/5.

This is very important for usage, as it enables printing of the error stack for any `logger.error` messages. It will make it much easier to remotely debug with users.

I opened an issue in `bcoin/blgr` about doing a new release here:
https://github.com/bcoin-org/blgr/issues/9

For now, I am using a fork of `bcoin/blgr` as part of this pull request and I'm happy to use the `bcoin/blgr` repo once there is a new release.
https://github.com/Handshake-Protocol/blgr

For users that are currently having trouble, you can run this updated code with the commands:

```bash
$ git clone https://github.com/tynes/hsd
$ cd hsd
$ git checkout update-blgr
$ npm i
$ ./bin/hsd --log-level error
```
Running with `--log-level error` will only print the error messages, so if you would like to still the the `info` and `debug` messages, use `--log-level spam`.