### PR TITLE
wallet: allow updating of claimed names

### DIFF
--- a/lib/wallet/txdb.js
+++ b/lib/wallet/txdb.js
@@ -1703,17 +1703,17 @@ class TXDB {
       case types.REGISTER: {
         assert(i < tx.inputs.length);
 
-        const nameHash = covenant.getHash(0);
         const prevout = tx.inputs[i].prevout;
 
-        const brv = await this.getReveal(nameHash, prevout);
-        assert(brv);
+        const coin = await this.getCoin(prevout.hash, prevout.index);
+        assert(coin);
+        assert(coin.covenant.isReveal() || coin.covenant.isClaim());
 
         if (height === -1) {
-          state.ulocked(path, -brv.value);
+          state.ulocked(path, -coin.value);
           state.ulocked(path, output.value);
         } else {
-          state.clocked(path, -brv.value);
+          state.clocked(path, -coin.value);
           state.clocked(path, output.value);
         }
 
@@ -1777,17 +1777,16 @@ class TXDB {
       case types.REGISTER: {
         assert(i < tx.inputs.length);
 
-        const nameHash = covenant.getHash(0);
-        const prevout = tx.inputs[i].prevout;
-
-        const brv = await this.getReveal(nameHash, prevout);
-        assert(brv);
+        const coins = await this.getSpentCoins(tx);
+        const coin = coins[i];
+        assert(coin);
+        assert(coin.covenant.isReveal() || coin.covenant.isClaim());
 
         if (height === -1) {
-          state.ulocked(path, brv.value);
+          state.ulocked(path, coin.value);
           state.ulocked(path, -output.value);
         } else {
-          state.clocked(path, brv.value);
+          state.clocked(path, coin.value);
           state.clocked(path, -output.value);
         }
 


### PR DESCRIPTION
There is currently a bug in the wallet where it assumes that `REGISTER` outputs only come from `REVEAL` outputs. This prevents any name claim from ever updating their name using the wallet API. It is still possible to manually create the `REGISTER` transaction and broadcast it directly to the blockchain without using the wallet API. This is risky because a user could forget to create the transaction with the additional output containing the value "locked in the claim" to themselves.

https://github.com/handshake-org/hsd/blob/4178fd3c86612e939e554a72f9e4aa85a55a9c37/lib/wallet/txdb.js#L1703-L1710

`REGISTER` outputs can also come from `CLAIM` outputs when the name is reserved.

https://github.com/handshake-org/hsd/blob/4178fd3c86612e939e554a72f9e4aa85a55a9c37/lib/covenants/rules.js#L1218-L1227

These changes do not use `rules.isReserved` and instead directly use `reserved.has` to handle the case when the name is claimed before the claim period ends and then updated for the first time after the claim period ends.

Tests are included that test updating fake claims using the wallet (not the memwallet).