### PR TITLE
wallet/rpc: fix error message typos

### DIFF
--- a/lib/wallet/rpc.js
+++ b/lib/wallet/rpc.js
@@ -2183,8 +2183,8 @@ class RPC extends RPCBase {
 
   _validateUpdate(args, help, method) {
     if (help || args.length < 2 || args.length > 3)
-      throw new RPCError(errs.MISC_ERROR, method
-        + '"name" "data" ( "account" )');
+      throw new RPCError(errs.MISC_ERROR,
+        `${method} "name" "data" ( "account" )`);
 
     const valid = new Validator(args);
     const name = valid.str(0);
@@ -2262,8 +2262,8 @@ class RPC extends RPCBase {
 
   _validateTransfer(args, help, method) {
     if (help || args.length < 2 || args.length > 3)
-      throw new RPCError(errs.MISC_ERROR, method
-        + '"name" "address" ( "account" )');
+      throw new RPCError(errs.MISC_ERROR,
+        `${method} "name" "address" ( "account" )`);
 
     const valid = new Validator(args);
     const name = valid.str(0);


### PR DESCRIPTION
There was a missing space in the wallet RPC error messages for `sendupdate`, `createupdate`, `sendtransfer` and `createtransfer`. This PR adds in the space so that the error message renders correctly.