### PR TITLE
wallet: do check covenants for dust in createTX.

### DIFF
--- a/lib/wallet/wallet.js
+++ b/lib/wallet/wallet.js
@@ -3285,8 +3285,7 @@ class Wallet extends EventEmitter {
       const output = new Output(obj);
       const addr = output.getAddress();
 
-      const {covenant} = output;
-      if (covenant.isDustworthy() && output.isDust())
+      if (output.isDust())
         throw new Error('Output is dust.');
 
       if (output.value > 0) {


### PR DESCRIPTION
The typical code path for generating covenants, specifically
bids, is through the createBid function. This function does
not check the output values against the wallet's dust policy
level. The createTX function should follow similar behaviour.

This check was previously added at commit 0bcc6af. This commit
removes it.