### PR TITLE
Fix RootServer resolution of SYNTH and GLUE records

### DIFF
--- a/lib/dns/resource.js
+++ b/lib/dns/resource.js
@@ -183,15 +183,14 @@ class Resource extends Struct {
       switch (record.type) {
         case hsTypes.GLUE4:
         case hsTypes.GLUE6:
+          if (!util.isSubdomain(name, record.ns))
+            continue;
         case hsTypes.SYNTH4:
         case hsTypes.SYNTH6:
           break;
         default:
           continue;
       }
-
-      if (!util.isSubdomain(name, record.ns))
-        continue;
 
       additional.push(record.toGlue(record.ns, this.ttl));
     }

--- a/lib/dns/resource.js
+++ b/lib/dns/resource.js
@@ -185,6 +185,7 @@ class Resource extends Struct {
         case hsTypes.GLUE6:
           if (!util.isSubdomain(name, record.ns))
             continue;
+          break;
         case hsTypes.SYNTH4:
         case hsTypes.SYNTH6:
           break;
@@ -236,7 +237,7 @@ class Resource extends Struct {
           continue;
 
         set.add(rr.data.ns);
-      }
+      }``
 
       zone.push(rr);
     }

--- a/lib/dns/server.js
+++ b/lib/dns/server.js
@@ -291,7 +291,7 @@ class RootServer extends DNSServer {
     // Handle reverse pointers.
     if (tld === '_synth' && labels.length === 2 && name[0] === '_') {
       const hash = util.label(name, labels, -2);
-      const ip = base32.decodeHex(hash.substring(1));
+      const ip = IP.map(base32.decodeHex(hash.substring(1)));
       const res = new Message();
       const rr = new Record();
 
@@ -397,7 +397,7 @@ class RootServer extends DNSServer {
 
     const res = await this.response(req, rinfo);
 
-    if (!util.equal(tld, '_synth'))
+    if (!util.equal(tld, '_synth.'))
       this.cache.set(name, type, res);
 
     return res;

--- a/test/ns-test.js
+++ b/test/ns-test.js
@@ -1,0 +1,69 @@
+'use strict';
+
+const assert = require('bsert');
+const {wire} = require('bns');
+const {RootServer} = require('../lib/dns/server');
+
+describe('RootServer', function() {
+  const ns = new RootServer({
+    port: 25349 // regtest
+  });
+
+  before(async () => {
+    await ns.open();
+  });
+
+  after(async () => {
+    await ns.close();
+  });
+
+  it('should resolve a SYNTH4', async () => {
+    const name = '_fs0000g._synth.';
+    const req = {
+      question: [{name}]
+    };
+
+    const res = await ns.resolve(req);
+    const answer = res.answer;
+    const rec = answer[0];
+
+    assert.strictEqual(rec.name, name);
+    assert.strictEqual(rec.type, wire.types.A);
+    assert.strictEqual(rec.data.address, '127.0.0.2');
+  });
+
+  it('should resolve a SYNTH6', async () => {
+    const name = '_00000000000000000000000008._synth.';
+    const req = {
+      question: [{name}]
+    };
+
+    const res = await ns.resolve(req);
+    const answer = res.answer;
+    const rec = answer[0];
+
+    assert.strictEqual(rec.name, name);
+    assert.strictEqual(rec.type, wire.types.AAAA);
+    assert.strictEqual(rec.data.address, '::2');
+  });
+
+  it('should not cache synth record', async () => {
+    // Handshake RootServer cache is keyed exclusively by the TLD when the
+    // name has more than one label (normally indicating a referral).
+    // If the cache doesn't handle the pseudo-TLD `_synth.` correctly,
+    // This SYNTH4 request would return the result of the SYNTH6
+    // record from the last `it` block.
+    const name = '_fs0000g._synth.';
+    const req = {
+      question: [{name}]
+    };
+
+    const res = await ns.resolve(req);
+    const answer = res.answer;
+    const rec = answer[0];
+
+    assert.strictEqual(rec.name, name);
+    assert.strictEqual(rec.type, wire.types.A);
+    assert.strictEqual(rec.data.address, '127.0.0.2');
+  });
+});

--- a/test/ns-test.js
+++ b/test/ns-test.js
@@ -48,22 +48,63 @@ describe('RootServer', function() {
   });
 
   it('should not cache synth record', async () => {
+    // Start fresh
+    const cache = ns.cache.cache;
+    cache.reset();
+    assert.strictEqual(cache.size, 0);
+
+    // Query a record the RootResolver knows even without a database
+    let name = '.';
+    let req = {
+      question: [
+        {
+          name,
+          type: wire.types.NS
+        }
+      ]
+    };
+    let res = await ns.resolve(req);
+
+    // Added to cache
+    assert.strictEqual(cache.size, 1);
+
+    // Query a SYNTH6 record
+    name = '_00000000000000000000000008._synth.';
+    req = {
+      question: [
+        {name}
+      ]
+    };
+    res = await ns.resolve(req);
+    let answer = res.answer;
+    let rec = answer[0];
+
+    assert.strictEqual(rec.name, name);
+    assert.strictEqual(rec.type, wire.types.AAAA);
+    assert.strictEqual(rec.data.address, '::2');
+
+    // Nothing was added to the cache
+    assert.strictEqual(cache.size, 1);
+
     // Handshake RootServer cache is keyed exclusively by the TLD when the
     // name has more than one label (normally indicating a referral).
     // If the cache doesn't handle the pseudo-TLD `_synth.` correctly,
     // This SYNTH4 request would return the result of the SYNTH6
-    // record from the last `it` block.
-    const name = '_fs0000g._synth.';
-    const req = {
+    // record from the last request.
+    name = '_fs0000g._synth.';
+     req = {
       question: [{name}]
     };
 
-    const res = await ns.resolve(req);
-    const answer = res.answer;
-    const rec = answer[0];
+    res = await ns.resolve(req);
+    answer = res.answer;
+    rec = answer[0];
 
     assert.strictEqual(rec.name, name);
     assert.strictEqual(rec.type, wire.types.A);
     assert.strictEqual(rec.data.address, '127.0.0.2');
+
+    // Nothing was added to the cache
+    assert.strictEqual(cache.size, 1);
   });
 });

--- a/test/resource-test.js
+++ b/test/resource-test.js
@@ -26,8 +26,13 @@ describe('Resource', function() {
         address: '127.0.0.1'
       },
       {
+        type: 'GLUE4',
+        ns: 'ns3.some-other-domain.',
+        address: '10.20.30.40'
+      },
+      {
         type: 'GLUE6',
-        ns: 'ns2.hns.',
+        ns: 'ns4.hns.',
         address: '::1'
       },
       {
@@ -58,16 +63,21 @@ describe('Resource', function() {
     const msg = res.toDNS('hns.', types.MX);
 
     assert(msg.answer.length === 0);
-    assert(msg.authority.length === 6);
-    assert(msg.additional.length === 2);
+    assert(msg.authority.length === 8);
+    // Notice that the glue for `ns3.some-other-domain.` is omitted
+    assert(msg.additional.length === 4);
 
-    const [ns1, ns2, synth4, synth6, ds, rrsig] = msg.authority;
-    const [glue4, glue6] = msg.additional;
+    const [ns1, ns2, ns3, ns4, synth4, synth6, ds, rrsig] = msg.authority;
+    const [glue4, glue6, synthA, synthAAAA] = msg.additional;
 
     assert.strictEqual(ns1.type, types.NS);
     assert.strictEqual(ns1.name, 'hns.');
     assert.strictEqual(ns2.type, types.NS);
     assert.strictEqual(ns2.name, 'hns.');
+    assert.strictEqual(ns3.type, types.NS);
+    assert.strictEqual(ns3.name, 'hns.');
+    assert.strictEqual(ns4.type, types.NS);
+    assert.strictEqual(ns4.name, 'hns.');
     assert.strictEqual(synth4.type, types.NS);
     assert.strictEqual(synth4.name, 'hns.');
     assert.strictEqual(synth6.type, types.NS);
@@ -79,7 +89,11 @@ describe('Resource', function() {
     assert.strictEqual(glue4.type, types.A);
     assert.strictEqual(glue4.name, 'ns2.hns.');
     assert.strictEqual(glue6.type, types.AAAA);
-    assert.strictEqual(glue6.name, 'ns2.hns.');
+    assert.strictEqual(glue6.name, 'ns4.hns.');
+    assert.strictEqual(synthA.type, types.A);
+    assert.strictEqual(synthA.name, '_fs0000g._synth.');
+    assert.strictEqual(synthAAAA.type, types.AAAA);
+    assert.strictEqual(synthAAAA.name, '_00000000000000000000000008._synth.');
 
     assert.strictEqual(ns1.data.ns, 'ns1.hns.');
     assert.strictEqual(ns2.data.ns, 'ns2.hns.');
@@ -88,6 +102,8 @@ describe('Resource', function() {
     assert.bufferEqual(ds.data.digest, json.records[0].digest);
     assert.strictEqual(glue4.data.address, '127.0.0.1');
     assert.strictEqual(glue6.data.address, '::1');
+    assert.strictEqual(synthA.data.address, '127.0.0.2');
+    assert.strictEqual(synthAAAA.data.address, '::2');
   });
 
   it('should synthesize an answer', () => {


### PR DESCRIPTION
SYNTH4 and SYNTH6 records are very special: they act like NS records that contain their own IP addresses, encoded in base32. They can therefore be resolved without any lookup whatsoever. It's a neat trick to save blockchain space and avoid using useless NS+glue.

This PR fixes three bugs in the hsd RootServer resolution of these records:

#### 1) `binet.isIPv4(raw)` expects `raw` to be 16 bytes

The server does not currently map IPv4 to IPv6 addresses before proceeding with response.

Without patch:

```
$  dig @127.0.0.1 -p 25349 _fs0000g._synth.

[error] (ns) Assertion failed.
    at Object.isMapped (/Users/matthewzipkin/Desktop/work/hsd/node_modules/binet/lib/ip.js:734:3)
    at Object.isIPv4 (/Users/matthewzipkin/Desktop/work/hsd/node_modules/binet/lib/ip.js:745:16)
    at RootServer.response (/Users/matthewzipkin/Desktop/work/hsd/lib/dns/server.js:303:14)
    at RootServer.resolve (/Users/matthewzipkin/Desktop/work/hsd/lib/dns/server.js:398:28)
    at RootServer.answer (/Users/matthewzipkin/Desktop/work/hsd/node_modules/bns/lib/server/dns.js:249:28)
    at RootServer.handle (/Users/matthewzipkin/Desktop/work/hsd/node_modules/bns/lib/server/dns.js:316:24)
    at Server.<anonymous> (/Users/matthewzipkin/Desktop/work/hsd/node_modules/bns/lib/server/dns.js:72:20)
    at Server.emit (events.js:210:5)
    at Socket.<anonymous> (/Users/matthewzipkin/Desktop/work/hsd/node_modules/bns/lib/internal/net.js:73:12)
    at Socket.emit (events.js:210:5)
```

#### 2) cache does not properly detect the `_synth.` pseudo-TLD

The root server caches the first `_synth.` response and returns the same answer for all further queries, even though the design of the synth record is to decode the "subdomain" every time the pseudo-TLD is resolved:

Without patch:

```
$ dig @127.0.0.1 -p 25349 _fs0000g._synth.
...
;; ANSWER SECTION:
_fs0000g._synth.        21600   IN      A       127.0.0.2
...

$ dig @127.0.0.1 -p 25349 _00000000000000000000000008._synth.
...
;; ANSWER SECTION:
_fs0000g._synth.        21600   IN      A       127.0.0.2
...
```

#### 3) glue is missing from the "additional" section of the answer

Expected result:

```
$ dig @127.0.0.1 -p 25349 proofofconcept

; <<>> DiG 9.14.6 <<>> @127.0.0.1 -p 25349 proofofconcept
; (1 server found)
;; global options: +cmd
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 47707
;; flags: qr rd; QUERY: 1, ANSWER: 0, AUTHORITY: 1, ADDITIONAL: 3
;; WARNING: recursion requested but not available

;; OPT PSEUDOSECTION:
; EDNS: version: 0, flags:; udp: 4096
;; QUESTION SECTION:
;proofofconcept.                        IN      A

;; AUTHORITY SECTION:
proofofconcept.         21600   IN      NS      _hpen718._synth.

;; ADDITIONAL SECTION:
_hpen718._synth.        21600   IN      A       142.93.115.133

;; SIG0 PSEUDOSECTION:
.                       0       ANY     SIG     0 253 0 0 20200507001656 20200506121656 64595 . culJQ/ASg95kPVG3uqYQpbUkU+uIcDlXRDb5mXImmjQCgG21C+CzRPtT J7KuWP/4k7XqSrQLZqh11cPR+coS7Q==

;; Query time: 15 msec
;; SERVER: 127.0.0.1#25349(127.0.0.1)
;; WHEN: Wed May 06 14:16:56 EDT 2020
;; MSG SIZE  rcvd: 182

```