### PR TITLE
node/rpc: addrToJSON include bech32 string

### DIFF
--- a/lib/node/rpc.js
+++ b/lib/node/rpc.js
@@ -2869,7 +2869,8 @@ class RPC extends RPCBase {
   addrToJSON(addr) {
     return {
       version: addr.version,
-      hash: addr.hash.toString('hex')
+      hash: addr.hash.toString('hex'),
+      string: addr.toString(this.network)
     };
   }
 

--- a/test/node-test.js
+++ b/test/node-test.js
@@ -616,6 +616,27 @@ describe('Node', function() {
     assert.strictEqual(tx.txid(), tx2.txid());
   });
 
+  it('should get raw transaction (verbose=true)', async () => {
+    const json = await node.rpc.call({
+      method: 'getrawtransaction',
+      params: [tx2.txid(), true],
+      id: '1'
+    }, {});
+
+    assert(!json.error);
+    const tx = TX.fromHex(json.result.hex);
+
+    assert.equal(json.result.vin.length, tx.inputs.length);
+    assert.equal(json.result.vout.length, tx.outputs.length);
+
+    for (const [i, vout] of json.result.vout.entries()) {
+      const output = tx.output(i);
+      assert.equal(vout.address.version, output.address.version);
+      assert.equal(vout.address.string, output.address.toString(node.network));
+      assert.equal(vout.address.hash, output.address.hash.toString('hex'));
+    }
+  });
+
   it('should prioritise transaction', async () => {
     const json = await node.rpc.call({
       method: 'prioritisetransaction',


### PR DESCRIPTION
The `address` field in some of the Node RPC methods returns an object with a version and a hash. This pull request adds an additional field to that object called `string`, which returns the bech32 encoded address to make it easier for users that don't want to encode the object client side.

Closes https://github.com/handshake-org/hsd/issues/442