### PR TITLE
rpc: resetrootcache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## unreleased
 
+### Node API Changes
+
+- Adds a new node rpc `resetrootcache` that clears the root name server cache.
+
 ### Wallet API changes
 
 - Adds new wallet rpc `importname` that enables user to "watch" a name and track

--- a/lib/dns/server.js
+++ b/lib/dns/server.js
@@ -95,6 +95,10 @@ class RootCache {
 
     return Message.decode(item.raw);
   }
+
+  reset() {
+    this.cache.reset();
+  }
 }
 
 /**

--- a/lib/dns/server.js
+++ b/lib/dns/server.js
@@ -413,6 +413,10 @@ class RootServer extends DNSServer {
     this.logger.info('Root nameserver listening on port %d.', this.port);
   }
 
+  resetCache() {
+    this.cache.reset();
+  }
+
   serial() {
     const date = new Date();
     const y = date.getUTCFullYear() * 1e6;

--- a/lib/node/rpc.js
+++ b/lib/node/rpc.js
@@ -243,6 +243,8 @@ class RPC extends RPCBase {
     this.add('sendrawairdrop', this.sendRawAirdrop);
     this.add('validateresource', this.validateResource);
 
+    this.add('resetrootcache', this.resetRootCache);
+
     // Compat
     // this.add('getnameinfo', this.getNameInfo);
     // this.add('getnameresource', this.getNameResource);
@@ -2497,6 +2499,18 @@ class RPC extends RPCBase {
     }
 
     return resource.toJSON();
+  }
+
+  async resetRootCache(args, help) {
+    if (help || args.length !== 0)
+      throw new RPCError(errs.MISC_ERROR, 'resetrootcache');
+
+    if (!this.node.ns)
+      return null;
+
+    this.node.ns.resetCache();
+
+    return null;
   }
 
   /*


### PR DESCRIPTION
When playing with my node, I found that resetting the root cache was sometimes helpful. This adds a node RPC method called `resetrootcache` and it drops the root server cache completely. It would also be technically possible to expose deleting a single name (or a set of names) out of the cache.

DNS servers employ [Dynamic DNS](https://en.wikipedia.org/wiki/Dynamic_DNS) to allow for remote clients to configure the zone, so maybe it makes sense to have expose an RPC interface for the DNS servers. This would give users a more familiar interface for the configuration.

Or maybe restarting the node to clear the cache is good enough.