### PR TITLE
Allow bid and lockup with 0 value in wallet-http

### DIFF
--- a/lib/wallet/http.js
+++ b/lib/wallet/http.js
@@ -1046,8 +1046,8 @@ class HTTP extends Server {
       const sign = valid.bool('sign', true);
 
       assert(name, 'Name is required.');
-      assert(bid, 'Bid is required.');
-      assert(lockup, 'Lockup is required.');
+      assert(bid != null, 'Bid is required.');
+      assert(lockup != null, 'Lockup is required.');
       assert(broadcast ? sign : true, 'Must sign when broadcasting.');
 
       const options = TransactionOptions.fromValidator(valid);

--- a/test/wallet-http-test.js
+++ b/test/wallet-http-test.js
@@ -483,6 +483,20 @@ describe('Wallet HTTP', function() {
     await assert.rejects(fn, {message: 'Lockup is required.'});
   });
 
+  it('should send bid with 0 value and 0 lockup', async () => {
+    await wallet.client.post(`/wallet/${wallet.id}/open`, {
+      name: name
+    });
+
+    await mineBlocks(treeInterval + 1, cbAddress);
+
+    await wallet.client.post(`/wallet/${wallet.id}/bid`, {
+      name: name,
+      bid: 0,
+      lockup: 0
+    });
+  });
+
   it('should get all bids (single player)', async () => {
     await wallet.client.post(`/wallet/${wallet.id}/open`, {
       name: name

--- a/test/wallet-http-test.js
+++ b/test/wallet-http-test.js
@@ -352,7 +352,7 @@ describe('Wallet HTTP', function() {
       sign: false
     }));
 
-    assert.rejects(fn, 'Must sign when broadcasting.');
+    await assert.rejects(fn, {message: 'Must sign when broadcasting.'});
   });
 
   it('should fail to create open for account with no monies', async () => {
@@ -365,7 +365,7 @@ describe('Wallet HTTP', function() {
       account: accountTwo
     }));
 
-    assert.rejects(fn, 'Not enough funds.');
+    await assert.rejects(fn, {message: /Not enough funds./});
   });
 
   it('should mine to the account with no monies', async () => {
@@ -471,7 +471,7 @@ describe('Wallet HTTP', function() {
       name: name
     }));
 
-    assert.rejects(fn, 'Bid is required.');
+    await assert.rejects(fn, {message: 'Bid is required.'});
   });
 
   it('should fail to open a bid without a lockup value', async () => {
@@ -480,7 +480,7 @@ describe('Wallet HTTP', function() {
       bid: 1000
     }));
 
-    assert.rejects(fn, 'Lockup is required.');
+    await assert.rejects(fn, {message: 'Lockup is required.'});
   });
 
   it('should get all bids (single player)', async () => {
@@ -796,7 +796,7 @@ describe('Wallet HTTP', function() {
       name: name
     }));
 
-    assert.rejects(fn, 'No reveals to redeem.');
+    await assert.rejects(fn, {message: 'No reveals to redeem.'});
 
     const json = await wallet.client.post(`wallet/${wallet.id}/redeem`, {
       name: name


### PR DESCRIPTION
Bids and Lockups are allowed to have value of 0, but get rejected by wallet http, which interprets the values as `false` and throws a "missing bid" error.

Also fixes `assert.reject` statements in wallet-http-test.js that weren't actually testing for the correct error message or executing asynchronously.