### PR TITLE
Adjust txdb locked coins balance for FINALIZE covenants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # HSD Release Notes & Changelog
 
+## unreleased
+
+### Wallet changes
+
+- Fixes a bug that ignored the effect of sending or receiving a FINALIZE on a
+wallet's `lockedConfirmed` and `lockedUnconfirmed` balance. 
+
 ## v2.2.0
 
 ### Upgrading

--- a/lib/wallet/txdb.js
+++ b/lib/wallet/txdb.js
@@ -959,7 +959,7 @@ class TXDB {
         state.unconfirmed(path, -coin.value);
 
         // FINALIZE is a special case: locked coins _leave_ the wallet.
-        if (tx.outputs[i] && tx.outputs[i].covenant.type === types.FINALIZE) {
+        if (tx.output(i) && tx.covenant(i).type === types.FINALIZE) {
           if (!block)
             state.ulocked(path, -tx.outputs[i].value);
           else
@@ -1166,7 +1166,7 @@ class TXDB {
         state.confirmed(path, -coin.value);
 
         // FINALIZE is a special case: locked coins _leave_ the wallet.
-        if (tx.outputs[i] && tx.outputs[i].covenant.type === types.FINALIZE)
+        if (tx.output(i) && tx.covenant(i).type === types.FINALIZE)
           state.clocked(path, -tx.outputs[i].value);
 
         await this.removeCredit(b, credit, path);
@@ -1314,7 +1314,7 @@ class TXDB {
 
         // FINALIZE is a special case: locked coins _leave_ the wallet.
         // In this case a TX is erased, adding them back.
-        if (tx.outputs[i] && tx.outputs[i].covenant.type === types.FINALIZE) {
+        if (tx.output(i) && tx.covenant(i).type === types.FINALIZE) {
           if (!block)
             state.ulocked(path, tx.outputs[i].value);
           else
@@ -1522,7 +1522,7 @@ class TXDB {
 
         // FINALIZE is a special case: locked coins _leave_ the wallet.
         // In this case a TX is reversed, adding them back.
-        if (tx.outputs[i] && tx.outputs[i].covenant.type === types.FINALIZE)
+        if (tx.output(i) && tx.covenant(i).type === types.FINALIZE)
             state.clocked(path, tx.outputs[i].value);
 
         // Resave the credit and mark it

--- a/lib/wallet/txdb.js
+++ b/lib/wallet/txdb.js
@@ -959,7 +959,7 @@ class TXDB {
         state.unconfirmed(path, -coin.value);
 
         // FINALIZE is a special case: locked coins _leave_ the wallet.
-        if (tx.output(i) && tx.covenant(i).type === types.FINALIZE) {
+        if (tx.output(i) && tx.covenant(i).isFinalize()) {
           if (!block)
             state.ulocked(path, -tx.outputs[i].value);
           else
@@ -1166,7 +1166,7 @@ class TXDB {
         state.confirmed(path, -coin.value);
 
         // FINALIZE is a special case: locked coins _leave_ the wallet.
-        if (tx.output(i) && tx.covenant(i).type === types.FINALIZE)
+        if (tx.output(i) && tx.covenant(i).isFinalize())
           state.clocked(path, -tx.outputs[i].value);
 
         await this.removeCredit(b, credit, path);
@@ -1314,7 +1314,7 @@ class TXDB {
 
         // FINALIZE is a special case: locked coins _leave_ the wallet.
         // In this case a TX is erased, adding them back.
-        if (tx.output(i) && tx.covenant(i).type === types.FINALIZE) {
+        if (tx.output(i) && tx.covenant(i).isFinalize()) {
           if (!block)
             state.ulocked(path, tx.outputs[i].value);
           else
@@ -1522,7 +1522,7 @@ class TXDB {
 
         // FINALIZE is a special case: locked coins _leave_ the wallet.
         // In this case a TX is reversed, adding them back.
-        if (tx.output(i) && tx.covenant(i).type === types.FINALIZE)
+        if (tx.output(i) && tx.covenant(i).isFinalize())
             state.clocked(path, tx.outputs[i].value);
 
         // Resave the credit and mark it

--- a/lib/wallet/txdb.js
+++ b/lib/wallet/txdb.js
@@ -958,6 +958,14 @@ class TXDB {
         state.coin(path, -1);
         state.unconfirmed(path, -coin.value);
 
+        // FINALIZE is a special case: locked coins _leave_ the wallet.
+        if (tx.outputs[i] && tx.outputs[i].covenant.type === types.FINALIZE) {
+          if (!block)
+            state.ulocked(path, -tx.outputs[i].value);
+          else
+            state.clocked(path, -tx.outputs[i].value);
+        }
+
         if (!block) {
           // If the tx is not mined, we do not
           // disconnect the coin, we simply mark
@@ -1157,6 +1165,10 @@ class TXDB {
         // been removed on-chain.
         state.confirmed(path, -coin.value);
 
+        // FINALIZE is a special case: locked coins _leave_ the wallet.
+        if (tx.outputs[i] && tx.outputs[i].covenant.type === types.FINALIZE)
+          state.clocked(path, -tx.outputs[i].value);
+
         await this.removeCredit(b, credit, path);
 
         view.addCoin(coin);
@@ -1299,6 +1311,15 @@ class TXDB {
         state.tx(path, -1);
         state.coin(path, 1);
         state.unconfirmed(path, coin.value);
+
+        // FINALIZE is a special case: locked coins _leave_ the wallet.
+        // In this case a TX is erased, adding them back.
+        if (tx.outputs[i] && tx.outputs[i].covenant.type === types.FINALIZE) {
+          if (!block)
+            state.ulocked(path, tx.outputs[i].value);
+          else
+            state.clocked(path, tx.outputs[i].value);
+        }
 
         if (block)
           state.confirmed(path, coin.value);
@@ -1498,6 +1519,11 @@ class TXDB {
         details.setInput(i, path, coin);
 
         state.confirmed(path, coin.value);
+
+        // FINALIZE is a special case: locked coins _leave_ the wallet.
+        // In this case a TX is reversed, adding them back.
+        if (tx.outputs[i] && tx.outputs[i].covenant.type === types.FINALIZE)
+            state.clocked(path, tx.outputs[i].value);
 
         // Resave the credit and mark it
         // as spent in the mempool instead.
@@ -1719,6 +1745,14 @@ class TXDB {
 
         break;
       }
+
+      case types.FINALIZE: {
+        if (height === -1)
+          state.ulocked(path, output.value);
+        else
+          state.clocked(path, output.value);
+        break;
+      }
     }
   }
 
@@ -1790,6 +1824,14 @@ class TXDB {
           state.clocked(path, -output.value);
         }
 
+        break;
+      }
+
+      case types.FINALIZE: {
+        if (height === -1)
+          state.ulocked(path, -output.value);
+        else
+          state.clocked(path, -output.value);
         break;
       }
     }


### PR DESCRIPTION
I think we may have overlooked the impact of FINALIZE covenants on locked coins balances in the wallet. They are unusual because it is the only case where locked coins _leave the wallet_. Meaning someone else's locked coin balance goes up. The current txdb functions `lockBalances()` and `unlockBalances()` process covenants received into the wallet, however in this case we must also catch FINALIZE as it is being _sent_, since our own locked coin balance goes down (along with the total balance - name and coins get transferred) 

TODO:
- Evaluate the impact of this change on exiting wallets in use. Do we need another wallet DB migration?
- Will some users have to completely restore wallet from seed and rescan like the [claim-to-register issue?](https://github.com/handshake-org/hsd/issues/454)
- Let's make sure REVOKE and TRANSFER aren't lingering issues as well

According to my covenant statistics script, at this time there are 14 `FINALIZE` covenants confirmed on the blockchain, for a total value of 3,700.500000 HNS. Both the sender and receiver of these names will have inaccurate locked coin balances, that may end up throwing an assertion error depending on future wallet activity.

Similar PRs recently merged affecting txdb locked coins computation:

https://github.com/handshake-org/hsd/pull/438
https://github.com/handshake-org/hsd/pull/387
https://github.com/handshake-org/hsd/pull/262