### PR TITLE
Add /wallet/:id/tx http call

### DIFF
--- a/lib/wallet/http.js
+++ b/lib/wallet/http.js
@@ -1009,6 +1009,46 @@ class HTTP extends Server {
       });
     });
 
+    // Create Transaction
+    this.post('/wallet/:id/tx', async (req, res) => {
+      const valid = Validator.fromRequest(req);
+      const passphrase = valid.str('passphrase');
+      const broadcast = valid.bool('broadcast', true);
+      const sign = valid.bool('sign', true);
+      const bids = valid.array('bids', []);
+      const options = TransactionOptions.fromValidator(valid);
+
+      assert(broadcast ? sign : true, 'Must sign when broadcasting.');
+
+      const outputs = [];
+      for (const bidArgs of bids) {
+        const bidValid = new Validator(bidArgs);
+        const name = bidValid.str('name');
+        const bid = bidValid.u64('bid');
+        const lockup = bidValid.u64('lockup');
+
+        assert(name, 'Name is required.');
+        assert(bid != null, 'Bid is required.');
+        assert(lockup != null, 'Lockup is required.');
+
+        // @todo: Is this safe without a lock around it? What needs and does not need locks isn't
+        // super clear.
+        outputs.push(await req.wallet.makeBidOutput(name, bid, lockup, options.account || 0));
+      }
+
+      const mtx = await req.wallet.createTx(outputs, options);
+
+      if (broadcast) {
+        const tx = await req.wallet.sendMTX(mtx, passphrase);
+        return res.json(200, tx.getJSON(this.network));
+      }
+
+      if (sign)
+        await req.wallet.sign(mtx, passphrase);
+
+      return res.json(200, mtx.getJSON(this.network));
+    });
+
     // Create Open
     this.post('/wallet/:id/open', async (req, res) => {
       const valid = Validator.fromRequest(req);

--- a/lib/wallet/wallet.js
+++ b/lib/wallet/wallet.js
@@ -1646,15 +1646,14 @@ class Wallet extends EventEmitter {
   }
 
   /**
-   * Make a bid MTX.
+   * Make a bid Output.
    * @param {String} name
    * @param {Number} value
    * @param {Number} lockup
    * @param {Number|String} acct
-   * @returns {MTX}
+   * @returns {Output}
    */
-
-  async makeBid(name, value, lockup, acct) {
+  async makeBidOutput(name, value, lockup, acct) {
     assert(typeof name === 'string');
     assert(Number.isSafeInteger(value) && value >= 0);
     assert(Number.isSafeInteger(lockup) && lockup >= 0);
@@ -1704,11 +1703,57 @@ class Wallet extends EventEmitter {
     output.covenant.pushU32(start);
     output.covenant.push(rawName);
     output.covenant.pushHash(blind);
+    return output;
+  }
 
+  /**
+   * Make a bid MTX.
+   * @param {String} name
+   * @param {Number} value
+   * @param {Number} lockup
+   * @param {Number|String} acct
+   * @returns {MTX}
+   */
+
+  async makeBid(name, value, lockup, acct) {
+    const output = await this.makeBidOutput(name, value, lockup, acct);
     const mtx = new MTX();
     mtx.outputs.push(output);
 
     return mtx;
+  }
+
+
+  /**
+   * Create and finalize a MTX without a lock.
+   * @param {Output[]} outputs
+   * @param {Object} options
+   * @returns {MTX}
+   */
+
+  async _createTx(outputs, options) {
+    const mtx = new MTX();
+    for (const output of outputs) {
+      mtx.outputs.push(output);
+    }
+    await this.fill(mtx, options);
+    return this.finalize(mtx, options);
+  }
+
+  /**
+   * Create and finalize a MTX with a lock.
+   * @param {Output[]} outputs
+   * @param {Object} options
+   * @returns {MTX}
+   */
+
+  async createTx(outputs, options) {
+    const unlock = await this.fundLock.lock();
+    try {
+      return await this._createTx(outputs, options);
+    } finally {
+      unlock();
+    }
   }
 
   /**


### PR DESCRIPTION
At the moment it is not possible to create a single transaction with multiple bids (or multiple opens.) This creates a new RPC endpoint that allows the caller to pass in an array of bids. The bids are specified exactly the same as the `bid` endpoint requires them.

This should be extendable to allow `opens`, `reveals`, and all other covenant types to be specified in a later change.

I have not heavily tested this change, but have verified that it works. If the approach is correct I can add some test cases.