### PR TITLE
chaindb: getcoinsbyaddress - handle string addrs

### DIFF
--- a/lib/blockchain/chaindb.js
+++ b/lib/blockchain/chaindb.js
@@ -1362,7 +1362,10 @@ class ChainDB {
 
     const coins = [];
 
-    for (const addr of addrs) {
+    for (let addr of addrs) {
+      if (typeof addr === 'string')
+        addr = Address.fromString(addr);
+
       const hash = Address.getHash(addr);
 
       const keys = await this.db.keys({


### PR DESCRIPTION
`getCoinsByAddress` currently expects an `Address` instance. I need to query for an address balance, from a plugin which receives a string input. I cannot cast the string to `Address` since they are from different modules. It would be nice to loosen the interface here to accept a string so that plugins can fetch coins by passing a string.

Otherwise, maybe we could add a RPC endpoint which accepts a string. I am currently using the HTTP API endpoint `/coin/address/:address` from the plugin.