### PR TITLE
rpc: swap txid and hash in txToJSON function

### DIFF
--- a/lib/node/rpc.js
+++ b/lib/node/rpc.js
@@ -2848,8 +2848,8 @@ class RPC extends RPCBase {
     }
 
     return {
-      txid: tx.txid(),
-      hash: tx.wtxid(),
+      hash: tx.txid(),
+      txid: tx.wtxid(),
       size: tx.getSize(),
       vsize: tx.getVirtualSize(),
       version: tx.version,


### PR DESCRIPTION
Not sure if I'm in love with this just yet. We are using these terms a little different than in Bitcoin (hash being non-witness data, and txid being witness data), but then when we set the txid of the prevouts, we use the function txid() which is actually the hash that does NOT have witness data.

Setting of the prevouts here: 
https://github.com/handshake-org/hsd/blob/master/lib/node/rpc.js#L2831

txid function: https://github.com/handshake-org/hsd/blob/bf9b1786b1ea0a1efa16e747a3f15124c17fc141/lib/primitives/tx.js#L1588-L1590

Should we actually be using wtxid in place of txid for the above prevouts? Happy to include that in this PR. 