### PR TITLE
wallet-rpc: switch the order of transactions returned to most recent

### DIFF
--- a/lib/wallet/rpc.js
+++ b/lib/wallet/rpc.js
@@ -1232,7 +1232,7 @@ class RPC extends RPCBase {
     const valid = new Validator(args);
     let name = valid.str(0);
     const count = valid.u32(1, 10);
-    const from = valid.u32(2, 0);
+    const skip = valid.u32(2, 0);
     const watchOnly = valid.bool(3, false);
 
     if (wallet.watchOnly !== watchOnly)
@@ -1248,11 +1248,12 @@ class RPC extends RPCBase {
 
     common.sortTX(txs);
 
-    const end = from + count;
-    const to = Math.min(end, txs.length);
+    const start = txs.length - skip - 1;
+    const end = start - count;
+    const to = Math.max(end, -1);
     const out = [];
 
-    for (let i = from; i < to; i++) {
+    for (let i = start; i > to; i--) {
       const wtx = txs[i];
       const json = await this._toListTX(wtx);
       out.push(json);


### PR DESCRIPTION
Re: discussion in the Telegram group. Looks like the intended behavior of this RPC call is to return the most recent transactions first, and then the "from/skip" parameter jumps ahead x number of txs.