### PR TITLE
Removes bid assert for nonce

### DIFF
--- a/lib/wallet/http.js
+++ b/lib/wallet/http.js
@@ -986,7 +986,6 @@ class HTTP extends Server {
       assert(name, 'Name is required.');
       assert(rules.verifyName(name), 'Valid name is required.');
       assert(addr, 'Address is required.');
-      assert(bid, 'Bid is required.');
 
       let address;
       try {


### PR DESCRIPTION
`assert(bid)` will fail for `0`.
[covenants/rules](https://github.com/handshake-org/hsd/blob/8c7053e45be78be638455e935dff7a8f8c3a5f4d/lib/covenants/rules.js#L385) accepts `0`;

This is affecting the Bob's Repair bid feature: kyokan/bob-wallet/issues/163