### PR TITLE
wallet: check auction TXs for dust and null address before sending

### DIFF
--- a/lib/wallet/wallet.js
+++ b/lib/wallet/wallet.js
@@ -3400,6 +3400,19 @@ class Wallet extends EventEmitter {
     if (ancestors.size + 1 > this.maxAncestors)
       throw new Error('TX exceeds maximum unconfirmed ancestors.');
 
+    for (const output of tx.outputs) {
+      if (output.isDust())
+        throw new Error('Output is dust.');
+
+      if (output.value > 0) {
+        if (!output.address)
+          throw new Error('Cannot send to unknown address.');
+
+        if (output.address.isNull())
+          throw new Error('Cannot send to null address.');
+      }
+    }
+
     await this.wdb.addTX(tx);
 
     this.logger.debug('Sending wallet tx (%s): %x', this.id, tx.hash());

--- a/test/wallet-auction-test.js
+++ b/test/wallet-auction-test.js
@@ -12,6 +12,7 @@ const Miner = require('../lib/mining/miner');
 const WalletDB = require('../lib/wallet/walletdb');
 const Network = require('../lib/protocol/network');
 const rules = require('../lib/covenants/rules');
+const Address = require('../lib/primitives/address');
 
 const network = Network.get('regtest');
 const NAME1 = rules.grindName(5, 2, network);
@@ -121,6 +122,17 @@ describe('Wallet Auction', function() {
       assert(block);
       assert(await chain.add(block));
     }
+  });
+
+  it('should fail to send bid to null address', async () => {
+    const mtx = await winner.makeBid(NAME1, 1000, 2000, 0);
+    mtx.outputs[0].address = new Address();
+    await winner.fill(mtx);
+    await winner.finalize(mtx);
+
+    const fn = async () => await winner.sendMTX(mtx);
+
+    await assert.rejects(fn, {message: 'Cannot send to null address.'});
   });
 
   it('should fail to re-open auction during BIDDING phase', async () => {

--- a/test/wallet-http-test.js
+++ b/test/wallet-http-test.js
@@ -508,7 +508,7 @@ describe('Wallet HTTP', function() {
     await assert.rejects(fn, {message: 'Lockup is required.'});
   });
 
-  it('should send bid with 0 value and 0 lockup', async () => {
+  it('should send bid with 0 value and non-dust lockup', async () => {
     await wallet.client.post(`/wallet/${wallet.id}/open`, {
       name: name
     });
@@ -518,8 +518,24 @@ describe('Wallet HTTP', function() {
     await wallet.client.post(`/wallet/${wallet.id}/bid`, {
       name: name,
       bid: 0,
+      lockup: 1000
+    });
+  });
+
+  it('should fail to send bid with 0 value and 0 lockup', async () => {
+    await wallet.client.post(`/wallet/${wallet.id}/open`, {
+      name: name
+    });
+
+    await mineBlocks(treeInterval + 1, cbAddress);
+
+    const fn = async () => await wallet.client.post(`/wallet/${wallet.id}/bid`, {
+      name: name,
+      bid: 0,
       lockup: 0
     });
+
+    await assert.rejects(fn, {message: 'Output is dust.'});
   });
 
   it('should get all bids (single player)', async () => {


### PR DESCRIPTION
Closes https://github.com/handshake-org/hsd/issues/463 maybe a few more...

These sanity checks are already applied to regular money-sending `NONE`-covenant transactions in the [`createTX()` method](https://github.com/handshake-org/hsd/blob/a3049d5b7e7feb431419e3c4d092bb71e17c86fc/lib/wallet/wallet.js#L3276-L3306)

However there is nothing yet to prevent a user from sending a BID with a lockup value that is below the dust threshold.

This is another issue with my least favorite line in the codebase, the "broadcast anyway" clause:

https://github.com/handshake-org/hsd/blob/a3049d5b7e7feb431419e3c4d092bb71e17c86fc/lib/node/fullnode.js#L335-L342

As much as I want to change the "broadcast anyway" behavior we still need the extra sanity check in the wallet for SPV nodes, which can't check new TXs against mempool policy.