### PR TITLE
Update CHANGELOG with recent significant changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,27 @@
 
 ## unreleased
 
+### Node API changes
+
+- A new RPC call `validateresource` was added to validate Handshake `Resource`
+JSON and will return an error message on an invalid `Resource`. The input JSON
+object is the format expected by `rpc sendupdate`.
+
+- A new RPC call `getdnssecproof` was added to build and return the DNSSEC
+proof used for reserved name claims. This can be used to test if a reserved
+name is ready for a CLAIM.
+
 ### Wallet API changes
 
 - Adds new wallet rpc `importname` that enables user to "watch" a name and track
 its auction progress without bidding on it directly.
+
+### Wallet changes
+
+- A bug was fixed that prevented reserved names that had been CLAIMed from
+REGISTERing. If unpatched software was used to CLAIM a name already, that wallet
+database is irreversibly corrupted and must be replaced.
+See https://github.com/handshake-org/hsd/issues/454
 
 ## v2.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,15 @@ object is the format expected by `rpc sendupdate`.
 proof used for reserved name claims. This can be used to test if a reserved
 name is ready for a CLAIM.
 
+- RPC calls that return tx outputs in JSON now include output addresses as a string
+in addition to the version/hash pair.
+
+- RPC methods `getblock` and `getblockheader` now return `confirmations: -1` if
+the block is not in the main chain.
+
+- A new HTTP endpoint `/header/:block` was added to retrieve a block header
+by its hash or height.
+
 ### Wallet API changes
 
 - Adds new wallet rpc `importname` that enables user to "watch" a name and track


### PR DESCRIPTION
Closes https://github.com/handshake-org/hsd/issues/446

(Did I miss anything?)

I think going forward, we should be vigilant about asking contributors to add details to CHANGELOG when necessary. I think little bug fixes (like allow bids of `0` value, etc) can be ignored. But definitely API changes should be recorded.