### PR TITLE
Fix tests

### DIFF
--- a/test/auction-reorg-test.js
+++ b/test/auction-reorg-test.js
@@ -67,7 +67,7 @@ function createNode() {
 }
 
 describe('Auction Reorg', function() {
-  this.timeout(15000);
+  this.timeout(20000);
 
   describe('Vickrey Auction Reorg', function() {
     const node = createNode();

--- a/test/http-test.js
+++ b/test/http-test.js
@@ -44,7 +44,7 @@ let addr = null;
 let hash = null;
 
 describe('HTTP', function() {
-  this.timeout(15000);
+  this.timeout(20000);
 
   it('should open node', async () => {
     await node.open();

--- a/test/txstart-test.js
+++ b/test/txstart-test.js
@@ -21,8 +21,7 @@ const VERIFY_NONE = common.flags.VERIFY_NONE;
 
 const node = new FullNode({
   memory: true,
-  network: 'regtest',
-  plugins: [require('../lib/wallet/plugin')]
+  network: 'regtest'
 });
 
 const RESET_TXSTART = node.network.txStart;

--- a/test/txstart-test.js
+++ b/test/txstart-test.js
@@ -51,6 +51,8 @@ wallet.getNameStatus = async (nameHash) => {
 };
 
 describe('Disable TXs', function() {
+  this.timeout(20000);
+
   let utxo, lastTX;
 
   before(async () => {


### PR DESCRIPTION
increase timeouts for auction-reorg, http and txstart tests. Also fixes an issue with txstart tests timing out on `before` because of node wallet.

Fixes #473 