### PR TITLE
Remove bslint as dep. Install manually in workflows. Explain process in new CONTRIBUTING guide

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -23,7 +23,7 @@ jobs:
 
     - name: Install
       run: sudo apt-get install -y libunbound-dev |
-           npm install nyc coveralls
+           npm install nyc coveralls bslint
 
     - name: Lint
       run: npm run lint

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,73 @@
+# Contributing to Handshake
+
+## Code style
+
+This repository includes a file [.eslintrc.json](.eslintrc.json) which sets
+linting preferences for the project. The continuous integration bot will
+install [bslint](https://www.npmjs.com/package/bslint) which vendors a specific
+version of eslint. Before submitting a pull request, please make sure your code
+is clean of linting errors. If you choose to use bslint, it can be installed
+globally in your development environment:
+
+```
+npm install bslint -g
+cd hsd            # must be in repository root
+npm run lint      # command is defined in package.json
+```
+
+## Testing
+
+[bmocha](https://www.npmjs.com/package/bmocha) will be installed as a
+"developer dependency" if installed without the `--production` flag. The
+complete built-in testing suite can be run with the command:
+
+```
+cd hsd
+npm run test
+```
+
+You can specify a single test file to run with (for example):
+
+```
+cd hsd
+npm run test-file test/wallet-test.js
+```
+
+Before submitting a pull request, please make sure your code changes do not
+break any of the existing regression tests or linting rules. We currently use
+GitHub Workflows to run the testing suite on all new pull requests.
+
+Recent workflow actions are available:
+https://github.com/handshake-org/hsd/actions
+
+All code changes should be covered by new tests if applicable. We currently use
+Coveralls to examine test coverage, and a pull request that *decreases* test
+coverage will likely not be reviewed by contributors or maintainers.
+
+Current test coverage details are available:
+https://coveralls.io/github/handshake-org/hsd
+
+## Commit messages
+
+Whenever possible, commits should prefixed by the module they change. The module
+name is generally the folder name in the `lib/` directory in which the changes
+occur (subdirectories can usually be ignored). Please see recent
+[commits to master branch](https://github.com/handshake-org/hsd/commits/master)
+for examples of the preferred pattern.
+
+Additional examples:
+
+```
+test: increase timeouts
+pkg: update CHANGELOG
+wallet: expose importname in RPC
+```
+
+Additional commit details are always welcome after the short title. A good
+example of this is in
+[this commit](https://github.com/handshake-org/hsd/commit/c385fc59d488f5cd592a1d23554fe1c018bf26da).
+Note how the author used a very brief commit message as the title but then added
+a detailed description in the extended message.
+
+
+

--- a/README.md
+++ b/README.md
@@ -123,6 +123,12 @@ $ npm install -g hs-client
 - API Docs: [https://hsd-dev.org/api-docs](https://hsd-dev.org/api-docs)
 - JSDoc: [https://hsd-dev.org/docs](https://hsd-dev.org/docs)
 
+## Contributing
+
+Handshake is a community project, we welcome contributions of all kinds from
+everyone. Before opening a pull request, please review the style guide and
+workflow tips in [CONTRIBUTING.md](CONTRIBUTING.md).
+
 ## Quickstart
 
 ### API

--- a/README.md
+++ b/README.md
@@ -119,11 +119,20 @@ $ npm install -g hs-client
 
 ## Documentation
 
-- Documentation Site: [https://handshake-org.github.io](https://handshake-org.github.io)
-- API Docs: [https://handshake-org.github.io/api-docs/index.html](https://handshake-org.github.io/api-docs/index.html)
-- JSDoc: [https://handshake-org.github.io/docs](https://handshake-org.github.io/docs)
+- Documentation Site: [https://hsd-dev.org](https://hsd-dev.org)
+- API Docs: [https://hsd-dev.org/api-docs](https://hsd-dev.org/api-docs)
+- JSDoc: [https://hsd-dev.org/docs](https://hsd-dev.org/docs)
 
 ## Quickstart
+
+### API
+
+Several RPC calls have been exposed in addition to the standard bitcoind-style
+RPC. There is also a RESTful HTTP API with different features. The full node
+and wallet node each run their own API servers on different ports.
+
+For more details and a complete list of API calls, review the documentation
+at https://hsd-dev.org/api-docs
 
 ### Unbound support
 
@@ -254,51 +263,6 @@ Expiration on testnet is around 30 days, so be sure to send a renewal soon!
 ``` bash
 $ hsw-rpc sendrenewal handshake
 ```
-
-### RPC Calls
-
-Several RPC calls have been exposed in addition to the standard bitcoind-style
-RPC.
-
-#### Node Calls
-
-All node calls should be made with `$ hsd-rpc [call] [arguments...]`.
-
-- `getnames` - List all names (debugging).
-- `getnameinfo [name]` - Returns name and auction status.
-- `getnameresource [name]` - Returns parsed DNS-style resource.
-- `getnameproof [name]` - Returns a JSON-ified [urkel] proof of a name.
-- `getnamebyhash [hex-hash]` - Returns the name hash preimage.
-- `sendrawclaim [base64-string]` - Send a raw serialized claim.
-- `grindname [size]` - Grind a name which satisifies the rollout.
-- `sendrawairdrop [base64-string]` - Send a raw serialized [airdrop] proof.
-
-#### Wallet Calls
-
-All wallet calls should be made with `$ hsw-rpc [call] [arguments...]`.
-
-- `getbids [name] [own]` - List own bids on a name.
-- `getreveals [name] [own]` - List own reveals on a name.
-- `getnames` - List all watched names and their statuses.
-- `getnameinfo [name]` - Returns name info, similar to the node call above.
-- `getauctioninfo [name]` - Returns auction info, along with all bids and
-  reveals.
-- `getnameresource [name]` - Returns parsed DNS-style resource.
-- `getnamebyhash [hex-hash]` - Returns the name hash preimage.
-- `createclaim [name]` - Create a to-be-signed claim.
-- `sendclaim [name]` - Claim a name by publishing a DNSSEC ownership proof.
-- `sendopen [name]` - Open an auction.
-- `sendbid [name] [bid-value] [lockup-value]` - Bid on a name.
-- `sendreveal [name]` - Reveal bids for name.
-- `sendredeem [name]` - Redeem reveals in the case of an auction loss.
-- `sendupdate [name] [json-data]` - Register or update a name.
-- `sendrenewal [name]` - Renew a name.
-- `sendtransfer [name] [address]` - Transfer name to another address.
-- `sendcancel [name]` - Cancel an in-progress transfer.
-- `sendfinalize [name]` - Finalize a transfer.
-- `sendrevoke [name]` - Revoke a name.
-- `importnonce [name] [address] [bid-value]` - Deterministically regenerate a
-  bid's nonce.
 
 ### Claiming a name
 

--- a/package.json
+++ b/package.json
@@ -49,8 +49,7 @@
     "urkel": "~0.6.3"
   },
   "devDependencies": {
-    "bmocha": "^2.1.4",
-    "bslint": "^5.15.3"
+    "bmocha": "^2.1.4"
   },
   "main": "./lib/hsd.js",
   "bin": {


### PR DESCRIPTION
Closes https://github.com/handshake-org/hsd/issues/489

Removes bslint from dependencies and installs it manually in workflows process for CI testing.

Added a CONTIRBUTING.md guide to explain how to install and use bslint since it is not automatic anymore. While there, added sections about bmocha and commit message preferences.

Linked that from README and, while there, removed the short list of RPC commands that we don't maintain and just linked to the API docs.