### PR TITLE
node rpc: scantxoutset

### DIFF
--- a/lib/blockchain/chain.js
+++ b/lib/blockchain/chain.js
@@ -2606,6 +2606,17 @@ class Chain extends AsyncEmitter {
   }
 
   /**
+   * Scans the UTXO set for coins that match
+   * the output descriptor.
+   * @param {Descriptor} - desc
+   * @returns {Promise} - Returns {Coin[]}
+   */
+
+  scanCoins(desc) {
+    return this.db.scanCoins(desc);
+  }
+
+  /**
    * Get all transaction hashes to an address.
    * @param {Address[]} addrs
    * @returns {Promise} - Returns {@link Hash}[].

--- a/lib/blockchain/chaindb.js
+++ b/lib/blockchain/chaindb.js
@@ -1109,6 +1109,34 @@ class ChainDB {
   }
 
   /**
+   * Scans the UTXO set for coins that match
+   * the output descriptor.
+   * @param {Descriptor} - desc
+   * @returns {Promise} - Returns {Coin[]}
+   */
+
+  async scanCoins(desc) {
+    const iter = this.db.iterator({
+      gte: layout.c.min(),
+      lte: layout.c.max(),
+      values: true
+    });
+
+    const coins = [];
+
+    await iter.each((key, value) => {
+      const entry = CoinEntry.decode(value);
+      const [hash, index] = layout.c.decode(key);
+      const coin = entry.toCoin({hash, index});
+
+      if (desc.test(coin.address))
+        coins.push(coin);
+    });
+
+    return coins;
+  }
+
+  /**
    * Check whether coins are still unspent. Necessary for bip30.
    * @see https://bitcointalk.org/index.php?topic=67738.0
    * @param {TX} tx

--- a/lib/node/rpc.js
+++ b/lib/node/rpc.js
@@ -28,6 +28,7 @@ const MerkleBlock = require('../primitives/merkleblock');
 const Headers = require('../primitives/headers');
 const MTX = require('../primitives/mtx');
 const Network = require('../protocol/network');
+const Descriptor = require('../utils/descriptor');
 const Outpoint = require('../primitives/outpoint');
 const Output = require('../primitives/output');
 const TX = require('../primitives/tx');
@@ -176,6 +177,7 @@ class RPC extends RPCBase {
     this.add('getrawmempool', this.getRawMempool);
     this.add('gettxout', this.getTXOut);
     this.add('gettxoutsetinfo', this.getTXOutSetInfo);
+    this.add('scantxoutset', this.scanTXOutSet);
     this.add('pruneblockchain', this.pruneBlockchain);
     this.add('verifychain', this.verifyChain);
 
@@ -1079,6 +1081,33 @@ class RPC extends RPCBase {
       hash_serialized: 0,
       total_amount: Amount.coin(this.chain.db.state.value, true),
       total_burned: Amount.coin(this.chain.db.state.burned, true)
+    };
+  }
+
+  async scanTXOutSet(args, help) {
+    if (help || args.length !== 1)
+      throw new RPCError(errs.MISC_ERROR, 'scantxoutset');
+
+    const valid = new Validator(args);
+    const descriptor = valid.str(0);
+
+    const desc = Descriptor.fromString(descriptor);
+    const coins = await this.chain.scanCoins(desc);
+
+    const unspents = [];
+    let amount = 0;
+    for (const coin of coins) {
+      amount += coin.value;
+      unspents.push(coin.toJSON());
+    }
+
+    return {
+      success: true,
+      txouts: coins.length,
+      height: this.chain.height,
+      bestblock: this.chain.tip.hash.toString('hex'),
+      unspents: unspents,
+      total_amount: amount
     };
   }
 

--- a/lib/utils/descriptor.js
+++ b/lib/utils/descriptor.js
@@ -18,8 +18,6 @@ const typeCache = new Set([
   'wpkh',
   'wsh',
   'addr',
-  'multi',
-  'sortedmulti',
   'opreturn'
 ]);
 

--- a/lib/utils/descriptor.js
+++ b/lib/utils/descriptor.js
@@ -1,15 +1,27 @@
 /**
- *
+ * descriptor.js - Output descriptor for hsd
+ * Copyright (c) 2020, The Handshake Developers (MIT License).
+ * Copyright (c) 2020, Mark Tyneway (MIT License).
+ * https://github.com/handshake-org/hsd
  */
 
+'use strict';
+
 const assert = require('bsert');
-const Script = require('../script/script')
+const Script = require('../script/script');
 const secp256k1 = require('bcrypto/lib/secp256k1');
 const Address = require('../primitives/address');
 const {BufferSet} = require('buffer-map');
 
 // all are top level
-const typeCache = new Set(['wpkh', 'wsh', 'addr', 'multi', 'sortedmulti', 'opreturn']);
+const typeCache = new Set([
+  'wpkh',
+  'wsh',
+  'addr',
+  'multi',
+  'sortedmulti',
+  'opreturn'
+]);
 
 class Descriptor {
   constructor(descriptor) {
@@ -24,13 +36,12 @@ class Descriptor {
     const chars = descriptor.split('');
 
     const stack = [];
-    const words = []; // TODO: for mulit, sortedmulti
     let word = [];
     let action = '';
 
     for (const char of chars) {
       switch (char) {
-        case '(':
+        case '(': {
           stack.push(char);
           const w = word.join('');
           if (!typeCache.has(w))
@@ -39,6 +50,7 @@ class Descriptor {
           action = w;
           word = [];
           break;
+        }
         case ')': {
           const item = stack.pop();
           if (item !== '(')
@@ -66,16 +78,6 @@ class Descriptor {
               this.addresses.add(address.encode());
               break;
             }
-            case 'multi': {
-              // not handling commas, unsupported still
-              throw new Error('multi Unsupported.');
-              break;
-            }
-            case 'sortedmulti': {
-              // not handling commas, unsupported still
-              throw new Error('sorted multi Unsupported.');
-              break;
-            }
             case 'opreturn': {
               let enc = 'ascii';
               if (w.startsWith('0x'))
@@ -95,7 +97,6 @@ class Descriptor {
           break;
       }
     }
-
 
     return this;
   }

--- a/lib/utils/descriptor.js
+++ b/lib/utils/descriptor.js
@@ -1,0 +1,116 @@
+/**
+ *
+ */
+
+const assert = require('bsert');
+const Script = require('../script/script')
+const secp256k1 = require('bcrypto/lib/secp256k1');
+const Address = require('../primitives/address');
+const {BufferSet} = require('buffer-map');
+
+// all are top level
+const typeCache = new Set(['wpkh', 'wsh', 'addr', 'multi', 'sortedmulti', 'opreturn']);
+
+class Descriptor {
+  constructor(descriptor) {
+    this.descriptor = descriptor || '';
+    this.addresses = new BufferSet();
+
+    if (descriptor)
+      this.fromString(descriptor);
+  }
+
+  fromString(descriptor) {
+    const chars = descriptor.split('');
+
+    const stack = [];
+    const words = []; // TODO: for mulit, sortedmulti
+    let word = [];
+    let action = '';
+
+    for (const char of chars) {
+      switch (char) {
+        case '(':
+          stack.push(char);
+          const w = word.join('');
+          if (!typeCache.has(w))
+            throw new Error(`Unknown word ${w}`);
+
+          action = w;
+          word = [];
+          break;
+        case ')': {
+          const item = stack.pop();
+          if (item !== '(')
+            throw new Error('Unclosed ")"');
+
+          const w = word.join('');
+          switch (action) {
+            case 'wsh': {
+              // w is a script
+              const script = Script.fromHex(w);
+              const address = Address.fromScript(script);
+              this.addresses.add(address.encode());
+              break;
+            }
+            case 'wpkh': {
+              // w is a pubkey
+              const pubkey = Buffer.from(w, 'hex');
+              assert(secp256k1.publicKeyVerify(pubkey));
+              const address = Address.fromPubkey(pubkey);
+              this.addresses.add(address.encode());
+              break;
+            }
+            case 'addr': {
+              const address = Address.fromString(w);
+              this.addresses.add(address.encode());
+              break;
+            }
+            case 'multi': {
+              // not handling commas, unsupported still
+              throw new Error('multi Unsupported.');
+              break;
+            }
+            case 'sortedmulti': {
+              // not handling commas, unsupported still
+              throw new Error('sorted multi Unsupported.');
+              break;
+            }
+            case 'opreturn': {
+              let enc = 'ascii';
+              if (w.startsWith('0x'))
+                enc = 'hex';
+
+              const data = Buffer.from(w, enc);
+              const address = Address.fromNulldata(data);
+              this.addresses.add(address.encode());
+              break;
+            }
+          }
+
+          break;
+        }
+        default:
+          word.push(char);
+          break;
+      }
+    }
+
+
+    return this;
+  }
+
+  toString() {
+    return this.descriptor;
+  }
+
+  test(address) {
+    return this.addresses.has(address.encode());
+  }
+
+  static fromString(descriptor) {
+    return new this(descriptor);
+  }
+}
+
+module.exports = Descriptor;

--- a/test/descriptor-test.js
+++ b/test/descriptor-test.js
@@ -1,0 +1,64 @@
+/**
+ * test/descriptor-test.js - Test output descriptor
+ * Copyright (c) 2020, The Handshake Developers (MIT License).
+ * Copyright (c) 2020, Mark Tyneway (MIT License).
+ * https://github.com/handshake-org/hsd
+ */
+
+'use strict';
+
+const assert = require('bsert');
+const secp256k1 = require('bcrypto/lib/secp256k1');
+const Address = require('../lib/primitives/address');
+const Script = require('../lib/script/script');
+const Opcode = require('../lib/script/opcode');
+const Descriptor = require('../lib/utils/descriptor');
+
+describe('Descriptor', function() {
+  it('should create wsh', () => {
+    const script = new Script([
+      Opcode.fromSymbol('return')
+    ]);
+
+    const copy = script.clone();
+    const address = Address.fromScript(copy);
+
+    const str = `wsh(${script.toHex()})`;
+    const desc = Descriptor.fromString(str);
+
+    assert.equal(desc.descriptor, str);
+    assert(desc.test(address));
+  });
+
+
+  it('should create wpkh', () => {
+    const privkey = secp256k1.privateKeyGenerate();
+    const pubkey = secp256k1.publicKeyCreate(privkey, true);
+    const str = `wpkh(${pubkey.toString('hex')})`;
+
+    const address = Address.fromPubkey(pubkey);
+    const desc = Descriptor.fromString(str);
+
+    assert.equal(desc.descriptor, str);
+    assert(desc.test(address));
+  });
+
+  it('should create addr', () => {
+    const address = new Address();
+    const str = `addr(${address.toString()})`;
+
+    const desc = Descriptor.fromString(str);
+    assert.equal(desc.descriptor, str);
+    assert(desc.test(address));
+  });
+
+  it('should create opreturn', () => {
+    const data = 'Bitcoin & BitDNS can be used separately'; // --Satoshi
+    const str = `opreturn(${data})`;
+    const address = Address.fromNulldata(Buffer.from(data, 'ascii'));
+
+    const desc = Descriptor.fromString(str);
+    assert.equal(desc.descriptor, str);
+    assert(desc.test(address));
+  });
+});

--- a/test/descriptor-test.js
+++ b/test/descriptor-test.js
@@ -30,7 +30,6 @@ describe('Descriptor', function() {
     assert(desc.test(address));
   });
 
-
   it('should create wpkh', () => {
     const privkey = secp256k1.privateKeyGenerate();
     const pubkey = secp256k1.publicKeyCreate(privkey, true);


### PR DESCRIPTION
This is a simple implementation of `scantxoutset`. This RPC returns a list of the outputs that match the output descriptor.

It currently works with the output descriptor types:

- `wpk`
- `wsh`
- `addr`
- `opreturn`

Some descriptor types defined in https://github.com/bitcoin/bitcoin/blob/master/doc/descriptors.md do not make sense for Handshake. It should be possible to add `multi` and `sortedmulti` with the current implementation.

The `Descriptor` class should be reimplemented and more thoroughly tested before this should be considered ready for a merge. I think a regex based approach for parsing the descriptor would be more flexible. The xpub stuff would be a nice to have. 

Example usage:

```
hsd-rpc --timeout 100000 scantxoutset 'addr(hs1qnryzj7n8awq7cd398q5t2cs6vqd6yv525y2c4l)'
```