### PR TITLE
[POLICY] address: fix isUnknown() to allow nullData and version 0 addresses

### DIFF
--- a/lib/primitives/address.js
+++ b/lib/primitives/address.js
@@ -371,9 +371,9 @@ class Address extends bio.Struct {
       case 0:
         return this.hash.length !== 20 && this.hash.length !== 32;
       case 31:
-        return true;
+        return false;
     }
-    return false;
+    return true;
   }
 
   /**

--- a/test/address-test.js
+++ b/test/address-test.js
@@ -14,4 +14,39 @@ describe('Address', function() {
     const expect = 'hs1qd42hrldu5yqee58se4uj6xctm7nk28r70e84vx';
     assert.strictEqual(addr.toString('main'), expect);
   });
+
+  it('should check standardness of address', () => {
+    const addr = new Address();
+
+    // Standard p2wpkh
+    addr.version = 0;
+    addr.hash = Buffer.alloc(20);
+    assert(!addr.isUnknown());
+
+    // Standard p2wsh
+    addr.version = 0;
+    addr.hash = Buffer.alloc(32);
+    assert(!addr.isUnknown());
+
+    // nullData, any valid length
+    for (let i = 2; i <= 40; i++) {
+      addr.version = 31;
+      addr.hash = Buffer.alloc(i);
+      assert(!addr.isUnknown());
+    }
+
+    // Non-Standard address
+    addr.version = 0;
+    addr.hash = Buffer.alloc(19);
+    assert(addr.isUnknown());
+
+    addr.version = 0;
+    addr.hash = Buffer.alloc(33);
+    assert(addr.isUnknown());
+
+    // Undefined version
+    addr.version = 1;
+    addr.hash = Buffer.alloc(32);
+    assert(addr.isUnknown());
+  });
 });


### PR DESCRIPTION
Fixes a bug in `Address.isUnknown()` that mis-identifies nulldata addresses as non-standard and mis-identifies all other witness program versions as standard (version 0 addresses are obviously OK)

Note that Bitcoin Core has allowed more flexibility in relaying unknown witness versions: https://github.com/bitcoin/bitcoin/pull/15846 But I don't think we need to worry about that yet.

Unfortunately before nulldata addresses can be used for practical purposes like [provably prunable outputs](https://github.com/handshake-org/hsd/issues/481#issuecomment-664658894), this patch needs to be released and widely deployed, especially to miners.