### PR TITLE
Send OPENs to nulldata address

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,13 @@ REGISTERing. If unpatched software was used to CLAIM a name already, that wallet
 database is irreversibly corrupted and must be replaced.
 See https://github.com/handshake-org/hsd/issues/454
 
+- By default the wallet will now send OPEN covenants to an unspendable `nullData`
+address (witness program version `31`, with minimum required data `0x0000`). This
+will prevent 0-value coins from bloating the UTXO set in chainDB and walletDB.
+It will also reduce the size of OPEN outputs in the blockchain by 18 bytes.
+Applications that relied on the output address to detect when a user has sent an
+OPEN must now rely on the input coins to an OPEN transaction for this purpose.
+
 ## v2.0.0
 
 ### Wallet API changes

--- a/lib/primitives/address.js
+++ b/lib/primitives/address.js
@@ -542,8 +542,6 @@ class Address extends bio.Struct {
       throw new Error('Object is not an address.');
 
     if (Buffer.isBuffer(data)) {
-      if (data.length !== 20 && data.length !== 32)
-        throw new Error('Object is not an address.');
       return data;
     }
 

--- a/lib/wallet/txdb.js
+++ b/lib/wallet/txdb.js
@@ -2155,7 +2155,6 @@ class TXDB {
       ns.applyState(delta);
 
       if (ns.isNull()) {
-        await this.removeNameMap(b, nameHash);
         b.del(layout.A.encode(nameHash));
       } else {
         b.put(layout.A.encode(nameHash), ns.encode());

--- a/lib/wallet/wallet.js
+++ b/lib/wallet/wallet.js
@@ -1091,9 +1091,6 @@ class Wallet extends EventEmitter {
   async _importName(name) {
     const nameHash = rules.hashName(name);
 
-    if (await this.txdb.hasNameState(nameHash))
-      throw new Error('Name already exists.');
-
     const b = this.db.batch();
     await this.wdb.addNameMap(b, nameHash, this.wid);
     await b.write();
@@ -1561,7 +1558,17 @@ class Wallet extends EventEmitter {
     if (start !== 0 && start !== height)
       throw new Error('Name is already opening.');
 
-    const addr = await this.receiveAddress(acct);
+    // Send 0-value output to provably unspendable address:
+    // hs1lqqqqhuxwgy (mainnet) is the smallest valid nulldata address
+    // and represents witness version 31 folowed by data of 0x0000.
+    // Unspendable outputs do not bloat the UTXO set or the wallet's coin set.
+    const addr = Address.fromNulldata(Buffer.alloc(2));
+
+    // Since this address is not in our wallet, we must "manually" add the name
+    // to the wallet database's name map. Normally the wallet would do this in
+    // txdb.js connectNames() when a TX is inserted into the DB, and the wallet
+    // recognizes the output address.
+    await this.importName(name);
 
     const output = new Output();
     output.address = addr;

--- a/test/wallet-importname-test.js
+++ b/test/wallet-importname-test.js
@@ -100,11 +100,8 @@ describe('Wallet Import Name', function() {
     assert(ns4 === null);
   });
 
-  it('should not re-import an existing name', async () => {
-    await assert.rejects(
-      alice.importName(name),
-      {message: 'Name already exists.'}
-    );
+  it('should ignore re-importing existing name', async () => {
+    await alice.importName(name);
   });
 
   it('should bid on names from Alice\'s wallet', async () => {
@@ -223,13 +220,9 @@ describe('Wallet Import Name', function() {
         assert(!bid.own);
     });
 
-    it('should not re-import name', async () => {
+    it('should ignore re-importing name', async () => {
       await wclient.execute('selectwallet', ['charlie']);
-
-      await assert.rejects(
-        wclient.execute('importname', [name, 0]),
-        {message: 'Name already exists.'}
-      );
+      await wclient.execute('importname', [name, 0]);
     });
   });
 });

--- a/test/wallet-test.js
+++ b/test/wallet-test.js
@@ -1962,7 +1962,7 @@ describe('Wallet', function() {
       // Check
       let bal = await wallet.getBalance();
       assert.strictEqual(bal.tx, 2);
-      assert.strictEqual(bal.coin, 2);
+      assert.strictEqual(bal.coin, 1); // OPENs are sent to a null address
       assert.strictEqual(bal.confirmed, 10e6);
       assert.strictEqual(bal.unconfirmed, 10e6 - fee);
       assert.strictEqual(bal.ulocked, 0);
@@ -1979,7 +1979,7 @@ describe('Wallet', function() {
       // Check
       bal = await wallet.getBalance();
       assert.strictEqual(bal.tx, 2);
-      assert.strictEqual(bal.coin, 2);
+      assert.strictEqual(bal.coin, 1);
       assert.strictEqual(bal.confirmed, 10e6 - (1 * fee));
       assert.strictEqual(bal.unconfirmed, 10e6 - (1 * fee));
       assert.strictEqual(bal.ulocked, 0);
@@ -1995,7 +1995,7 @@ describe('Wallet', function() {
       // Check
       let bal = await wallet.getBalance();
       assert.strictEqual(bal.tx, 3);
-      assert.strictEqual(bal.coin, 3);
+      assert.strictEqual(bal.coin, 2);
       assert.strictEqual(bal.confirmed, 10e6 - (1 * fee));
       assert.strictEqual(bal.unconfirmed, 10e6 - (2 * fee));
       assert.strictEqual(bal.ulocked, lockup);
@@ -2012,7 +2012,7 @@ describe('Wallet', function() {
       // Check
       bal = await wallet.getBalance();
       assert.strictEqual(bal.tx, 3);
-      assert.strictEqual(bal.coin, 3);
+      assert.strictEqual(bal.coin, 2);
       assert.strictEqual(bal.confirmed, 10e6 - (2 * fee));
       assert.strictEqual(bal.unconfirmed, 10e6 - (2 * fee));
       assert.strictEqual(bal.ulocked, lockup);
@@ -2028,7 +2028,7 @@ describe('Wallet', function() {
       // Check
       let bal = await wallet.getBalance();
       assert.strictEqual(bal.tx, 4);
-      assert.strictEqual(bal.coin, 4);
+      assert.strictEqual(bal.coin, 3);
       assert.strictEqual(bal.confirmed, 10e6 - (2 * fee));
       assert.strictEqual(bal.unconfirmed, 10e6 - (3 * fee));
       assert.strictEqual(bal.ulocked, value);
@@ -2045,7 +2045,7 @@ describe('Wallet', function() {
       // Check
       bal = await wallet.getBalance();
       assert.strictEqual(bal.tx, 4);
-      assert.strictEqual(bal.coin, 4);
+      assert.strictEqual(bal.coin, 3);
       assert.strictEqual(bal.confirmed, 10e6 - (3 * fee));
       assert.strictEqual(bal.unconfirmed, 10e6 - (3 * fee));
       assert.strictEqual(bal.ulocked, value);
@@ -2126,7 +2126,7 @@ describe('Wallet', function() {
       // Check
       bal = await wallet.getBalance();
       assert.strictEqual(bal.tx, 2);
-      assert.strictEqual(bal.coin, 2);
+      assert.strictEqual(bal.coin, 1);
       assert.strictEqual(bal.confirmed, 10e6 - (1 * fee));
       assert.strictEqual(bal.unconfirmed, 10e6 - (1 * fee));
       assert.strictEqual(bal.ulocked, 0);
@@ -2142,7 +2142,7 @@ describe('Wallet', function() {
       // Check
       let bal = await wallet.getBalance();
       assert.strictEqual(bal.tx, 2);
-      assert.strictEqual(bal.coin, 2);
+      assert.strictEqual(bal.coin, 1);
       assert.strictEqual(bal.confirmed, 10e6 - (1 * fee));
       assert.strictEqual(bal.unconfirmed, 10e6 - (1 * fee));
       assert.strictEqual(bal.ulocked, 0);
@@ -2159,7 +2159,7 @@ describe('Wallet', function() {
       // Check
       bal = await wallet.getBalance();
       assert.strictEqual(bal.tx, 3);
-      assert.strictEqual(bal.coin, 3);
+      assert.strictEqual(bal.coin, 2);
       assert.strictEqual(bal.confirmed, 10e6 - (2 * fee));
       assert.strictEqual(bal.unconfirmed, 10e6 - (2 * fee));
       assert.strictEqual(bal.ulocked, lockup);
@@ -2175,7 +2175,7 @@ describe('Wallet', function() {
       // Check
       let bal = await wallet.getBalance();
       assert.strictEqual(bal.tx, 3);
-      assert.strictEqual(bal.coin, 3);
+      assert.strictEqual(bal.coin, 2);
       assert.strictEqual(bal.confirmed, 10e6 - (2 * fee));
       assert.strictEqual(bal.unconfirmed, 10e6 - (2 * fee));
       assert.strictEqual(bal.ulocked, lockup);
@@ -2192,7 +2192,7 @@ describe('Wallet', function() {
       // Check
       bal = await wallet.getBalance();
       assert.strictEqual(bal.tx, 4);
-      assert.strictEqual(bal.coin, 4);
+      assert.strictEqual(bal.coin, 3);
       assert.strictEqual(bal.confirmed, 10e6 - (3 * fee));
       assert.strictEqual(bal.unconfirmed, 10e6 - (3 * fee));
       assert.strictEqual(bal.ulocked, value);


### PR DESCRIPTION
Closes https://github.com/handshake-org/hsd/issues/481
Chips away at https://github.com/handshake-org/hsd/issues/478
~Requires network deployment (especially miners) of https://github.com/handshake-org/hsd/pull/498~ ✅ 

Motivation is partly explained in #481 but here are the pros and cons:

### PROs

- reduce size of OPEN covenants by 18 bytes
- OPEN covenants do not bloat the UTXO set with 0-value outputs (technically spendable but why would you?)
- OPEN covenants do not bloat the wallet's UTXO set, which adds to the burden of the coin selector
- ~Prevents an annoyance where an attacker can send an OPEN to someone else's wallet, forcing that wallet to watch and collect all bids for that auction, whether or not the unwilling recipient cares about the name (also adds a 0-value UTXO to the victim's wallet, [because OPENs aren't checked for dust](https://github.com/handshake-org/hsd/blob/d1b42a6a50332ab64de4750297b468de76b05b76/lib/primitives/covenant.js#L352-L366))~ <- This will require a second patch in txdb if we decide it is a big enough issue.

### CONs

- We must wait until a majority of the relay nodes and miners have updated with #498 which fixes a bug in relay policy.
 - Because there is no address associated with OPEN, applications that used to use the address to detect when a wallet has sent an OPEN must be refactored to instead check the inputs to the TX ("Did my wallet send this tx? Then OK, tell the user they have OPENed an auction" -- as opposed to "This OPEN is being sent to my own address -- [example in Bob Wallet](https://github.com/kyokan/bob-wallet/blob/master/app/ducks/walletActions.js#L253-L255)")

### Review





commit 4b75f8aa8e45d325f8b7b6501767ff98fceebda9  address: don't restrict data length to 20 or 32
  - I'm not sure if we ever needed this check in the first place, opened an issue upstream: https://github.com/bcoin-org/bcoin/issues/989

commit 0301f47e6163b55712c2bd97af4adb54790bfed7  wallet: do not remove wallet-name-map when disconnecting a block
  - At the beginning of a rescan, a lot of wallet state is thrown out (not transactions themselves, but whether or not they are confirmed and in what block). We also clear out the name map, which is a simple structure that stores which wallet IDs are "watching" a name. I do not think we need to reset this, and removed it here.

commit 4075ae856d2195ad4c4b9f8c98debd50f1cb25a6  wallet: send OPENs to unspendable nullData address
  - this is the fix, comments should explain the patch. Luckily we have `importName()` now! https://github.com/handshake-org/hsd/pull/408

commit 8edaea67e01a3e18856b97384ace398de4a7ce1c  test: OPEN outputs no longer inserted as coins into txdb
  - notice how certain tests had to be adjusted because the OPEN output is no longer stored as a coin in the wallet

commit c1932472d1093f793e69db946161be595f6b5a32  pkg: update CHANGELOG
  - hopefully this explains the change well enough to developers using hsd in their own wallet applications
