### PR TITLE
wallet: add 'spendable_balance' to getwalletinfo RPC

### DIFF
--- a/lib/wallet/rpc.js
+++ b/lib/wallet/rpc.js
@@ -748,12 +748,14 @@ class RPC extends RPCBase {
 
     const wallet = this.wallet;
     const balance = await wallet.getBalance();
+    const spendableBalance = balance.unconfirmed - balance.ulocked;
 
     return {
       walletid: wallet.id,
       walletversion: 6,
       balance: Amount.coin(balance.unconfirmed, true),
       unconfirmed_balance: Amount.coin(balance.unconfirmed, true),
+      spendable_balance: Amount.coin(spendableBalance, true),
       txcount: balance.tx,
       keypoololdest: 0,
       keypoolsize: 0,


### PR DESCRIPTION
This enables a user to view their spendable balance using the `getwalletinfo` RPC