### PR TITLE
Mining: set minimum block weight to 5000, parse as configuration option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## unreleased
 
+### Node changes
+
+- `FullNode` now parses option `--min-weight=<number>` (`min-weight: <number>` in
+hsd.conf or `minWeight: <number>` in JavaScript object instantiation).
+When assembling a block template, if there are not enough fee-paying transactions available,
+the miner will add transactions up to the minimum weight that would normally be
+ignored for being "free" (paying a fee below policy limit). The default value is
+raised from `0` to `5000` (a 1-in, 2-out BID transaction has a weight of about `889`).
+
 ### Wallet changes
 
 - Fixes a bug that ignored the effect of sending or receiving a FINALIZE on a

--- a/lib/node/fullnode.js
+++ b/lib/node/fullnode.js
@@ -121,6 +121,7 @@ class FullNode extends Node {
       address: this.config.array('coinbase-address'),
       coinbaseFlags: this.config.str('coinbase-flags'),
       preverify: this.config.bool('preverify'),
+      minWeight: this.config.uint('min-weight'),
       maxWeight: this.config.uint('max-weight'),
       reservedWeight: this.config.uint('reserved-weight'),
       reservedSigops: this.config.uint('reserved-sigops')

--- a/lib/protocol/policy.js
+++ b/lib/protocol/policy.js
@@ -138,7 +138,7 @@ exports.MEMPOOL_MAX_ORPHANS = 100;
  * @default
  */
 
-exports.MIN_BLOCK_WEIGHT = 0;
+exports.MIN_BLOCK_WEIGHT = 5000;
 
 /**
  * Maximum block weight to be mined.

--- a/test/miner-test.js
+++ b/test/miner-test.js
@@ -1,0 +1,173 @@
+/* eslint-env mocha */
+
+'use strict';
+
+const assert = require('bsert');
+
+const WorkerPool = require('../lib/workers/workerpool');
+const Chain = require('../lib/blockchain/chain');
+const Mempool = require('../lib/mempool/mempool');
+const Miner = require('../lib/mining/miner');
+const Address = require('../lib/primitives/address');
+const MTX = require('../lib/primitives/mtx');
+const MemWallet = require('./util/memwallet');
+const {BufferSet} = require('buffer-map');
+
+const workers = new WorkerPool({
+  enabled: true
+});
+
+const chain = new Chain({
+  network: 'regtest',
+  memory: true,
+  workers
+});
+
+const mempool = new Mempool({
+  chain,
+  memory: true,
+  workers
+});
+
+const miner = new Miner({
+  chain,
+  mempool,
+  workers
+});
+
+const wallet = new MemWallet({
+  network: 'regtest'
+});
+
+// Dummy address to receive
+const addr = new Address({
+  version: 0,
+  hash: Buffer.alloc(20, 0x88)
+});
+
+chain.on('connect', async (entry, block, view) => {
+  await mempool._addBlock(entry, block.txs, view);
+  wallet.addBlock(entry, block.txs);
+});
+
+describe('Miner', function() {
+  before(async () => {
+    await workers.open();
+    await chain.open();
+    await mempool.open();
+    await miner.open();
+  });
+
+  after(async () => {
+    await miner.close();
+    await mempool.close();
+    await workers.close();
+    await chain.close();
+  });
+
+  let walletAddr;
+  const txids = new BufferSet();
+
+  it('should generate 20 blocks to wallet address', async () => {
+    walletAddr = wallet.createReceive().getAddress();
+
+    for (let i = 1; i <= 20; i++) {
+      assert.bufferEqual(chain.tip.hash, mempool.tip);
+      const block = await miner.mineBlock(chain.tip, walletAddr);
+      await chain.add(block);
+      assert.bufferEqual(chain.tip.hash, mempool.tip);
+      assert.strictEqual(chain.tip.height, i);
+    }
+  });
+
+  it('should mine block with 10 ok-fee transactions', async () => {
+    const value = 1 * 1e6;
+    const fee = 1000;
+
+    for (let i = 0; i < 10; i++) {
+      const change = wallet.createChange().getAddress();
+      const coin = wallet.getCoins()[i];
+      const mtx = new MTX();
+      mtx.addCoin(coin);
+      mtx.addOutput(addr, value);
+      mtx.addOutput(change, coin.value - value - fee);
+      wallet.sign(mtx);
+      const tx = mtx.toTX();
+      wallet.addTX(tx);
+      txids.add(tx.hash());
+
+      await mempool.addTX(tx, -1);
+    }
+
+    assert.strictEqual(mempool.map.size, 10);
+
+    const block = await miner.mineBlock(chain.tip, addr);
+    await chain.add(block);
+
+    // All 10 TXs are in the block, cleared from the mempool
+    assert.strictEqual(mempool.map.size, 0);
+    assert.strictEqual(block.txs.length, 11);
+    for (let i = 1; i < block.txs.length; i++) {
+      assert(txids.has(block.txs[i].hash()));
+    }
+  });
+
+  it('should not include free transactions in block', async () => {
+    // Clear
+    txids.clear();
+    assert.strictEqual(txids.size, 0);
+
+    // Miner does not have any room for free TXs
+    miner.options.minWeight = 0;
+
+    const addr = new Address({
+      version: 0,
+      hash: Buffer.alloc(20, 0x88)
+    });
+
+    const value = 1 * 1e6;
+    const fee = 0;
+
+    for (let i = 0; i < 10; i++) {
+      const change = wallet.createChange().getAddress();
+      const coin = wallet.getCoins()[i];
+      const mtx = new MTX();
+      mtx.addCoin(coin);
+      mtx.addOutput(addr, value);
+      mtx.addOutput(change, coin.value - value - fee);
+      wallet.sign(mtx);
+      const tx = mtx.toTX();
+      wallet.addTX(tx);
+      txids.add(tx.hash());
+
+      await mempool.addTX(tx, -1);
+    }
+
+    assert.strictEqual(mempool.map.size, 10);
+
+    const block = await miner.mineBlock(chain.tip, addr);
+    await chain.add(block);
+
+    // All 10 TXs are still in mempool, nothing in block except coinbase
+    assert.strictEqual(mempool.map.size, 10);
+    assert.strictEqual(block.txs.length, 1);
+  });
+
+  it('should include free transactions in block with minWeight', async () => {
+    // Now the miner has allocated space for free TXs
+    miner.options.minWeight = 10000;
+
+    // Transactions are still in mempool from last test
+    assert.strictEqual(mempool.map.size, 10);
+
+    const block = await miner.mineBlock(chain.tip, addr);
+    await chain.add(block);
+
+    // All 10 TXs are in the block, cleared from the mempool
+    assert.strictEqual(mempool.map.size, 0);
+    assert.strictEqual(block.txs.length, 11);
+    for (let i = 1; i < block.txs.length; i++) {
+      assert(txids.has(block.txs[i].hash()));
+    }
+  });
+});


### PR DESCRIPTION
Addresses https://github.com/handshake-org/hsd/issues/430 -- [solution 1 & 2](https://github.com/handshake-org/hsd/issues/430#issuecomment-614611881)

(see also #515)

# Goal

Prevent low- or no-fee transactions from being stuck in the mempool forever, by adjusting mining policy to occasionally include them.

This PR is mainly changing a constant in policy.js from a value that used to be `0`:
```
/**
 * Minimum block size to create. Block will be
 * filled with free transactions until block
 * reaches this weight.
 * @const {Number}
 * @default
 */

exports.MIN_BLOCK_WEIGHT = 5000;
```

What this means is, in miner.js `assemble()` when a block is being put together to be hashed, if the current block template has a total weight under 5000, the miner will insert "free" transactions from the mempool (very low fee transactions).

One such TX might be this poor guy:

https://shakescan.com/transaction/a239970210b948d462adf8a07fb2e8bf9b301ba34942cb01b86eb96aeec2ad30

...that has been patiently pending for SIX MONTHS.

5000 weight units is tiny by the way. An "empty" block with just a coinbase is already `1308` weight.

I ran a few heuristics to determine how often a block with <5000 weight ever gets mined. Parsing blocks 2016-33054. ([all data](https://gist.github.com/pinheadmz/e7257136a60325f705458a8cb71185bc))
```
weight || count
   1000   2834
   2000   1391
   3000   1175
   4000   840
   5000   829
   6000   727
   7000   708
   8000   719
   9000   598
   10000  4361
   20000  2867
   30000  2128
   40000  1595
   50000  1206
   60000  979
   70000  848
   80000  724
   90000  628
   100000 502
```

and another test to see how big the average "gap" in blocks is between blocks of a certain weight:

```
wt.   || average gap
1000   10.942484121383204
2000   22.249640287769783
3000   26.313458262350938
4000   36.84642857142857
5000   37.39492753623188
6000   42.57575757575758
7000   43.74115983026874
8000   43.17941585535466
9000   51.88609715242881
10000   7.109736540664375
20000  10.815202231520223
30000  14.49906015037594
40000  19.337092731829575
50000  25.409958506224065
60000  31.163265306122447
70000  36.560802833530104
80000  42.881051175656985
90000  48.346092503987244
100000 60.439121756487026
```

# So,

long story short - we can expect a block < 5000 weight a few times a day at the current network activity level. This means there is still very limited opportunities for a low-fee tx to get included in a block with this new policy rule. And when it happens, miners won't be sacrificing really anything.

# Also,

miners can bypass this rule by launching with `--min-weight=0` (or other value) which is now parsed by the full node.