### PR TITLE
test: make cloudflare fake claims deterministic

### DIFF
--- a/test/mempool-test.js
+++ b/test/mempool-test.js
@@ -904,7 +904,7 @@ describe('Mempool', function() {
       assert(!mempool.getTX(bid.hash()));
     });
 
-    it.skip('should handle reorg: name claim - DNSSEC timestamp', async () => {
+    it('should handle reorg: name claim - DNSSEC timestamp', async () => {
       // Mempool is empty
       await mempool.reset();
       assert.strictEqual(mempool.map.size, 0);
@@ -990,7 +990,7 @@ describe('Mempool', function() {
       assert(!mempool.getClaim(claim.hash()));
     });
 
-    it.skip('should handle reorg: name claim - block commitment', async () => {
+    it('should handle reorg: name claim - block commitment', async () => {
       // Mempool is empty
       await mempool.reset();
       assert.strictEqual(mempool.map.size, 0);

--- a/test/wallet-test.js
+++ b/test/wallet-test.js
@@ -2529,7 +2529,14 @@ describe('Wallet', function() {
     const network = Network.get('regtest');
     const workers = new WorkerPool({enabled: false});
     const wdb = new WalletDB({network, workers});
-    const lockup = 6800503496047;
+    // Cloudflare's "custom value" plus the standard "name value".
+    // Verifiable with reserved-browser.js and names.json
+    const lockup = 6800000000000 + 503513487;
+    // By setting the fee rate to zero when we create the claim,
+    // we can ensure determinstic wallet values even if the size of
+    // claim changes due to external factors like Cloudflare updating
+    // their real world DNS zone, which is retrieved by the wallet in this test.
+    const fee = 0;
     const name = 'cloudflare';
     const nameHash = rules.hashString(name);
 
@@ -2562,7 +2569,7 @@ describe('Wallet', function() {
       assert.equal(pre.ulocked, 0);
       assert.equal(pre.clocked, 0);
 
-      const claim = await wallet.sendFakeClaim('cloudflare');
+      const claim = await wallet.sendFakeClaim('cloudflare', {fee});
       assert(claim);
 
       const tx = claim.toTX(network, wdb.state.height + 1);


### PR DESCRIPTION
Closes https://github.com/handshake-org/hsd/pull/516
Resolves https://github.com/handshake-org/hsd/commit/a5cc3930bbe906c791f3bac54901fb657029a506

There are several tests that make "fake" reserved name claims in order to test the HNS reserved name claim system. That system looks up actual, real-world, ICANN-rooted DNS records and checks the DNSSEC chain. The only thing "fake" about the tests is that once we download the actual live DNSSEC chain, the test inserts a wallet claim such as this into the `cloudflare.com` zone:

```
cloudflare.com. 300 IN TXT "hns-regtest:aakbvmygsp7rrhmsauhwlnwx6srd5m2v4m3p3eidadl5yn2f"
```

Of course this invalidates the `RRSIG TXT` in that zone, but we have a bypass just for this precise case so we can test everything else:

https://github.com/handshake-org/hsd/blob/7826128ff72c20fdf42c659309dcffea7a28f6cc/test/auction-reorg-test.js#L454-L459

The issue is that now the test suite is dependent on the runner's ability to access the internet, and lookup the `cloudflare.com` DNS zone. I think that is OK -- since the ability to do so is also crucial for the HNS reserved name claims system to work.

What this PR fixes is a set value that the fake claim redeems by claiming `cloudflare` on regtest. The claim still pays a fee, which is an amount of HNS based on the size of the claim (just like any other type of transaction). However, cloudflare is welcome to change their DNS records at any time -- add or remove TXT in their zone, sign RRSIGs with different key algorithms, etc. This means we can not predetermine the size of the fake claim for the test and therefore can not assert that a specific value of HNS will be redeemed by submitting the claim on regtest.

Solution: set the fee rate to zero :-)

