### PR TITLE
wallet: remove wid from index when wallet is removed

### DIFF
--- a/lib/wallet/walletdb.js
+++ b/lib/wallet/walletdb.js
@@ -1018,6 +1018,16 @@ class WalletDB extends EventEmitter {
       return this.removePathMap(b, hash, wid);
     });
 
+    const niter = this.db.iterator({
+      gte: layout.N.min(),
+      lte: layout.N.max()
+    });
+
+    await niter.each((key) => {
+      const [hash] = layout.N.decode(key);
+      return this.removeNameMap(b, hash, wid);
+    });
+
     const removeRange = (opt) => {
       return this.db.iterator(opt).each(key => b.del(key));
     };
@@ -1068,16 +1078,6 @@ class WalletDB extends EventEmitter {
     await siter.each((key, value) => {
       const [hash, index] = tlayout.s.decode(key);
       return this.removeOutpointMap(b, hash, index, wid);
-    });
-
-    const niter = this.db.iterator({
-      gte: layout.N.min(),
-      lte: layout.N.max()
-    });
-
-    await niter.each((key) => {
-      const [hash] = layout.N.decode(key);
-      return this.removeNameMap(b, hash, wid);
     });
 
     const uiter = bucket.iterator({

--- a/lib/wallet/walletdb.js
+++ b/lib/wallet/walletdb.js
@@ -1070,6 +1070,17 @@ class WalletDB extends EventEmitter {
       return this.removeOutpointMap(b, hash, index, wid);
     });
 
+    const niter = bucket.iterator({
+      gte: layout.N.min(),
+      lte: layout.N.max(),
+      keys: true
+    });
+
+    await niter.each((key, value) => {
+      const [hash] = layout.N.decode(key);
+      return this.removeNameMap(b, hash, wid);
+    });
+
     const uiter = bucket.iterator({
       gte: tlayout.p.min(),
       lte: tlayout.p.max(),
@@ -1609,8 +1620,6 @@ class WalletDB extends EventEmitter {
 
   async getWalletsByTX(tx) {
     const wids = new Set();
-    const b = this.db.batch();
-    let del = false;
 
     if (!tx.isCoinbase()) {
       for (const {prevout} of tx.inputs) {
@@ -1624,14 +1633,8 @@ class WalletDB extends EventEmitter {
         if (!map)
           continue;
 
-        for (const wid of map.wids) {
-          if (await this.has(wid)) {
-            wids.add(wid);
-          } else {
-            await this.removeOutpointMap(b, hash, index, wid);
-            del = true;
-          }
-        }
+        for (const wid of map.wids)
+          wids.add(wid);
       }
     }
 
@@ -1646,14 +1649,8 @@ class WalletDB extends EventEmitter {
       if (!map)
         continue;
 
-      for (const wid of map.wids) {
-        if (await this.has(wid)) {
-          wids.add(wid);
-        } else {
-          await this.removePathMap(b, hash, wid);
-          del = true;
-        }
-      }
+      for (const wid of map.wids)
+        wids.add(wid);
     }
 
     for (const {covenant} of tx.outputs) {
@@ -1670,19 +1667,9 @@ class WalletDB extends EventEmitter {
       if (!map)
         continue;
 
-      for (const wid of map.wids) {
-        if (await this.has(wid)) {
-          wids.add(wid);
-        } else {
-          await this.removeNameMap(b, nameHash, wid);
-          del = true;
-        }
-      }
+      for (const wid of map.wids)
+        wids.add(wid);
     }
-
-    // Delete old wid from maps
-    if (del)
-      await b.write();
 
     if (wids.size === 0)
       return null;

--- a/lib/wallet/walletdb.js
+++ b/lib/wallet/walletdb.js
@@ -1609,6 +1609,8 @@ class WalletDB extends EventEmitter {
 
   async getWalletsByTX(tx) {
     const wids = new Set();
+    const b = this.db.batch();
+    let del = false;
 
     if (!tx.isCoinbase()) {
       for (const {prevout} of tx.inputs) {
@@ -1622,8 +1624,14 @@ class WalletDB extends EventEmitter {
         if (!map)
           continue;
 
-        for (const wid of map.wids)
-          wids.add(wid);
+        for (const wid of map.wids) {
+          if (await this.has(wid)) {
+            wids.add(wid);
+          } else {
+            await this.removeOutpointMap(b, hash, index, wid);
+            del = true;
+          }
+        }
       }
     }
 
@@ -1638,8 +1646,14 @@ class WalletDB extends EventEmitter {
       if (!map)
         continue;
 
-      for (const wid of map.wids)
-        wids.add(wid);
+      for (const wid of map.wids) {
+        if (await this.has(wid)) {
+          wids.add(wid);
+        } else {
+          await this.removePathMap(b, hash, wid);
+          del = true;
+        }
+      }
     }
 
     for (const {covenant} of tx.outputs) {
@@ -1656,9 +1670,19 @@ class WalletDB extends EventEmitter {
       if (!map)
         continue;
 
-      for (const wid of map.wids)
-        wids.add(wid);
+      for (const wid of map.wids) {
+        if (await this.has(wid)) {
+          wids.add(wid);
+        } else {
+          await this.removeNameMap(b, nameHash, wid);
+          del = true;
+        }
+      }
     }
+
+    // Delete old wid from maps
+    if (del)
+      await b.write();
 
     if (wids.size === 0)
       return null;

--- a/lib/wallet/walletdb.js
+++ b/lib/wallet/walletdb.js
@@ -1070,13 +1070,12 @@ class WalletDB extends EventEmitter {
       return this.removeOutpointMap(b, hash, index, wid);
     });
 
-    const niter = bucket.iterator({
+    const niter = this.db.iterator({
       gte: layout.N.min(),
-      lte: layout.N.max(),
-      keys: true
+      lte: layout.N.max()
     });
 
-    await niter.each((key, value) => {
+    await niter.each((key) => {
       const [hash] = layout.N.decode(key);
       return this.removeNameMap(b, hash, wid);
     });

--- a/test/wallet-test.js
+++ b/test/wallet-test.js
@@ -1510,20 +1510,23 @@ describe('Wallet', function() {
     await b.write();
 
     // Should return tx from TX Map
-    assert(await wdb.getWalletsByTX(mtx));
+    let wids = await wdb.getWalletsByTX(mtx);
+    assert(wids.has(wid));
 
     // Should have wid in NameMap
-    const map = await wdb.getNameMap(hashName('test123'));
+    let map = await wdb.getNameMap(hashName('test123'));
     assert(map.wids.has(wid));
 
     // Remove wallet
     await wdb.remove('alice100');
 
-    // Should not return wid from NameMap after wid is removed
-    assert(!await wdb.getNameMap(hashName('test123')));
-
     // Should not return tx from TX Map after wallet is removed
-    assert(!await wdb.getWalletsByTX(mtx));
+    wids = await wdb.getWalletsByTX(mtx);
+    assert.strictEqual(wids, null);
+
+    // Should not return wid from NameMap after wid is removed
+    map = await wdb.getNameMap(hashName('test123'));
+    assert.strictEqual(map, null);
 
     // Should not return wallet after it is removed
     assert(!await wdb.get('alice100'));

--- a/test/wallet-test.js
+++ b/test/wallet-test.js
@@ -1514,7 +1514,7 @@ describe('Wallet', function() {
 
     // Should have wid in NameMap
     const map = await wdb.getNameMap(hashName('test123'));
-    assert(map[wid]);
+    assert(map.wids[wid]);
 
     // Remove wallet
     await wdb.remove('alice100');

--- a/test/wallet-test.js
+++ b/test/wallet-test.js
@@ -1514,12 +1514,12 @@ describe('Wallet', function() {
 
     // Should have wid in NameMap
     const map = await wdb.getNameMap(hashName('test123'));
-    assert(map.wids[wid]);
+    assert(map.wids.has(wid));
 
     // Remove wallet
     await wdb.remove('alice100');
 
-    // Should not wid from NameMap after wid is removed
+    // Should not return wid from NameMap after wid is removed
     assert(!await wdb.getNameMap(hashName('test123')));
 
     // Should not return tx from TX Map after wallet is removed


### PR DESCRIPTION
This fixes an issue where wallet ids were still stored in `OutpointMap`, `TXMap`, and `NameMap` after the wallet is removed, causing rescan of any wallet containing a matching `outpoint`, `tx`, or `name` to fail due to this [exception](https://github.com/handshake-org/hsd/blob/master/lib/wallet/walletdb.js#L2310).

This fix does two things:
- only return current `wid` when `getWalletsByTX` is called
- if old `wid` are found, remove from the corresponding map
