### PR TITLE
protocol: clear regtest and simnet seeds

### DIFF
--- a/lib/protocol/networks.js
+++ b/lib/protocol/networks.js
@@ -727,10 +727,7 @@ const regtest = {};
 
 regtest.type = 'regtest';
 
-regtest.seeds = [
-  '127.0.0.1',
-  'aorsxa4ylaacshipyjkfbvzfkh3jhh4yowtoqdt64nzemqtiw2whk@127.0.0.1'
-];
+regtest.seeds = [];
 
 regtest.magic = genesis.regtest.magic;
 
@@ -873,10 +870,7 @@ const simnet = {};
 
 simnet.type = 'simnet';
 
-simnet.seeds = [
-  '127.0.0.1',
-  'aorsxa4ylaacshipyjkfbvzfkh3jhh4yowtoqdt64nzemqtiw2whk@127.0.0.1'
-];
+simnet.seeds = [];
 
 simnet.magic = genesis.simnet.magic;
 


### PR DESCRIPTION
Reduces console spam when only a single node is running on regtest/simnet networks.

This was merged into bcoin (https://github.com/bcoin-org/bcoin/pull/694) and later into hsd (https://github.com/handshake-org/hsd/commit/eaf53f4f75eee45aee1208bdd9a554a606c40724, https://github.com/handshake-org/hsd/pull/106), but reverted by @chjj in https://github.com/handshake-org/hsd/commit/41558d8b698455a1e189d75191ffd2568fc56ae7 and https://github.com/handshake-org/hsd/commit/a2e357d9b57884a78bd7e406e3c7c98cc3deaf4b.

Is there any reason these must be hardcoded? They can always be added with arguments/config when required.