### PR TITLE
wallet: fix the return of POST /reveal and /redeem

### DIFF
--- a/lib/wallet/http.js
+++ b/lib/wallet/http.js
@@ -1076,7 +1076,7 @@ class HTTP extends Server {
 
       if (!name) {
         const tx = await req.wallet.sendRevealAll();
-        return tx.getJSON(this.network);
+        return res.json(200, tx.getJSON(this.network));
       }
 
       const options = TransactionOptions.fromValidator(valid);
@@ -1105,7 +1105,7 @@ class HTTP extends Server {
 
       if (!name) {
         const tx = await req.wallet.sendRedeemAll();
-        return tx.getJSON(this.network);
+        return res.json(200, tx.getJSON(this.network));
       }
 
       const options = TransactionOptions.fromValidator(valid);

--- a/test/wallet-http-test.js
+++ b/test/wallet-http-test.js
@@ -669,6 +669,33 @@ describe('Wallet HTTP', function() {
     assert.equal(reveals.length, 1);
   });
 
+  it('should create all reveals', async () => {
+    await wallet.createOpen({
+      name: name
+    });
+
+    await mineBlocks(treeInterval + 1, cbAddress);
+
+    for (let i = 0; i < 3; i++) {
+      await wallet.createBid({
+        name: name,
+        bid: 1000,
+        lockup: 2000
+      });
+    }
+
+    await mineBlocks(biddingPeriod + 1, cbAddress);
+
+    const {info} = await nclient.execute('getnameinfo', [name]);
+    assert.equal(info.name, name);
+    assert.equal(info.state, 'REVEAL');
+
+    const json = await wallet.createReveal();
+
+    const reveals = json.outputs.filter(output => output.covenant.type === types.REVEAL);
+    assert.equal(reveals.length, 3);
+  });
+
   it('should get all reveals (single player)', async () => {
     await wallet.createOpen({
       name: name


### PR DESCRIPTION
Fix the return of POST /reveal and /redeem when no name provided.