### PR TITLE
v2.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,6 @@
 # HSD Release Notes & Changelog
 
-## unreleased
-
+## v2.3.0
 
 ### Node changes
 

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ $ npm install -g https://github.com/handshake-org/hsd.git
 
 A `git` ref can be used to install a particular version by appending
 a `#` and the name of the `git` ref to the URL. For example,
-`https://github.com/handshake-org/hsd.git#v2.2.0`. It is recommended
+`https://github.com/handshake-org/hsd.git#v2.3.0`. It is recommended
 to use the [latest tagged release](https://github.com/handshake-org/hsd/releases).
 
 If adding `hsd` as a dependency to a project, use the command:

--- a/lib/pkg.js
+++ b/lib/pkg.js
@@ -70,7 +70,7 @@ pkg.cfg = `${pkg.core}.conf`;
  * @default
  */
 
-pkg.version = '2.2.0';
+pkg.version = '2.3.0';
 
 /**
  * Repository URL.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "hsd",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hsd",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "description": "Cryptocurrency bike-shed",
   "license": "MIT",
   "repository": "git://github.com/handshake-org/hsd.git",


### PR DESCRIPTION
This release contains a bug fix that affected wallet balances after sending or receiving names. The bug could permanently corrupt the walletDB. It also introduces an API endpoint to clear out this corruption so the wallet can be restored with a rescan (after upgrading). There are also policy improvements to help clear out or confirm transactions accidentally sent with too-low a fee.

Reviewers can install master branch of hsd at this time, and check through the list of closed PRs in the v2.3.0 milestone list: https://github.com/handshake-org/hsd/milestone/2?closed=1

You might grep your log for similar messages to see 3-day-old transactions being evicted from the mempool:

```
[D:2021-01-14T15:46:44Z] (mempool) Added 6cb49aa29103f4f74ab9a9d37e776a827eec26957544eb69f15e13e04db91821 to mempool (txs=46).
...
[D:2021-01-17T15:46:44Z] (mempool) Removing package 6cb49aa29103f4f74ab9a9d37e776a827eec26957544eb69f15e13e04db91821 from mempool (too old).
```

And if you ever transferred names in or out of your wallet you can try the `deepclean` process to restore an accurate balance in the UI (`hsw-cli balance`).