### PR TITLE
dns/server: blacklist rfc2606 domains in the resolver

### DIFF
--- a/lib/dns/server.js
+++ b/lib/dns/server.js
@@ -51,6 +51,20 @@ const TYPE_MAP = Buffer.from('000722000000000380', 'hex');
 const RES_OPT = { inet6: false, tcp: true };
 const CACHE_TTL = 30 * 60 * 1000;
 
+// reference: https://tools.ietf.org/id/draft-chapin-rfc2606bis-00.html#registry
+const rfc2606 = [
+  'corp',
+  'domain',
+  'example',
+  'home',
+  'host',
+  'invalid',
+  'lan',
+  'local',
+  'localdomain',
+  'localhost',
+  'test'
+];
 const blacklist = new Set([
   'bit', // Namecoin
   'eth', // ENS
@@ -59,7 +73,8 @@ const blacklist = new Set([
   'i2p', // Invisible Internet Project
   'onion', // Tor
   'tor', // OnioNS
-  'zkey' // GNS
+  'zkey', // GNS
+  ...rfc2606
 ]);
 
 /**


### PR DESCRIPTION
Reference: https://tools.ietf.org/id/draft-chapin-rfc2606bis-00.html#registry

There are a small handful of domains that are commonly used for internal DNS that ICANN has never delegated. They make up a significant portion of DNS traffic because all those internal DNS queries leak to resolvers they're not supposed to. Handshake has already blacklisted a few of these domains from being registered (see `covenants/rules.js`), but there are others that have not been blacklisted.

Perhaps this was an intentional choice, and if so, I'm curious to discuss it. But assuming it was just an oversight, this PR blacklists the remaining names in the referenced RFC draft.