### PR TITLE
Fix jsdocs

### DIFF
--- a/lib/wallet/path.js
+++ b/lib/wallet/path.js
@@ -25,7 +25,7 @@ class Path extends bio.Struct {
   /**
    * Create a path.
    * @constructor
-   * @param {Object?} options
+   * @param {Object} [options]
    */
 
   constructor(options) {
@@ -213,7 +213,7 @@ class Path extends bio.Struct {
 
   /**
    * Convert path object to string derivation path.
-   * @param {String|Network?} network - Network type.
+   * @param {String|Network} [network] - Network type.
    * @returns {String}
    */
 
@@ -243,7 +243,7 @@ class Path extends bio.Struct {
 
   /**
    * Convert path to a json-friendly object.
-   * @param {String|Network?} network - Network type.
+   * @param {String|Network} [network] - Network type.
    * @returns {Object}
    */
 


### PR DESCRIPTION
JSDoc is complaining about a few optional parameters. 
[Optional parameters](https://jsdoc.app/tags-param.html#optional-parameters-and-default-values) should be placed between `[square bracket]` instead of prefixed with `?`