### PR TITLE
namestate: expose transfer lockup period

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## unreleased
 
+### Wallet API changes
+
 - Adds new wallet HTTP endpoint `/wallet/:id/auction` based on `POST /wallet/:id/bid`.
 It requires an additional parameter `broadcastBid` set to either true or false.
 This action returns a bid and its corresponding reveal, the reveal being prepared in advance.
@@ -10,6 +12,11 @@ The bid will be broadcasted either during the creation (`broadcastBid=true`) or 
 The reveal will have to be broadcasted at a later time, during the REVEAL phase.
 The lockup must include a blind big enough to ensure the BID will be the only input of the REVEAL
 transaction. 
+
+### Node & Wallet API changes
+
+- The `stats` field included in `namestate.toJSON()` includes extra data if the name
+is in a TRANSFER state.
 
 ## v2.3.0
 

--- a/lib/covenants/namestate.js
+++ b/lib/covenants/namestate.js
@@ -732,7 +732,8 @@ class NameState extends bio.Struct {
       biddingPeriod,
       revealPeriod,
       renewalWindow,
-      auctionMaturity
+      auctionMaturity,
+      transferLockup
     } = network.names;
 
     const openPeriod = treeInterval + 1;
@@ -815,6 +816,20 @@ class NameState extends bio.Struct {
 
       stats.blocksUntilReopen = blocks;
       stats.hoursUntilReopen = Number(hours.toFixed(2));
+    }
+
+    // Add these details if name is in mid-transfer
+    if (this.transfer !== 0) {
+      const start = this.transfer;
+      const end = start + transferLockup;
+      const blocks = end - height;
+      const hours = ((blocks * spacing) / 60 / 60);
+
+      stats.transferLockupStart = start;
+      stats.transferLockupEnd = end;
+
+      stats.blocksUntilValidFinalize = blocks;
+      stats.hoursUntilValidFinalize = Number(hours.toFixed(2));
     }
 
     return stats;

--- a/test/auction-test.js
+++ b/test/auction-test.js
@@ -417,7 +417,9 @@ describe('Auction', function() {
       assert.ok(stats.blocksUntilValidFinalize);
       assert.ok(stats.hoursUntilValidFinalize);
 
+      // The height of the first block that can contain a valid FINALIZE
       transferLockupEnd = stats.transferLockupEnd;
+      // The number of blocks (inclusive) until that height will be reached
       blocksUntilValidFinalize = stats.blocksUntilValidFinalize;
     });
 
@@ -459,7 +461,7 @@ describe('Auction', function() {
       }
 
       assert.strictEqual(count, blocksUntilValidFinalize);
-      assert.strictEqual(transferLockupEnd, entry.height);
+      assert.strictEqual(entry.height, transferLockupEnd);
     });
 
     it('should cleanup', async () => {


### PR DESCRIPTION
Closes https://github.com/handshake-org/hsd/issues/178

example output:

```
$ hsd-rpc getnameinfo test-ds
{
  "start": {
    "reserved": false,
    "week": 28,
    "start": 56
  },
  "info": {
    "name": "test-ds",
    "nameHash": "c3243b05628fe67bde09bf7bf53752cd446fab5e0434d15c9d04c5db8dcb7ce4",
    "state": "CLOSED",
    "height": 211,
    "renewal": 235,
    "owner": {
      "hash": "5c8beb5651b28c05c10133771933e42fea09130c983ebd27715b414ba30db757",
      "index": 0
    },
    "value": 0,
    "highest": 0,
    "data": "0000e00b08022095a57c3bab7849dbcddf7c72ada71a88146b141110318ca5be672057e865c3e2",
    "transfer": 245,
    "revoked": 0,
    "claimed": 0,
    "renewals": 0,
    "registered": true,
    "expired": false,
    "weak": false,
    "stats": {
      "renewalPeriodStart": 235,
      "renewalPeriodEnd": 5235,
      "blocksUntilExpire": 4990,
      "daysUntilExpire": 34.65,
      "transferLockupStart": 245,
      "transferLockupEnd": 255,
      "blocksUntilValidFinalize": 10,
      "hoursUntilValidFinalize": 1.67
    }
  }
}
```