### PR TITLE
wallet: filter rpc getbids by unrevealed and return address

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,22 @@
 # HSD Release Notes & Changelog
 
 ## unreleased
-### RPC Changes
 
-- New methods:
+### Wallet changes
+
+- New RPC methods:
   - `signmessagewithname`: Like `signmessage` but uses a name instead of an address. The owner's address will be used to sign the message.
   - `verifymessagewithname`: Like `verifymessage` but uses a name instead of an address. The owner's address will be used to verify the message.
+
+- New wallet creation accepts parameter `language` to generate the mnemonic phrase.
+
+- `rpc getbids` accepts a third parameter `unrevealed` _(bool)_ which filters the response by checking
+the wallet's unspent coins database for each bid. If an unspent coin is found, the output address
+of that coin is added to the JSON response. This is useful for wallet recovery scenarios
+when users need to call `rpc importnonce` to repair unknown blinds. The complete usage is now
+`rpc getbids name (own) (unrevealed)` so for example a wallet-recovering user would execute
+`rpc getbids null true true`.
+
 ## v2.4.0
 
 ### Chain & Consensus changes

--- a/lib/wallet/rpc.js
+++ b/lib/wallet/rpc.js
@@ -1789,16 +1789,27 @@ class RPC extends RPCBase {
   }
 
   async getBids(args, help) {
-    if (help || args.length > 2)
-      throw new RPCError(errs.MISC_ERROR, 'getbids "name"  ( own )');
+    if (help || args.length > 3)
+      throw new RPCError(
+        errs.MISC_ERROR,
+        'getbids "name"  ( own ) ( unrevealed )'
+      );
 
     const wallet = this.wallet;
     const valid = new Validator(args);
     const name = valid.str(0);
     let own = valid.bool(1, false);
+    const unrevealed = valid.bool(2, false);
 
     if (name && !rules.verifyName(name))
       throw new RPCError(errs.TYPE_ERROR, 'Invalid name.');
+
+    if (unrevealed && !own) {
+      throw new RPCError(
+        errs.MISC_ERROR,
+        '"own" must be true if "unrevealed" is set.'
+      );
+    }
 
     if (!name)
       own = true;
@@ -1807,8 +1818,23 @@ class RPC extends RPCBase {
     const items = [];
 
     for (const bid of bids) {
-      if (!own || bid.own)
-        items.push(bid.toJSON());
+      if (!own || bid.own) {
+        const json = bid.toJSON();
+
+        if (unrevealed) {
+          const coin = await wallet.getCoin(
+            bid.prevout.hash,
+            bid.prevout.index
+          );
+          if (!coin) {
+            continue;
+          } else {
+            json.address = coin.address.toString(this.network);
+          }
+        }
+
+        items.push(json);
+      }
     }
 
     return items;

--- a/lib/wallet/rpc.js
+++ b/lib/wallet/rpc.js
@@ -1789,11 +1789,12 @@ class RPC extends RPCBase {
   }
 
   async getBids(args, help) {
-    if (help || args.length > 3)
+    if (help || args.length > 3) {
       throw new RPCError(
         errs.MISC_ERROR,
         'getbids "name"  ( own ) ( unrevealed )'
       );
+    }
 
     const wallet = this.wallet;
     const valid = new Validator(args);
@@ -1826,11 +1827,11 @@ class RPC extends RPCBase {
             bid.prevout.hash,
             bid.prevout.index
           );
-          if (!coin) {
+
+          if (!coin)
             continue;
-          } else {
-            json.address = coin.address.toString(this.network);
-          }
+
+          json.address = coin.address.toString(this.network);
         }
 
         items.push(json);

--- a/test/auction-rpc-test.js
+++ b/test/auction-rpc-test.js
@@ -145,6 +145,15 @@ describe('Auction RPCs', function() {
   const util = new TestUtil();
   const name = rules.grindName(2, 0, Network.get('regtest'));
   let winner, loser;
+  const winnerBid = {
+    bid: 5,
+    lockup: 10
+  };
+  const loserBid ={
+    bid: 4,
+    lockup: 10
+  };
+  const COIN = 1e6;
 
   const mineBlocks = async (num, wallet, account = 'default') => {
     const address = (await wallet.createAddress(account)).address;
@@ -220,16 +229,108 @@ describe('Auction RPCs', function() {
   it('should create BID with signing paths', async () => {
     // Create loser's BID.
     await util.wrpc('selectwallet', [loser.id]);
-    assert(await util.wrpc('sendbid', [name, 4, 10]));
+    assert(
+      await util.wrpc('sendbid', [name, loserBid.bid, loserBid.lockup])
+    );
 
     // Create, assert, submit and mine winner's BID.
     await util.wrpc('selectwallet', [winner.id]);
     const submit = true;
-    const json = await util.wrpc('createbid', [name, 5, 10]);
+    const json = await util.wrpc(
+      'createbid',
+      [name, winnerBid.bid, winnerBid.lockup]
+    );
     await processJSON(json, submit);
 
     // Mine past BID period.
     await mineBlocks(util.network.names.biddingPeriod, winner);
+  });
+
+  it('should get all BIDs for name', async () => {
+    // Loser gets all bids
+    await util.wrpc('selectwallet', [loser.id]);
+    const all = await util.wrpc('getbids', [name]);
+    assert.strictEqual(all.length, 2);
+    let own = 0;
+    let unown = 0;
+    for (const bid of all) {
+      // "unrevealed" not set.
+      assert(!bid.address);
+
+      if (bid.own)
+        own++;
+      else
+        unown++;
+    }
+    assert.strictEqual(own, 1);
+    assert.strictEqual(unown, 1);
+  });
+
+  it('should get only owned BIDs for name', async () => {
+    await util.wrpc('selectwallet', [loser.id]);
+    const bids = await util.wrpc('getbids', [name, true]);
+    assert.strictEqual(bids.length, 1);
+    let own = 0;
+    let unown = 0;
+    for (const bid of bids) {
+      // "unrevealed" not set.
+      assert(!bid.address);
+
+      if (bid.own)
+        own++;
+      else
+        unown++;
+    }
+    assert.strictEqual(own, 1);
+    assert.strictEqual(unown, 0);
+  });
+
+  it('should get unrevealed BIDs for name', async () => {
+    await util.wrpc('selectwallet', [loser.id]);
+    const bids = await util.wrpc('getbids', [name, true, true]);
+    assert.strictEqual(bids.length, 1);
+    let own = 0;
+    let unown = 0;
+    for (const bid of bids) {
+      // Unrevealed bids come with their address
+      assert(bid.address);
+
+      if (bid.own)
+        own++;
+      else
+        unown++;
+    }
+    assert.strictEqual(own, 1);
+    assert.strictEqual(unown, 0);
+  });
+
+  it('should have enough data to import nonce', async () => {
+    await util.wrpc('selectwallet', [loser.id]);
+    // Same as last test, getting "owned" and "unrevealed" BIDs only
+    const bids = await util.wrpc('getbids', [name, true, true]);
+    assert.strictEqual(bids.length, 1);
+
+    const bid = bids[0];
+    const bidName = bid.name;
+    const bidAddress = bid.address;
+    const bidValue = bid.value;
+    const bidLockup = bid.lockup;
+    const bidBlind = bid.blind;
+
+    assert.strictEqual(name, bidName);
+    assert.strictEqual(loserBid.bid  * COIN, bidValue);
+    assert.strictEqual(loserBid.lockup * COIN, bidLockup);
+
+    // In this case, "loser" already knows their blind value,
+    // but we can still check that importnonce works by returning
+    // that same value. Note that "loser" MUST remember their original
+    // bid value. If this were a wallet recovery scenario, that value
+    // would have to be entered by the user without data from the blockchain.
+    const importedBlind = await util.wrpc(
+      'importnonce',
+      [bidName, bidAddress, loserBid.bid]
+    );
+    assert.strictEqual(importedBlind, bidBlind);
   });
 
   it('should create REVEAL with signing paths', async () => {

--- a/test/auction-rpc-test.js
+++ b/test/auction-rpc-test.js
@@ -229,9 +229,7 @@ describe('Auction RPCs', function() {
   it('should create BID with signing paths', async () => {
     // Create loser's BID.
     await util.wrpc('selectwallet', [loser.id]);
-    assert(
-      await util.wrpc('sendbid', [name, loserBid.bid, loserBid.lockup])
-    );
+    assert(await util.wrpc('sendbid', [name, loserBid.bid, loserBid.lockup]));
 
     // Create, assert, submit and mine winner's BID.
     await util.wrpc('selectwallet', [winner.id]);
@@ -346,6 +344,15 @@ describe('Auction RPCs', function() {
 
     // Mine past REVEAL period.
     await mineBlocks(util.network.names.revealPeriod, winner);
+  });
+
+  it('should request only unrevealed BIDs for name and find none', async () => {
+    await util.wrpc('selectwallet', [loser.id]);
+    const owned = await util.wrpc('getbids', [name, true, false]);
+    const unrevealed = await util.wrpc('getbids', [name, true, true]);
+
+    assert.strictEqual(owned.length, 1);
+    assert.strictEqual(unrevealed.length, 0);
   });
 
   it('should create REDEEM with signing paths', async () => {


### PR DESCRIPTION
Sumamry (added to CHANGELOG):

`rpc getbids` accepts a third parameter `unrevealed` _(bool)_ which filters the response by checking
the wallet's unspent coins database for each bid. If an unspent coin is found, the output address
of that coin is added to the JSON response. This is useful for wallet recovery scenarios
when users need to call `rpc importnonce` to repair unknown blinds. The complete usage is now
`rpc getbids name (own) (unrevealed)` so for example a wallet-recovering user would execute
`rpc getbids null true true`.

## Examples of new usage:

### Get all bids for name
```
--> hsw-rpc getbids test-txt
[
  {
    "name": "test-txt",
    "nameHash": "e4dfb97162995a696714a84f3bd3f242b02f5f071c1c6670a24f5ae1e1235007",
    "prevout": {
      "hash": "735060373e19caf8500eb050c456004069cb1edeebc689ee36c1bb0f5a45cd1b",
      "index": 0
    },
    "value": 1000000,
    "lockup": 2000000,
    "blind": "d934d810a3f51e892fcd19d8db069eafa5705cb0ec1c29c7d36fe507b6ae3b12",
    "own": true
  },
  {
    "name": "test-txt",
    "nameHash": "e4dfb97162995a696714a84f3bd3f242b02f5f071c1c6670a24f5ae1e1235007",
    "prevout": {
      "hash": "f01521ea16a1a8c52bf9013ec6e197ced493cd4e819c3b582b1ecb09073725da",
      "index": 0
    },
    "lockup": 2000000,
    "blind": "92e0fc416b3e6ab49a1af55183ed85e02d37ab111f3feafe7175f4b6ecf43c49",
    "own": false
  }
]
```

### get only my own bids for a name
```
--> hsw-rpc getbids test-txt true
[
  {
    "name": "test-txt",
    "nameHash": "e4dfb97162995a696714a84f3bd3f242b02f5f071c1c6670a24f5ae1e1235007",
    "prevout": {
      "hash": "735060373e19caf8500eb050c456004069cb1edeebc689ee36c1bb0f5a45cd1b",
      "index": 0
    },
    "value": 1000000,
    "lockup": 2000000,
    "blind": "d934d810a3f51e892fcd19d8db069eafa5705cb0ec1c29c7d36fe507b6ae3b12",
    "own": true
  }
]
```

### get only my own unrevealed bids for a name
```
--> hsw-rpc getbids test-txt true true
[
  {
    "name": "test-txt",
    "nameHash": "e4dfb97162995a696714a84f3bd3f242b02f5f071c1c6670a24f5ae1e1235007",
    "prevout": {
      "hash": "735060373e19caf8500eb050c456004069cb1edeebc689ee36c1bb0f5a45cd1b",
      "index": 0
    },
    "value": 1000000,
    "lockup": 2000000,
    "blind": "d934d810a3f51e892fcd19d8db069eafa5705cb0ec1c29c7d36fe507b6ae3b12",
    "own": true,
    "address": "rs1qturhhrp68gr508an6ncq7nacm87h50yerr944h"
  }
]
```

## importnonce using unrevealed bids filter
(notice has an `address` value has appeared

```
--> hsw-rpc importnonce test-txt rs1qturhhrp68gr508an6ncq7nacm87h50yerr944h 1
d934d810a3f51e892fcd19d8db069eafa5705cb0ec1c29c7d36fe507b6ae3b12
```

Notice also that the nonce we just computed equals the nonce in the bid that we already knew
