### PR TITLE
namestate: improve "stats" object for transfers, expiry and revoke

### DIFF
--- a/lib/covenants/namestate.js
+++ b/lib/covenants/namestate.js
@@ -733,7 +733,8 @@ class NameState extends bio.Struct {
       revealPeriod,
       renewalWindow,
       auctionMaturity,
-      transferLockup
+      transferLockup,
+      claimPeriod
     } = network.names;
 
     const openPeriod = treeInterval + 1;
@@ -808,7 +809,9 @@ class NameState extends bio.Struct {
       }
       case states.CLOSED: {
         const start = this.renewal;
-        const end = start + renewalWindow;
+        const end = this.claimed ?
+          claimPeriod :
+          start + renewalWindow;
         const blocks = end - height;
         const days = ((blocks * spacing) / 60 / 60 / 24);
 
@@ -816,6 +819,7 @@ class NameState extends bio.Struct {
         stats.renewalPeriodEnd = end;
 
         stats.blocksUntilExpire = blocks;
+        assert(stats.blocksUntilExpire >= 0);
         stats.daysUntilExpire = Number(days.toFixed(2));
 
         // Add these details if name is in mid-transfer

--- a/lib/covenants/namestate.js
+++ b/lib/covenants/namestate.js
@@ -209,7 +209,7 @@ class NameState extends bio.Struct {
     if (this.isClaimable(height, network))
       return false;
 
-    // If we haven't been renewed in a year, start over.
+    // If we haven't been renewed in two years, start over.
     if (height >= this.renewal + network.names.renewalWindow)
       return true;
 
@@ -740,96 +740,117 @@ class NameState extends bio.Struct {
 
     const stats = {};
 
-    if (this.isOpening(height, network)) {
-      const start = this.height;
-      const end = this.height + openPeriod;
-      const blocks = end - height;
-      const hours = ((blocks * spacing) / 60 / 60);
+    let state = this.state(height, network);
 
-      stats.openPeriodStart = start;
-      stats.openPeriodEnd = end;
+    // Special case for a state that is not a state:
+    // EXPIRED but not revoked.
+    const EXPIRED = -1;
+    if (this.isExpired(height, network)) {
+      if (this.owner.isNull())
+        return null;
 
-      stats.blocksUntilBidding = blocks;
-      stats.hoursUntilBidding = Number(hours.toFixed(2));
+      if (state !== states.REVOKED)
+        state = EXPIRED;
     }
 
-    if (this.isLocked(height, network)) {
-      const start = this.height;
-      const end = this.height + lockupPeriod;
-      const blocks = end - height;
-      const hours = ((blocks * spacing) / 60 / 60);
+    switch (state) {
+      case states.OPENING: {
+        const start = this.height;
+        const end = this.height + openPeriod;
+        const blocks = end - height;
+        const hours = ((blocks * spacing) / 60 / 60);
 
-      stats.lockupPeriodStart = start;
-      stats.lockupPeriodEnd = end;
+        stats.openPeriodStart = start;
+        stats.openPeriodEnd = end;
 
-      stats.blocksUntilClosed = blocks;
-      stats.hoursUntilClosed = Number(hours.toFixed(2));
-    }
+        stats.blocksUntilBidding = blocks;
+        stats.hoursUntilBidding = Number(hours.toFixed(2));
+        break;
+      }
+      case states.LOCKED: {
+        const start = this.height;
+        const end = this.height + lockupPeriod;
+        const blocks = end - height;
+        const hours = ((blocks * spacing) / 60 / 60);
 
-    if (this.isBidding(height, network)) {
-      const start = this.height + openPeriod;
-      const end = start + biddingPeriod;
-      const blocks = end - height;
-      const hours = ((blocks * spacing) / 60 / 60);
+        stats.lockupPeriodStart = start;
+        stats.lockupPeriodEnd = end;
 
-      stats.bidPeriodStart = start;
-      stats.bidPeriodEnd = end;
+        stats.blocksUntilClosed = blocks;
+        stats.hoursUntilClosed = Number(hours.toFixed(2));
+        break;
+      }
+      case states.BIDDING: {
+        const start = this.height + openPeriod;
+        const end = start + biddingPeriod;
+        const blocks = end - height;
+        const hours = ((blocks * spacing) / 60 / 60);
 
-      stats.blocksUntilReveal = blocks;
-      stats.hoursUntilReveal = Number(hours.toFixed(2));
-    }
+        stats.bidPeriodStart = start;
+        stats.bidPeriodEnd = end;
 
-    if (this.isReveal(height, network)) {
-      const start = this.height + openPeriod + biddingPeriod;
-      const end = start + revealPeriod;
-      const blocks = end - height;
-      const hours = ((blocks * spacing) / 60 / 60);
+        stats.blocksUntilReveal = blocks;
+        stats.hoursUntilReveal = Number(hours.toFixed(2));
+        break;
+      }
+      case states.REVEAL: {
+        const start = this.height + openPeriod + biddingPeriod;
+        const end = start + revealPeriod;
+        const blocks = end - height;
+        const hours = ((blocks * spacing) / 60 / 60);
 
-      stats.revealPeriodStart = start;
-      stats.revealPeriodEnd = end;
+        stats.revealPeriodStart = start;
+        stats.revealPeriodEnd = end;
 
-      stats.blocksUntilClose = blocks;
-      stats.hoursUntilClose = Number(hours.toFixed(2));
-    }
+        stats.blocksUntilClose = blocks;
+        stats.hoursUntilClose = Number(hours.toFixed(2));
+        break;
+      }
+      case states.CLOSED: {
+        const start = this.renewal;
+        const end = start + renewalWindow;
+        const blocks = end - height;
+        const days = ((blocks * spacing) / 60 / 60 / 24);
 
-    if (this.isClosed(height, network)) {
-      const start = this.renewal;
-      const end = start + renewalWindow;
-      const blocks = end - height;
-      const days = ((blocks * spacing) / 60 / 60 / 24);
+        stats.renewalPeriodStart = start;
+        stats.renewalPeriodEnd = end;
 
-      stats.renewalPeriodStart = start;
-      stats.renewalPeriodEnd = end;
+        stats.blocksUntilExpire = blocks;
+        stats.daysUntilExpire = Number(days.toFixed(2));
 
-      stats.blocksUntilExpire = blocks;
-      stats.daysUntilExpire = Number(days.toFixed(2));
-    }
+        // Add these details if name is in mid-transfer
+        if (this.transfer !== 0) {
+          const start = this.transfer;
+          const end = start + transferLockup;
+          const blocks = end - height;
+          const hours = ((blocks * spacing) / 60 / 60);
 
-    if (this.isRevoked(height, network)) {
-      const start = this.revoked;
-      const end = start + auctionMaturity;
-      const blocks = end - height;
-      const hours = ((blocks * spacing) / 60 / 60);
+          stats.transferLockupStart = start;
+          stats.transferLockupEnd = end;
 
-      stats.revokePeriodStart = start;
-      stats.revokePeriodEnd = end;
+          stats.blocksUntilValidFinalize = blocks;
+          stats.hoursUntilValidFinalize = Number(hours.toFixed(2));
+        }
+        break;
+      }
+      case states.REVOKED: {
+        const start = this.revoked;
+        const end = start + auctionMaturity;
+        const blocks = end - height;
+        const hours = ((blocks * spacing) / 60 / 60);
 
-      stats.blocksUntilReopen = blocks;
-      stats.hoursUntilReopen = Number(hours.toFixed(2));
-    }
+        stats.revokePeriodStart = start;
+        stats.revokePeriodEnd = end;
 
-    // Add these details if name is in mid-transfer
-    if (this.transfer !== 0) {
-      const start = this.transfer;
-      const end = start + transferLockup;
-      const blocks = end - height;
-      const hours = ((blocks * spacing) / 60 / 60);
-
-      stats.transferLockupStart = start;
-      stats.transferLockupEnd = end;
-
-      stats.blocksUntilValidFinalize = blocks;
-      stats.hoursUntilValidFinalize = Number(hours.toFixed(2));
+        stats.blocksUntilReopen = blocks;
+        stats.hoursUntilReopen = Number(hours.toFixed(2));
+        break;
+      }
+      case EXPIRED: {
+        const expired = this.renewal + renewalWindow;
+        stats.blocksSinceExpired = height - expired;
+        break;
+      }
     }
 
     return stats;

--- a/lib/covenants/namestate.js
+++ b/lib/covenants/namestate.js
@@ -724,7 +724,8 @@ class NameState extends bio.Struct {
     assert((height >>> 0) === height);
     assert(network && network.names);
 
-    const spacing = network.pow.targetSpacing;
+    const {blocksPerDay} = network.pow;
+    const blocksPerHour = blocksPerDay / 24;
 
     const {
       treeInterval,
@@ -759,7 +760,7 @@ class NameState extends bio.Struct {
         const start = this.height;
         const end = this.height + openPeriod;
         const blocks = end - height;
-        const hours = ((blocks * spacing) / 60 / 60);
+        const hours = blocks / blocksPerHour;
 
         stats.openPeriodStart = start;
         stats.openPeriodEnd = end;
@@ -772,7 +773,7 @@ class NameState extends bio.Struct {
         const start = this.height;
         const end = this.height + lockupPeriod;
         const blocks = end - height;
-        const hours = ((blocks * spacing) / 60 / 60);
+        const hours = blocks / blocksPerHour;
 
         stats.lockupPeriodStart = start;
         stats.lockupPeriodEnd = end;
@@ -785,7 +786,7 @@ class NameState extends bio.Struct {
         const start = this.height + openPeriod;
         const end = start + biddingPeriod;
         const blocks = end - height;
-        const hours = ((blocks * spacing) / 60 / 60);
+        const hours = blocks / blocksPerHour;
 
         stats.bidPeriodStart = start;
         stats.bidPeriodEnd = end;
@@ -798,7 +799,7 @@ class NameState extends bio.Struct {
         const start = this.height + openPeriod + biddingPeriod;
         const end = start + revealPeriod;
         const blocks = end - height;
-        const hours = ((blocks * spacing) / 60 / 60);
+        const hours = blocks / blocksPerHour;
 
         stats.revealPeriodStart = start;
         stats.revealPeriodEnd = end;
@@ -809,11 +810,10 @@ class NameState extends bio.Struct {
       }
       case states.CLOSED: {
         const start = this.renewal;
-        const end = this.claimed ?
-          claimPeriod :
-          start + renewalWindow;
+        const normalEnd = start + renewalWindow;
+        const end = this.claimed ? Math.max(claimPeriod, normalEnd) : normalEnd;
         const blocks = end - height;
-        const days = ((blocks * spacing) / 60 / 60 / 24);
+        const days = blocks / blocksPerDay;
 
         stats.renewalPeriodStart = start;
         stats.renewalPeriodEnd = end;
@@ -827,7 +827,7 @@ class NameState extends bio.Struct {
           const start = this.transfer;
           const end = start + transferLockup;
           const blocks = end - height;
-          const hours = ((blocks * spacing) / 60 / 60);
+          const hours = blocks / blocksPerHour;
 
           stats.transferLockupStart = start;
           stats.transferLockupEnd = end;
@@ -841,7 +841,7 @@ class NameState extends bio.Struct {
         const start = this.revoked;
         const end = start + auctionMaturity;
         const blocks = end - height;
-        const hours = ((blocks * spacing) / 60 / 60);
+        const hours = blocks / blocksPerHour;
 
         stats.revokePeriodStart = start;
         stats.revokePeriodEnd = end;

--- a/test/namestate-test.js
+++ b/test/namestate-test.js
@@ -1,0 +1,323 @@
+/* eslint-env mocha */
+/* eslint prefer-arrow-callback: "off" */
+
+'use strict';
+
+const assert = require('bsert');
+const NameState = require('../lib/covenants/namestate');
+const rules = require('../lib/covenants/rules');
+const Network = require('../lib/protocol/network');
+
+const network = Network.get('regtest');
+
+const {
+  treeInterval,
+  biddingPeriod,
+  revealPeriod,
+  renewalWindow,
+  claimPeriod,
+  lockupPeriod
+} = network.names;
+
+describe('Namestate', function() {
+  describe('open auction name', function() {
+    const name = 'handshake';
+    const nameHash = rules.hashName(name);
+    let height = 0;
+
+    const ns = new NameState();
+    ns.nameHash = nameHash;
+    ns.set(Buffer.from(name, 'ascii'), height);
+
+    it('should be OPENING', () => {
+      while (height < treeInterval + 1) {
+        const json = ns.getJSON(height, network);
+
+        assert.strictEqual(json.state, 'OPENING');
+
+        const stats = Object.keys(json.stats);
+        assert.deepStrictEqual(
+          stats,
+          [
+            'openPeriodStart',
+            'openPeriodEnd',
+            'blocksUntilBidding',
+            'hoursUntilBidding'
+          ]
+        );
+        height++;
+      }
+    });
+
+    it('should be BIDDING', () => {
+      while (height < treeInterval + 1 + biddingPeriod) {
+        const json = ns.getJSON(height, network);
+
+        assert.strictEqual(json.state, 'BIDDING');
+
+        const stats = Object.keys(json.stats);
+        assert.deepStrictEqual(
+          stats,
+          [
+            'bidPeriodStart',
+            'bidPeriodEnd',
+            'blocksUntilReveal',
+            'hoursUntilReveal'
+          ]
+        );
+        height++;
+      }
+    });
+
+    it('should be REVEALING', () => {
+      while (height < treeInterval + 1 + biddingPeriod + revealPeriod) {
+        const json = ns.getJSON(height, network);
+
+        assert.strictEqual(json.state, 'REVEAL');
+
+        const stats = Object.keys(json.stats);
+        assert.deepStrictEqual(
+          stats,
+          [
+            'revealPeriodStart',
+            'revealPeriodEnd',
+            'blocksUntilClose',
+            'hoursUntilClose'
+          ]
+        );
+        height++;
+      }
+    });
+
+    it('should be CLOSED without owner', () => {
+      const json = ns.getJSON(height, network);
+
+      assert.strictEqual(json.state, 'CLOSED');
+      assert(json.stats === null);
+    });
+
+    it('should be CLOSED until expiration with owner', () => {
+      // Fork the timeline;
+      let heightWithOwner = height;
+
+      // Someone won the name
+      ns.owner.hash = Buffer.alloc(32, 0x01);
+      ns.owner.index = 0;
+
+      while (heightWithOwner < renewalWindow) {
+        const json = ns.getJSON(heightWithOwner, network);
+
+        assert.strictEqual(json.state, 'CLOSED');
+
+        const stats = Object.keys(json.stats);
+        assert.deepStrictEqual(
+          stats,
+          [
+            'renewalPeriodStart',
+            'renewalPeriodEnd',
+            'blocksUntilExpire',
+            'daysUntilExpire'
+          ]
+        );
+        heightWithOwner++;
+      }
+
+      // Expired without renewal
+      while (heightWithOwner < renewalWindow + 10) {
+        const json = ns.getJSON(heightWithOwner, network);
+
+        assert.strictEqual(json.state, 'CLOSED');
+
+        const stats = Object.keys(json.stats);
+        assert.deepStrictEqual(
+          stats,
+          [
+            'blocksSinceExpired'
+          ]
+        );
+        heightWithOwner++;
+      }
+    });
+
+    it('should be CLOSED with transfer statistics', () => {
+      // Fork the timeline;
+      let heightWithTransfer = height;
+
+      // Someone won the name
+      ns.owner.hash = Buffer.alloc(32, 0x01);
+      ns.owner.index = 0;
+
+      // Winner confirmed a TRANSFER
+      ns.transfer = heightWithTransfer;
+
+      while (heightWithTransfer < renewalWindow) {
+        const json = ns.getJSON(heightWithTransfer, network);
+
+        assert.strictEqual(json.state, 'CLOSED');
+
+        const stats = Object.keys(json.stats);
+        assert.deepStrictEqual(
+          stats,
+          [
+            'renewalPeriodStart',
+            'renewalPeriodEnd',
+            'blocksUntilExpire',
+            'daysUntilExpire',
+            'transferLockupStart',
+            'transferLockupEnd',
+            'blocksUntilValidFinalize',
+            'hoursUntilValidFinalize'
+          ]
+        );
+        heightWithTransfer++;
+      }
+
+      // Expired before FINALIZE (which resets everything)
+      while (heightWithTransfer < renewalWindow + 10) {
+        const json = ns.getJSON(heightWithTransfer, network);
+
+        assert.strictEqual(json.state, 'CLOSED');
+
+        const stats = Object.keys(json.stats);
+        assert.deepStrictEqual(
+          stats,
+          [
+            'blocksSinceExpired'
+          ]
+        );
+        heightWithTransfer++;
+      }
+    });
+
+    it('should be REVOKED', () => {
+      // Fork the timeline;
+      let heightWithRevoke = height;
+
+      // Someone won the name
+      ns.owner.hash = Buffer.alloc(32, 0x01);
+      ns.owner.index = 0;
+
+      // Winner confirmed a TRANSFER
+      ns.transfer = heightWithRevoke;
+
+      while (heightWithRevoke < height + 10) {
+        const json = ns.getJSON(heightWithRevoke, network);
+
+        assert.strictEqual(json.state, 'CLOSED');
+
+        const stats = Object.keys(json.stats);
+        assert.deepStrictEqual(
+          stats,
+          [
+            'renewalPeriodStart',
+            'renewalPeriodEnd',
+            'blocksUntilExpire',
+            'daysUntilExpire',
+            'transferLockupStart',
+            'transferLockupEnd',
+            'blocksUntilValidFinalize',
+            'hoursUntilValidFinalize'
+          ]
+        );
+        heightWithRevoke++;
+      }
+
+      // Winner REVOKEd before FINALIZE
+      ns.transfer = 0;
+      ns.revoked = heightWithRevoke;
+      const revokedHeight = heightWithRevoke;
+
+      // Revoked stats remain until re-opened
+      while (heightWithRevoke < revokedHeight + renewalWindow) {
+        const json = ns.getJSON(heightWithRevoke, network);
+
+        assert.strictEqual(json.state, 'REVOKED');
+
+        const stats = Object.keys(json.stats);
+        assert.deepStrictEqual(
+          stats,
+          [
+            'revokePeriodStart',
+            'revokePeriodEnd',
+            'blocksUntilReopen',
+            'hoursUntilReopen'
+          ]
+        );
+        heightWithRevoke++;
+      }
+    });
+  });
+
+  describe('reserved name', function() {
+    const name = 'handshake';
+    const nameHash = rules.hashName(name);
+    let height = 1; // ns.claimed can not be 0
+
+    const ns = new NameState();
+    ns.nameHash = nameHash;
+    ns.set(Buffer.from(name, 'ascii'), height);
+    // Someone claimed the name
+    ns.owner.hash = Buffer.alloc(32, 0x01);
+    ns.owner.index = 0;
+    ns.claimed = height;
+
+    it('should be LOCKED', () => {
+      while (height - 1 < lockupPeriod) {
+        const json = ns.getJSON(height, network);
+
+        assert.strictEqual(json.state, 'LOCKED');
+
+        const stats = Object.keys(json.stats);
+        assert.deepStrictEqual(
+          stats,
+          [
+            'lockupPeriodStart',
+            'lockupPeriodEnd',
+            'blocksUntilClosed',
+            'hoursUntilClosed'
+          ]
+        );
+        height++;
+      }
+    });
+
+    it('should be CLOSED until claim period ends', () => {
+      // Fork the timeline;
+      let heightWithOwner = height;
+
+      while (heightWithOwner < claimPeriod) {
+        const json = ns.getJSON(heightWithOwner, network);
+
+        assert.strictEqual(json.state, 'CLOSED');
+
+        const stats = Object.keys(json.stats);
+        assert.deepStrictEqual(
+          stats,
+          [
+            'renewalPeriodStart',
+            'renewalPeriodEnd',
+            'blocksUntilExpire',
+            'daysUntilExpire'
+          ]
+        );
+        heightWithOwner++;
+      }
+
+      // Expired without renewal
+      while (heightWithOwner < claimPeriod + 10) {
+        const json = ns.getJSON(heightWithOwner, network);
+
+        assert.strictEqual(json.state, 'CLOSED');
+
+        const stats = Object.keys(json.stats);
+        assert.deepStrictEqual(
+          stats,
+          [
+            'blocksSinceExpired'
+          ]
+        );
+        heightWithOwner++;
+      }
+    });
+  });
+});

--- a/test/namestate-test.js
+++ b/test/namestate-test.js
@@ -175,6 +175,7 @@ describe('Namestate', function() {
               'hoursUntilValidFinalize'
             ]
           );
+
           heightWithTransfer++;
         }
 


### PR DESCRIPTION
Adds an expired state to the "stats" object, refactors the `toStats()` method in namestate.js.

```
    "stats": {
      "blocksSinceExpired": 21
    }
```