### PR TITLE
Make Root nameserver more flexible for plugins

### DIFF
--- a/lib/dns/server.js
+++ b/lib/dns/server.js
@@ -51,17 +51,6 @@ const TYPE_MAP = Buffer.from('000722000000000380', 'hex');
 const RES_OPT = { inet6: false, tcp: true };
 const CACHE_TTL = 30 * 60 * 1000;
 
-const blacklist = new Set([
-  'bit', // Namecoin
-  'eth', // ENS
-  'exit', // Tor
-  'gnu', // GNUnet (GNS)
-  'i2p', // Invisible Internet Project
-  'onion', // Tor
-  'tor', // OnioNS
-  'zkey' // GNS
-]);
-
 /**
  * RootCache
  */
@@ -121,6 +110,19 @@ class RootServer extends DNSServer {
     this.port = 5300;
     this.lookup = null;
     this.publicHost = '127.0.0.1';
+
+    // Plugins can add or remove items from
+    // this set before the server is opened.
+    this.blacklist = new Set([
+      'bit', // Namecoin
+      'eth', // ENS
+      'exit', // Tor
+      'gnu', // GNUnet (GNS)
+      'i2p', // Invisible Internet Project
+      'onion', // Tor
+      'tor', // OnioNS
+      'zkey' // GNS
+    ]);
 
     this.cache = new RootCache(3000);
 
@@ -321,7 +323,7 @@ class RootServer extends DNSServer {
     }
 
     // Ask the urkel tree for the name data.
-    const data = !blacklist.has(tld)
+    const data = !this.blacklist.has(tld)
       ? (await this.lookupName(tld))
       : null;
 

--- a/lib/dns/server.js
+++ b/lib/dns/server.js
@@ -109,6 +109,7 @@ class RootServer extends DNSServer {
     this.host = '127.0.0.1';
     this.port = 5300;
     this.lookup = null;
+    this.middle = null;
     this.publicHost = '127.0.0.1';
 
     // Plugins can add or remove items from
@@ -397,6 +398,27 @@ class RootServer extends DNSServer {
     const {name, type} = qs;
     const tld = util.from(name, -1);
 
+    // Plugins can insert middleware here and hijack the
+    // lookup for special TLDs before checking Urkel tree.
+    // We also pass the entire question in case a plugin
+    // is able to return an authoritative (non-referral) answer.
+    if (typeof this.middle === 'function') {
+      let res;
+      try {
+        res = await this.middle(tld, req);
+      } catch (e) {
+        this.logger.warning(
+          'Root server middleware resolution failed for name: %s',
+          name
+        );
+        this.logger.debug(e.stack);
+      }
+
+      if (res) {
+        return res;
+      }
+    }
+
     // Hit the cache first.
     const cache = this.cache.get(name, type);
 
@@ -419,6 +441,11 @@ class RootServer extends DNSServer {
 
   getReserved(tld) {
     return reserved.getByName(tld);
+  }
+
+  // Intended to be called by plugin.
+  signRRSet(rrset, type) {
+    key.signZSK(rrset, type);
   }
 
   resetCache() {

--- a/lib/dns/server.js
+++ b/lib/dns/server.js
@@ -329,7 +329,7 @@ class RootServer extends DNSServer {
 
     // Non-existent domain.
     if (!data) {
-      const item = reserved.getByName(tld);
+      const item = this.getReserved(tld);
 
       // This name is in the existing root zone.
       // Fall back to ICANN's servers if not yet
@@ -415,6 +415,10 @@ class RootServer extends DNSServer {
     await super.open(this.port, this.host);
 
     this.logger.info('Root nameserver listening on port %d.', this.port);
+  }
+
+  getReserved(tld) {
+    return reserved.getByName(tld);
   }
 
   resetCache() {

--- a/lib/node/node.js
+++ b/lib/node/node.js
@@ -342,6 +342,8 @@ class Node extends EventEmitter {
         case 'pool':
         case 'rpc':
         case 'http':
+        case 'ns':
+        case 'rs':
           assert(false, `${plugin.id} is already added.`);
           break;
       }
@@ -401,6 +403,12 @@ class Node extends EventEmitter {
       case 'http':
         assert(this.http, 'http is not loaded.');
         return this.http;
+      case 'rs':
+        assert(this.rs, 'rs is not loaded.');
+        return this.rs;
+      case 'ns':
+        assert(this.ns, 'ns is not loaded.');
+        return this.ns;
     }
 
     return this.plugins[name] || null;

--- a/test/ns-test.js
+++ b/test/ns-test.js
@@ -175,3 +175,95 @@ describe('RootServer Blacklist', function() {
     assert.strictEqual(res.answer.length, 0);
   });
 });
+
+describe('RootServer Plugins', function() {
+  const ns = new RootServer({
+    port: 25349, // regtest
+    lookup: (hash) => {
+      // Normally an Urkel Tree goes here.
+      // Blacklisted names should never get this far.
+      if (hash.equals(rules.hashName('bit')))
+        throw new Error('Blacklisted name!');
+
+      // For this test all other names have the same record
+      const namestate = new NameState();
+      namestate.data = Resource.fromJSON({
+        records: [
+          {
+            type: 'NS',
+            ns: 'ns1.handshake.'
+          }
+        ]
+      }).encode();
+      return namestate.encode();
+    }
+  });
+
+  before(async () => {
+    // Plugin inserts middleware before server is opened
+    ns.middle = (tld, req) => {
+      const [qs] = req.question;
+      const name = qs.name.toLowerCase();
+      const type = qs.type;
+
+      if (tld === 'bit.') {
+        // This plugin runs an imaginary Namecoin full node.
+        // It looks up records and returns an authoritative answer.
+        // This makes it look like the complete record including
+        // the subdomain is in the HNS root zone.
+        const res = new wire.Message();
+        res.aa = true;
+
+        // This plugin only returns A records,
+        // and all Namecoin names have the same IP address.
+        if (type !== wire.types.A)
+          return null;
+
+        const rr = new wire.Record();
+        const rd = new wire.ARecord();
+        rr.name = name;
+        rr.type = wire.types.A;
+        rr.ttl = 518400;
+        rr.data = rd;
+        rd.address = '4.8.15.16';
+
+        res.answer.push(rr);
+        ns.signRRSet(res.answer, wire.types.A);
+
+        return res;
+      }
+
+      // Plugin doesn't care about this name
+      return null;
+    };
+
+    await ns.open();
+  });
+
+  after(async () => {
+    await ns.close();
+  });
+
+  it('should hijack lookup for blacklisted name', async () => {
+    const name = 'decentralize.bit.';
+    const req = {
+      question: [{
+        name,
+        type: wire.types.A
+      }]
+    };
+
+    const res = await ns.resolve(req);
+    assert.strictEqual(res.authority.length, 0);
+    assert.strictEqual(res.answer.length, 2);
+
+    const rec = res.answer[0];
+    assert.strictEqual(rec.name, name);
+    assert.strictEqual(rec.type, wire.types.A);
+    assert.strictEqual(rec.data.address, '4.8.15.16');
+
+    const sig = res.answer[1];
+    assert.strictEqual(sig.name, name);
+    assert.strictEqual(sig.type, wire.types.RRSIG);
+  });
+});


### PR DESCRIPTION
Closes #541

TODO: Include example plugins to close...
- [x] dns/server: blacklist rfc2606 domains in the resolver #544
- [x] Handshake TLDs .0 and .1 ... .255 confusion with IPv4 Namespace #455
- [x] Blacklist should include homographs of ICANN TLDs #255
- [x] On Resolving Alternative DNS Systems #208
