### PR TITLE
wallet: save and recover undo data from critical namestate transitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## unreleased
 
+### Wallet changes
+
+- Fixes a bug that caused rescans to fail if a name being "watched" was ever
+`TRANSFER`ed. A `deepclean` plus `rescan` may be required to fix affected wallets.
+
 ### Wallet API changes
 
 - Adds new wallet HTTP endpoint `/wallet/:id/auction` based on `POST /wallet/:id/bid`.

--- a/lib/primitives/address.js
+++ b/lib/primitives/address.js
@@ -542,8 +542,6 @@ class Address extends bio.Struct {
       throw new Error('Object is not an address.');
 
     if (Buffer.isBuffer(data)) {
-      if (data.length !== 20 && data.length !== 32)
-        throw new Error('Object is not an address.');
       return data;
     }
 

--- a/lib/wallet/txdb.js
+++ b/lib/wallet/txdb.js
@@ -1029,19 +1029,14 @@ class TXDB {
     }
 
     // Handle names.
-    if (block) {
-      const {updated, index} = await this.connectNames(b, tx, view, height);
+    if (block && !await this.bucket.has(layout.U.encode(hash))) {
+      const updated = await this.connectNames(b, tx, view, height);
 
       if (updated && !state.updated()) {
-        if (index) {
-          // TRANSFER, FINALIZE, and REVOKE transactions must be indexed
-          // so we can undo them in event of reorg or rescan.
-          await this.addBlockMap(b, height);
-          await this.addBlock(b, tx.hash(), block);
-        }
-
         // Always save namestate transitions,
         // even if they don't affect wallet balance
+        await this.addBlockMap(b, height);
+        await this.addBlock(b, tx.hash(), block);
         await b.write();
       }
     }
@@ -1490,11 +1485,17 @@ class TXDB {
         'Reverting namestate without transaction: %x',
         hash
       );
+
       const b = this.bucket.batch();
-      await this.applyNameUndo(b, hash);
-      await this.removeBlockMap(b, height);
-      await this.removeBlock(b, hash, height);
-      return b.write();
+
+      if (await this.applyNameUndo(b, hash)) {
+        await this.removeBlockMap(b, height);
+        await this.removeBlock(b, hash, height);
+
+        return b.write();
+      }
+
+      return null;
     }
 
     if (wtx.height === -1)
@@ -1882,16 +1883,6 @@ class TXDB {
     // If namestate has been updated we need to write to DB
     let updated = false;
 
-    // If namestate has been updated with a critical property
-    // we need to not only save the new namestate but also
-    // index the transaction (whether or not it affects our balance)
-    // so that we can rollback the change during reorg or rescan.
-    // Critical properties are anything that are asserted by this
-    // function the _next_ time we see this transaction:
-    //   TRANSFER / FINALIZE: ns.transfer
-    //   REVOKE: ns.revoked
-    let index = false;
-
     for (let i = 0; i < tx.outputs.length; i++) {
       const output = tx.outputs[i];
       const {covenant} = output;
@@ -2110,7 +2101,6 @@ class TXDB {
           ns.setTransfer(height);
 
           updated = true;
-          index = true;
 
           break;
         }
@@ -2148,7 +2138,6 @@ class TXDB {
           ns.setRenewals(ns.renewals + 1);
 
           updated = true;
-          index = true;
 
           break;
         }
@@ -2163,7 +2152,6 @@ class TXDB {
           ns.setData(null);
 
           updated = true;
-          index = true;
 
           break;
         }
@@ -2184,11 +2172,17 @@ class TXDB {
     if (updated) {
       const undo = view.toNameUndo();
 
-      if (undo.names.length > 0)
-        b.put(layout.U.encode(hash), undo.encode());
+      // Always write the undo record as it
+      // serves as a marker to determine whether
+      // we have a processed a transaction's
+      // covenants before. This function is
+      // probably better served by its own
+      // special record, but that would require
+      // a data migration.
+      b.put(layout.U.encode(hash), undo.encode());
     }
 
-    return {updated, index};
+    return updated;
   }
 
   /**
@@ -2240,7 +2234,7 @@ class TXDB {
     const raw = await this.bucket.get(layout.U.encode(hash));
 
     if (!raw)
-      return;
+      return false;
 
     const undo = NameUndo.decode(raw);
     const view = new CoinView();
@@ -2259,6 +2253,8 @@ class TXDB {
     }
 
     b.del(layout.U.encode(hash));
+
+    return true;
   }
 
   /**

--- a/lib/wallet/txdb.js
+++ b/lib/wallet/txdb.js
@@ -1481,7 +1481,7 @@ class TXDB {
     const wtx = await this.getTX(hash);
 
     if (!wtx) {
-      this.logger.warning(
+      this.logger.spam(
         'Reverting namestate without transaction: %x',
         hash
       );

--- a/lib/wallet/txdb.js
+++ b/lib/wallet/txdb.js
@@ -1030,10 +1030,20 @@ class TXDB {
 
     // Handle names.
     if (block) {
-      const updated = await this.connectNames(b, tx, view, height);
+      const {updated, index} = await this.connectNames(b, tx, view, height);
 
-      if (updated && !state.updated())
+      if (updated && !state.updated()) {
+        if (index) {
+          // TRANSFER, FINALIZE, and REVOKE transactions must be indexed
+          // so we can undo them in event of reorg or rescan.
+          await this.addBlockMap(b, height);
+          await this.addBlock(b, tx.hash(), block);
+        }
+
+        // Always save namestate transitions,
+        // even if they don't affect wallet balance
         await b.write();
+      }
     }
 
     // If this didn't update any coins,
@@ -1474,8 +1484,15 @@ class TXDB {
   async unconfirm(hash) {
     const wtx = await this.getTX(hash);
 
-    if (!wtx)
-      return null;
+    if (!wtx) {
+      this.logger.warning(
+        'Reverting namestate without transaction: %x',
+        hash
+      );
+      const b = this.bucket.batch();
+      await this.applyNameUndo(b, hash);
+      return b.write();
+    }
 
     if (wtx.height === -1)
       return null;
@@ -1848,6 +1865,7 @@ class TXDB {
    * @param {Number} i
    * @param {Path} path
    * @param {Number} height
+   * @returns {Object}
    */
 
   async connectNames(b, tx, view, height) {
@@ -1856,7 +1874,18 @@ class TXDB {
 
     assert(height !== -1);
 
+    // If namestate has been updated we need to write to DB
     let updated = false;
+
+    // If namestate has been updated with a critical property
+    // we need to not only save the new namestate but also
+    // index the transaction (whether or not it affects our balance)
+    // so that we can rollback the change during reorg or rescan.
+    // Critical properties are anything that are asserted by this
+    // function the _next_ time we see this transaction:
+    //   TRANSFER / FINALIZE: ns.transfer
+    //   REVOKE: ns.revoked
+    let index = false;
 
     for (let i = 0; i < tx.outputs.length; i++) {
       const output = tx.outputs[i];
@@ -2076,6 +2105,7 @@ class TXDB {
           ns.setTransfer(height);
 
           updated = true;
+          index = true;
 
           break;
         }
@@ -2113,6 +2143,7 @@ class TXDB {
           ns.setRenewals(ns.renewals + 1);
 
           updated = true;
+          index = true;
 
           break;
         }
@@ -2127,6 +2158,7 @@ class TXDB {
           ns.setData(null);
 
           updated = true;
+          index = true;
 
           break;
         }
@@ -2151,7 +2183,7 @@ class TXDB {
         b.put(layout.U.encode(hash), undo.encode());
     }
 
-    return updated;
+    return {updated, index};
   }
 
   /**
@@ -2187,6 +2219,19 @@ class TXDB {
       }
     }
 
+    return this.applyNameUndo(b, hash);
+  }
+
+  /**
+   * Apply namestate undo data by hash without transaction.
+   * Should only be called directly to undo namestate transitions
+   * that do not affect wallet balance like a TRANSFER for a name
+   * that is in the nameMap but does not involve wallet addresses.
+   * @param {Object} b
+   * @param {Hash} hash
+   */
+
+  async applyNameUndo(b, hash) {
     const raw = await this.bucket.get(layout.U.encode(hash));
 
     if (!raw)

--- a/lib/wallet/txdb.js
+++ b/lib/wallet/txdb.js
@@ -1468,7 +1468,7 @@ class TXDB {
 
     for (let i = hashes.length - 1; i >= 0; i--) {
       const hash = hashes[i];
-      await this.unconfirm(hash);
+      await this.unconfirm(hash, height);
     }
 
     return hashes.length;
@@ -1478,10 +1478,11 @@ class TXDB {
    * Unconfirm a transaction without a batch.
    * @private
    * @param {Hash} hash
+   * @param {Number} height
    * @returns {Promise}
    */
 
-  async unconfirm(hash) {
+  async unconfirm(hash, height) {
     const wtx = await this.getTX(hash);
 
     if (!wtx) {
@@ -1491,6 +1492,8 @@ class TXDB {
       );
       const b = this.bucket.batch();
       await this.applyNameUndo(b, hash);
+      await this.removeBlockMap(b, height);
+      await this.removeBlock(b, hash, height);
       return b.write();
     }
 

--- a/lib/wallet/txdb.js
+++ b/lib/wallet/txdb.js
@@ -1865,7 +1865,9 @@ class TXDB {
    * @param {Number} i
    * @param {Path} path
    * @param {Number} height
-   * @returns {Object}
+   * @returns {Object} out
+   * @returns {Boolean} out.updated
+   * @returns {Boolean} out.index
    */
 
   async connectNames(b, tx, view, height) {

--- a/test/wallet-rescan-test.js
+++ b/test/wallet-rescan-test.js
@@ -1,0 +1,335 @@
+/* eslint-env mocha */
+/* eslint prefer-arrow-callback: "off" */
+/* eslint no-implicit-coercion: "off" */
+
+'use strict';
+
+const assert = require('bsert');
+const FullNode = require('../lib/node/fullnode');
+const MemWallet = require('./util/memwallet');
+const Network = require('../lib/protocol/network');
+const Address = require('../lib/primitives/address');
+const rules = require('../lib/covenants/rules');
+const {Resource} = require('../lib/dns/resource');
+const {forValue} = require('./util/common');
+
+const network = Network.get('regtest');
+
+const {
+  treeInterval,
+  biddingPeriod,
+  revealPeriod
+} = network.names;
+
+describe('Wallet Rescan with TRANSFER', function() {
+  describe('Only sends OPEN', function() {
+    // Bob runs a full node with wallet plugin
+    const node = new FullNode({
+      network: network.type,
+      memory: true,
+      plugins: [require('../lib/wallet/plugin')]
+    });
+    node.on('error', (err) => {
+      assert(false, err);
+    });
+
+    const {wdb} = node.require('walletdb');
+    let bob, bobAddr;
+
+    // Alice is some other wallet on the network
+    const alice = new MemWallet({ network });
+    const aliceAddr = alice.getAddress();
+
+    // Connect MemWallet to chain as minimally as possible
+    node.chain.on('connect', (entry, block) => {
+      alice.addBlock(entry, block.txs);
+    });
+    alice.getNameStatus = async (nameHash) => {
+      assert(Buffer.isBuffer(nameHash));
+      const height = node.chain.height + 1;
+      const state = await node.chain.getNextState();
+      const hardened = state.hasHardening();
+      return node.chain.db.getNameStatus(nameHash, height, hardened);
+    };
+
+    const NAME = rules.grindName(4, 4, network);
+
+    async function mineBlocks(n, addr) {
+      addr = addr ? addr : new Address().toString('regtest');
+      const blocks = [];
+      for (let i = 0; i < n; i++) {
+        const block = await node.miner.mineBlock(null, addr);
+        await node.chain.add(block);
+        blocks.push(block);
+      }
+
+      return blocks;
+    }
+    before(async () => {
+      await node.open();
+      bob = await wdb.create();
+      bobAddr = await bob.receiveAddress();
+    });
+
+    after(async () => {
+      await node.close();
+    });
+
+    it('should fund wallets', async () => {
+      const blocks = 10;
+      await mineBlocks(blocks, aliceAddr);
+      await mineBlocks(blocks, bobAddr);
+
+      const bobBal  = await bob.getBalance();
+      assert.strictEqual(bobBal.confirmed, blocks * 2000 * 1e6);
+      assert.strictEqual(alice.balance, blocks * 2000 * 1e6);
+    });
+
+    it('should run auction', async () => {
+      // Poor Bob, all he does is send an OPEN but his wallet will
+      // watch all the other activity including TRANSFERS for this name
+      await bob.sendOpen(NAME, true);
+      const openBlocks = await mineBlocks(1);
+      // Coinbase plus open
+      assert.strictEqual(openBlocks[0].txs.length, 2);
+
+      // Advance to bidding phase
+      await mineBlocks(treeInterval);
+      await forValue(alice, 'height', node.chain.height);
+
+      // Alice sends only bid
+      const aliceBid = await alice.createBid(NAME, 20000, 20000);
+      await node.mempool.addTX(aliceBid.toTX());
+      const bidBlocks = await mineBlocks(1);
+      assert.strictEqual(bidBlocks[0].txs.length, 2);
+
+      // Advance to reveal phase
+      await mineBlocks(biddingPeriod);
+      const aliceReveal = await alice.createReveal(NAME);
+      await node.mempool.addTX(aliceReveal.toTX());
+      const revealBlocks = await mineBlocks(1);
+      assert.strictEqual(revealBlocks[0].txs.length, 2);
+
+      // Close auction
+      await mineBlocks(revealPeriod);
+
+      // Alice registers
+      const aliceRegister = await alice.createRegister(
+        NAME,
+        Resource.fromJSON({records:[]})
+      );
+      await node.mempool.addTX(aliceRegister.toTX());
+
+      const registerBlocks = await mineBlocks(1);
+      assert.strictEqual(registerBlocks[0].txs.length, 2);
+    });
+
+    it('should get namestate', async () => {
+      const ns = await bob.getNameStateByName(NAME);
+      // Bob has the namestate
+      assert(ns);
+
+      // Bob is not the name owner
+      const {hash, index} = ns.owner;
+      const coin = await bob.getCoin(hash, index);
+      assert.strictEqual(coin, null);
+
+      // Name is not in mid-TRANSFER
+      assert.strictEqual(ns.transfer, 0);
+    });
+
+    it('should process TRANSFER', async () => {
+      // Alice transfers the name to her own address
+      const aliceTransfer = await alice.createTransfer(NAME, aliceAddr);
+      await node.mempool.addTX(aliceTransfer.toTX());
+      const transferBlocks = await mineBlocks(1);
+      assert.strictEqual(transferBlocks[0].txs.length, 2);
+
+      // Bob detects the TRANSFER even though it doesn't involve him at all
+      const ns = await bob.getNameStateByName(NAME);
+      assert(ns);
+      assert.strictEqual(ns.transfer, node.chain.height);
+
+      // Bob's wallet has indexed the TRANSFER
+      const bobTransfer = await bob.getTX(aliceTransfer.hash());
+      assert.strictEqual(bobTransfer, null);
+    });
+
+    it('should fully rescan', async () => {
+      // Complete chain rescan
+      await wdb.rescan(0);
+      await forValue(wdb, 'height', node.chain.height);
+
+      // No change
+      const ns = await bob.getNameStateByName(NAME);
+      assert(ns);
+      assert.strictEqual(ns.transfer, node.chain.height);
+    });
+  });
+
+  describe('Bids, loses, shallow rescan', function() {
+    // Bob runs a full node with wallet plugin
+    const node = new FullNode({
+      network: network.type,
+      memory: true,
+      plugins: [require('../lib/wallet/plugin')]
+    });
+    node.on('error', (err) => {
+      assert(false, err);
+    });
+
+    const {wdb} = node.require('walletdb');
+    let bob, bobAddr;
+
+    // Alice is some other wallet on the network
+    const alice = new MemWallet({ network });
+    const aliceAddr = alice.getAddress();
+
+    // Connect MemWallet to chain as minimally as possible
+    node.chain.on('connect', (entry, block) => {
+      alice.addBlock(entry, block.txs);
+    });
+    alice.getNameStatus = async (nameHash) => {
+      assert(Buffer.isBuffer(nameHash));
+      const height = node.chain.height + 1;
+      const state = await node.chain.getNextState();
+      const hardened = state.hasHardening();
+      return node.chain.db.getNameStatus(nameHash, height, hardened);
+    };
+
+    const NAME = rules.grindName(4, 4, network);
+
+    // Block that confirmed the bids
+    let bidBlockHash;
+
+    async function mineBlocks(n, addr) {
+      addr = addr ? addr : new Address().toString('regtest');
+      const blocks = [];
+      for (let i = 0; i < n; i++) {
+        const block = await node.miner.mineBlock(null, addr);
+        await node.chain.add(block);
+        blocks.push(block);
+      }
+
+      return blocks;
+    }
+
+    before(async () => {
+      await node.open();
+      bob = await wdb.create();
+      bobAddr = await bob.receiveAddress();
+    });
+
+    after(async () => {
+      await node.close();
+    });
+
+    it('should fund wallets', async () => {
+      const blocks = 10;
+      await mineBlocks(blocks, aliceAddr);
+      await mineBlocks(blocks, bobAddr);
+
+      const bobBal  = await bob.getBalance();
+      assert.strictEqual(bobBal.confirmed, blocks * 2000 * 1e6);
+      assert.strictEqual(alice.balance, blocks * 2000 * 1e6);
+    });
+
+    it('should run auction', async () => {
+      // Alice opens
+      const aliceOpen = await alice.createOpen(NAME);
+      await node.mempool.addTX(aliceOpen.toTX());
+      const openBlocks = await mineBlocks(1);
+      // Coinbase plus open
+      assert.strictEqual(openBlocks[0].txs.length, 2);
+
+      // Advance to bidding phase
+      await mineBlocks(treeInterval);
+      await forValue(alice, 'height', node.chain.height);
+
+      // Poor Bob, all he does is send one (losing) bid but his wallet will
+      // watch all the other activity including TRANSFERS for this name
+      await bob.sendBid(NAME, 10000, 10000);
+
+      // Alice sends winning bid
+      const aliceBid = await alice.createBid(NAME, 20000, 20000);
+      await node.mempool.addTX(aliceBid.toTX());
+      const bidBlocks = await mineBlocks(1);
+      assert.strictEqual(bidBlocks[0].txs.length, 3);
+
+      bidBlockHash = bidBlocks[0].hash();
+
+      // Advance to reveal phase
+      await mineBlocks(biddingPeriod);
+      await bob.sendReveal(NAME);
+      const aliceReveal = await alice.createReveal(NAME);
+      await node.mempool.addTX(aliceReveal.toTX());
+      const revealBlocks = await mineBlocks(1);
+      assert.strictEqual(revealBlocks[0].txs.length, 3);
+
+      // Close auction
+      await mineBlocks(revealPeriod);
+
+      // Alice registers
+      const aliceRegister = await alice.createRegister(
+        NAME,
+        Resource.fromJSON({records:[]})
+      );
+      await node.mempool.addTX(aliceRegister.toTX());
+
+      const registerBlocks = await mineBlocks(1);
+      assert.strictEqual(registerBlocks[0].txs.length, 2);
+    });
+
+    it('should get namestate', async () => {
+      const ns = await bob.getNameStateByName(NAME);
+      // Bob has the namestate
+      assert(ns);
+
+      // Bob is not the name owner
+      const {hash, index} = ns.owner;
+      const coin = await bob.getCoin(hash, index);
+      assert.strictEqual(coin, null);
+
+      // Name is not in mid-TRANSFER
+      assert.strictEqual(ns.transfer, 0);
+    });
+
+    it('should process TRANSFER', async () => {
+      // Alice transfers the name to her own address
+      const aliceTransfer = await alice.createTransfer(NAME, aliceAddr);
+      await node.mempool.addTX(aliceTransfer.toTX());
+      const transferBlocks = await mineBlocks(1);
+      assert.strictEqual(transferBlocks[0].txs.length, 2);
+
+      // Bob detects the TRANSFER even though it doesn't involve him at all
+      const ns = await bob.getNameStateByName(NAME);
+      assert(ns);
+      assert.strictEqual(ns.transfer, node.chain.height);
+
+      // Bob's wallet has indexed the TRANSFER
+      const bobTransfer = await bob.getTX(aliceTransfer.hash());
+      assert.strictEqual(bobTransfer, null);
+    });
+
+    it('should fully rescan', async () => {
+      await wdb.rescan(0);
+      await forValue(wdb, 'height', node.chain.height);
+
+      // No change
+      const ns = await bob.getNameStateByName(NAME);
+      assert(ns);
+      assert.strictEqual(ns.transfer, node.chain.height);
+    });
+
+    it('should rescan since, but not including, the BIDs', async () => {
+      const bidBlock = await node.chain.getEntry(bidBlockHash);
+      await wdb.rescan(bidBlock.height);
+      await forValue(wdb, 'height', node.chain.height);
+
+      // No change
+      const ns = await bob.getNameStateByName(NAME);
+      assert(ns);
+      assert.strictEqual(ns.transfer, node.chain.height);
+    });
+  });
+});


### PR DESCRIPTION
Closes https://github.com/handshake-org/hsd/issues/510

This PR fixes a wallet issue that throws an assertion error during a rescan in a shockingly simple scenario:

- Alice OPENs a name. It doesn't matter if she bids or not
- Bob wins the name
- Bob sends a TRANSFER for the name. It doesn't matter if it's ever FINALIZEd or what address the TRANSFER commits to
- Alice rescans --> `assertion error  at TXDB.connectNames`

## Background

There are other related scenarios where Alice doesn't send the OPEN but does bid, and still loses. The crux of the issue has to do with UNDO DATA. Blockchain is generally designed to be append-only and therefore only move forwards. However there are scenarios in which the chain is rewound: a reorganization or a wallet rescan. In these scenarios, the software depends on UNDO data, which are essentially snapshots of state just before a transition happens. To move backwards, the undo data is retrieved and applied. Essentially for every new block and every wallet transaction, a "negative" is stored in the database and used to reverse whatever state update the action caused initially.

The Handshake wallet is a mysterious beast because a lot of its state depends on the actions of OTHER USERS, like tracking bids and determining who won an auction. Bids and Reveals are stored in special buckets in the database so that they can be reverted even if they don't actually directly affect the wallet's _balance_.

TRANSFER, FINALIZE, and REVOKE transactions up until now are _not_ stored in special buckets in the database. In fact, they are not stored at all unless they directly affect the wallet's balance. That's what this PR changes. We still don't need to store the entire TX but we do need to store the UNDO data, and we need to remember to retrieve it if one of the above "rewind" scenarios is triggered.

With all this background I can now explain the bug at the lowest level: When the wallet rescans, it starts by reverting / undoing / unconfirming all the transactions in every block from chain tip backwards to the rescan target (provided as an argument by the user, default `0` aka genesis block). Before this PR, the wallet DID NOT revert transactions like TRANSFERs unless they involved the wallet directly. Because of this, when the wallet rescans the chain it encounters the TRANSFER a second time, but throws an error because it thinks the name is still in a transfer state (`ns.transfer !== 0`)


## To test / fix your own wallet

If you've encountered this bug, you can test this PR by attempting to fix your own wallet:

```sh
# enter hsd repo
cd /path/to/hsd

# download this branch
git remote add pinheadmz https://github.com/pinheadmz/hsd
git fetch pinheadmz
git checkout rescantransfer1

# stop hsd (or killall hsd)
hsd-rpc stop

# back up your wallet
cp -r ~/.hsd/wallet ~/.hsd/wallet-backup-for-rescantransfer1

# restart hsd
hsd

# deep clean the wallet and rescan, may require API key
curl 127.0.0.1:12039/deepclean -X POST --data '{"I_HAVE_BACKED_UP_MY_WALLET":true}'
hsw-cli rescan 0

# watch wallet height and wait until it is fully synced (check height in JSON result)
hsw-rpc getwalletinfo

# rescan a second time
hsw-cli rescan 0

# check
hsw-rpc getwalletinfo
hsw-cli balance
```

## Bonus

Because this PR is urgent and likely to get merged and released quickly, I attached a rider ;-)

I cherry picked https://github.com/handshake-org/hsd/pull/499/commits/4b75f8aa8e45d325f8b7b6501767ff98fceebda9 from https://github.com/handshake-org/hsd/pull/499 which bypasses a too-strict length requirement in `Address` length. (see also https://github.com/bcoin-org/bcoin/issues/989) Without this fix,  assertion errors are still thrown during rescan for wallets (like mine) that have ever sent to a nulldata address. I had to add this bug fix to test this PR against my own wallet.

## TODO

Just by eyeballing the code, I assume that this bug will have the same effect if Bob (see above) sends a FINALIZE or REVOKE -- because these covenant types update namestate properties that are also `assert()`'ed in txdb. So this PR was written to also catch those types but I still need to add explicit tests

- [x] ~Add tests for FINALIZE and REVOKE~ 5013fffa06067bb646f3188a79490acbb3f5746b


## 💰 PR REVIEW BOUNTY: 💰

10 HNS: add a comment to the PR with an original meme expressing how tired we are all of all the damn wallet bugs
100 HNS: add a comment with a screen shot proving you pulled the branch and ran the test locally: `npm run test-file test/wallet-rescan-test.js`
1000 HNS: add a comment that actually influnces me to change the pull request in some way. if its just a typo/ nit ill send you..... oh i dunno 200 HNS



