### PR TITLE
dns: fix root zone dnssec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## unreleased
 
+### DNS changes
+
+- Root server DNSSEC has been fixed. It is only authoritative over DS and TXT records,
+and only returns TXT if no NS (referral) is present in the zone.
+
 ### Wallet API changes
 
 - Adds new wallet HTTP endpoint `/wallet/:id/auction` based on `POST /wallet/:id/bid`.

--- a/lib/dns/resource.js
+++ b/lib/dns/resource.js
@@ -322,9 +322,6 @@ class Resource extends Struct {
         res.authority = this.toNS(name);
         res.additional = this.toGlue(name);
         break;
-      case types.TXT:
-        res.answer = this.toTXT(name);
-        break;
       case types.DS:
         res.aa = true;
         res.answer = this.toDS(name);

--- a/lib/dns/resource.js
+++ b/lib/dns/resource.js
@@ -285,10 +285,12 @@ class Resource extends Struct {
       res.additional = this.toGlue(name);
 
       // Note: should have nsec unsigned zone proof.
-      if (!this.hasDS())
-        key.signZSK(res.authority, types.NS);
-      else
+      if (this.hasDS()) {
+        // DS records are the only record type
+        // the root zone is actually authoritative over.
+        res.aa = true;
         key.signZSK(res.authority, types.DS);
+      }
     } else {
       // Needs SOA.
     }
@@ -311,17 +313,20 @@ class Resource extends Struct {
     // Potentially an answer.
     const res = new Message();
 
+    // TLDs are authoritative over their own NS & TXT records.
+    // The NS records in the root zone are just "hints"
+    // and therefore are not signed by the root ZSK.
+    // The only records root is authoritative over is DS.
     switch (type) {
       case types.NS:
         res.authority = this.toNS(name);
         res.additional = this.toGlue(name);
-        key.signZSK(res.authority, types.NS);
         break;
       case types.TXT:
         res.answer = this.toTXT(name);
-        key.signZSK(res.answer, types.TXT);
         break;
       case types.DS:
+        res.aa = true;
         res.answer = this.toDS(name);
         key.signZSK(res.answer, types.DS);
         break;
@@ -332,9 +337,6 @@ class Resource extends Struct {
         && res.authority.length === 0) {
       return this.toReferral(name);
     }
-
-    // We're authoritative for the answer.
-    res.aa = res.answer.length !== 0;
 
     return res;
   }

--- a/lib/dns/resource.js
+++ b/lib/dns/resource.js
@@ -322,6 +322,13 @@ class Resource extends Struct {
         res.authority = this.toNS(name);
         res.additional = this.toGlue(name);
         break;
+      case types.TXT:
+        if (!this.hasNS()) {
+          res.aa = true;
+          res.answer = this.toTXT(name);
+          key.signZSK(res.answer, types.TXT);
+        }
+        break;
       case types.DS:
         res.aa = true;
         res.answer = this.toDS(name);

--- a/lib/dns/server.js
+++ b/lib/dns/server.js
@@ -339,6 +339,7 @@ class RootServer extends DNSServer {
 
         if (res.ad && res.code !== codes.NXDOMAIN) {
           res.ad = false;
+          res.aa = true;
           res.question = [qs];
           key.signZSK(res.authority, types.DS);
           key.signZSK(res.authority, types.NSEC);
@@ -381,6 +382,7 @@ class RootServer extends DNSServer {
 
     if (res.answer.length === 0
         && res.authority.length === 0) {
+      res.aa = true;
       res.authority.push(this.toSOA());
       key.signZSK(res.authority, types.SOA);
     }

--- a/test/resource-test.js
+++ b/test/resource-test.js
@@ -106,21 +106,35 @@ describe('Resource', function() {
     assert.strictEqual(synthAAAA.data.address, '::2');
   });
 
-  it('should synthesize an answer', () => {
+  it('should not return TXT from root zone', () => {
     const res = Resource.fromJSON(json);
     const msg = res.toDNS('hns.', types.TXT);
 
     assert(msg.aa);
+    assert(msg.answer.length === 0);
+  });
+
+  it('should synthesize an answer', () => {
+    const res = Resource.fromJSON(json);
+    const msg = res.toDNS('hns.', types.DS);
+
+    assert(msg.aa);
     assert(msg.answer.length === 2);
 
-    const [txt, sig] = msg.answer;
+    const [ds, sig] = msg.answer;
 
-    assert.strictEqual(txt.type, types.TXT);
-    assert.strictEqual(txt.name, 'hns.');
+    assert.strictEqual(ds.type, types.DS);
+    assert.strictEqual(ds.name, 'hns.');
     assert.strictEqual(sig.type, types.RRSIG);
     assert.strictEqual(sig.name, 'hns.');
 
-    assert.strictEqual(txt.data.txt.length, 1);
-    assert.strictEqual(txt.data.txt[0], 'hello world');
+    assert.strictEqual(ds.data.keyTag, 57355);
+    assert.bufferEqual(
+      ds.data.digest,
+      Buffer.from(
+        '95a57c3bab7849dbcddf7c72ada71a88146b141110318ca5be672057e865c3e2',
+        'hex'
+      )
+    );
   });
 });


### PR DESCRIPTION
Closes https://github.com/handshake-org/hsd/issues/565

Based on https://github.com/james-stevens/hsd/commit/18cdabc43d79f88617e52aa56b18239e73a10709

TODO:
- [x] ~Maybe also stop serving TXT (https://github.com/handshake-org/hsd/issues/565)~ (06cf026817dee74c47b2abfb7088afc88f6ead1d)

Changes:
- Root always signs DS, never signs NS, and only signs TXT _if NS is not present_
- Root always sets `aa` (authority) bit for DS, never for NS, and for TXT only _if NS is not present_
- Root doesn't answer a query for TXT if NS is present (sends referral instead)
- Root sets authority bit for NXDOMAIN 