### PR TITLE
wallet: --check-lookahead to update old wallets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,12 @@ The bid will be broadcasted either during the creation (`broadcastBid=true`) or 
 (`broadcastBid=false`).
 The reveal will have to be broadcasted at a later time, during the REVEAL phase.
 The lockup must include a blind big enough to ensure the BID will be the only input of the REVEAL
-transaction. 
+transaction.
+
+- Now parses option `--wallet-check-lookahead` (or `--check-lookahead` for standalone
+wallet node) that will check every account of every wallet in the DB and ensure
+the lookahead value is the current default and maximum of `200`. A rescan is
+recommended after this action.
 
 ### Node & Wallet API changes
 

--- a/lib/wallet/node.js
+++ b/lib/wallet/node.js
@@ -51,7 +51,8 @@ class WalletNode extends Node {
       cacheSize: this.config.mb('cache-size'),
       wipeNoReally: this.config.bool('wipe-no-really'),
       spv: this.config.bool('spv'),
-      migrate: this.config.uint('migrate')
+      migrate: this.config.uint('migrate'),
+      checkLookahead: this.config.bool('check-lookahead', false)
     });
 
     this.rpc = new RPC(this);

--- a/lib/wallet/plugin.js
+++ b/lib/wallet/plugin.js
@@ -52,7 +52,8 @@ class Plugin extends EventEmitter {
       cacheSize: this.config.mb('cache-size'),
       wipeNoReally: this.config.bool('wipe-no-really'),
       spv: node.spv,
-      migrate: this.config.uint('migrate')
+      migrate: this.config.uint('migrate'),
+      checkLookahead: this.config.bool('check-lookahead', false)
     });
 
     this.rpc = new RPC(this);

--- a/lib/wallet/walletdb.js
+++ b/lib/wallet/walletdb.js
@@ -208,6 +208,8 @@ class WalletDB extends EventEmitter {
     this.primary = wallet;
 
     await this.migrateChange();
+
+    await this.checkLookahead();
   }
 
   /**
@@ -267,6 +269,40 @@ class WalletDB extends EventEmitter {
       );
     }
   }
+
+  /**
+   * Update account lookahead & depth
+   * @returns {Promise}
+   */
+
+   async checkLookahead() {
+    if (!this.options.checkLookahead)
+      return;
+
+    const b = this.db.batch();
+
+    const wids = await this.db.keys({
+      gte: layout.W.min(),
+      lte: layout.W.max(),
+      parse: key => layout.W.decode(key)[0]
+    });
+
+    for (const wid of wids) {
+      const wallet = await this.get(wid);
+
+      for (let i = 0; i < wallet.accountDepth; i++) {
+        this.logger.warning(
+          'Setting lookahead for wallet %s account %d',
+          wallet.id,
+          i
+        );
+        const account = await wallet.getAccount(i);
+        await account.setLookahead(b, Account.MAX_LOOKAHEAD);
+      }
+    }
+
+    await b.write();
+   }
 
   /**
    * Verify network.
@@ -2479,6 +2515,7 @@ class WalletOptions {
     this.spv = false;
     this.wipeNoReally = false;
     this.migrate = null;
+    this.checkLookahead = false;
 
     if (options)
       this.fromOptions(options);
@@ -2559,6 +2596,11 @@ class WalletOptions {
     if (options.migrate != null) {
       assert((options.migrate >>> 0) === options.migrate);
       this.migrate = options.migrate;
+    }
+
+    if (options.checkLookahead != null) {
+      assert(typeof options.checkLookahead === 'boolean');
+      this.checkLookahead = options.checkLookahead;
     }
 
     return this;


### PR DESCRIPTION
Closes https://github.com/handshake-org/hsd/issues/563

This probably should have been included in https://github.com/handshake-org/hsd/pull/506

This PR adds an extra wallet option to upgrade wallets created before #506 was merged, that still have a lookahead of `10`. When the option is set, all accounts of all wallets are called with `Account.setLookahead(Account.MAX_LOOKAHEAD
)` which is now `200`. This will set the metadata lookahead value, generate whatever keys/addresses are necessary and write to the database. This only needs to be run once per walletDB, since the update is permanent.

Usage:

`hsd --wallet-check-lookahead`

Log messages:

```
[warning] (wallet) Setting lookahead for wallet primary account 0
[warning] (wallet) Setting lookahead for wallet ten account 0
```

Can be verified by this bash test script: https://gist.github.com/pinheadmz/029bb4ff773b548cf632a5c300e4c17b

output:

```
HEAD is now at 7ca1b71ff v2.1.0
79552

hsd v2.1.0 - initialize
wallet lookahead:
10
wallet getaddressesbyaccount length:
22

Stopping.
Previous HEAD position was 7ca1b71ff v2.1.0
Switched to branch 'synclookahead1'
79564

hsd v2.3.0 #synclookahead1 - open old wallet
wallet lookahead:
10
wallet getaddressesbyaccount length:
22

Stopping.
79575

hsd v2.3.0 #synclookahead1 - check lookahead option set
wallet lookahead:
200
wallet getaddressesbyaccount length:
402

Stopping.
79585

hsd v2.3.0 #synclookahead1 - no extra option set
wallet lookahead:
200
wallet getaddressesbyaccount length:
402
```