### PR TITLE
Build docs to gh-pages

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,19 @@
+name: Docs
+on:
+  release:
+    types: [published]
+jobs:
+  docs:
+    name: Build docs
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - run: |
+        npm install -g jsdoc
+        jsdoc -c jsdoc.json
+    - name: Deploy
+      uses: peaceiris/actions-gh-pages@v3
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        publish_dir: ./docs/reference

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -9,6 +9,9 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+    - uses: actions/setup-node@v1
+      with:
+          node-version: 12.x
     - run: |
         npm install -g jsdoc
         jsdoc -c jsdoc.json


### PR DESCRIPTION
This is similar to the work done for https://hsd-dev.org/ in handshake-org/handshake-org.github.io/issues/102.

If this PR is merged, each release of hsd will update https://hsd-dev.org/hsd (not existing right now).
Next, we need to update `/docs` => `/hsd`

https://github.com/handshake-org/handshake-org.github.io/blob/a60e4b1b60334bcd38b215ebfcb3a50ae634e970/src/templates/layout.html#L44