### PR TITLE
dns: make request info available to plugins

### DIFF
--- a/lib/dns/server.js
+++ b/lib/dns/server.js
@@ -405,7 +405,7 @@ class RootServer extends DNSServer {
     if (typeof this.middle === 'function') {
       let res;
       try {
-        res = await this.middle(tld, req);
+        res = await this.middle(tld, req, rinfo);
       } catch (e) {
         this.logger.warning(
           'Root server middleware resolution failed for name: %s',


### PR DESCRIPTION
Making the request info available to plugins can be very useful. For example, to do access control based on IP address (bind has this feature). Also, Implementing some advanced features in DNS that requires knowing the protocol, port and IP address like the [HSD AXFR plugin](https://github.com/buffrr/hsd-axfr) which needs rinfo to send multiple dns messages over TCP. 
