### PR TITLE
added check for admin permissions on wallet create

### DIFF
--- a/lib/wallet/http.js
+++ b/lib/wallet/http.js
@@ -278,6 +278,11 @@ class HTTP extends Server {
 
     // Create wallet
     this.put('/wallet/:id', async (req, res) => {
+      if (!req.admin) {
+        res.json(403);
+        return;
+      }
+
       const valid = Validator.fromRequest(req);
 
       let master = valid.str('master');


### PR DESCRIPTION
Previously admin token was not required for wallet creation, yet in documentation it was stated. During the update of hints it was discovered: https://github.com/handshake-org/hs-client/pull/35#discussion_r598968378