### PR TITLE
Major fixes & improvements for getwork

### DIFF
--- a/lib/blockchain/chain.js
+++ b/lib/blockchain/chain.js
@@ -3223,7 +3223,7 @@ class Chain extends AsyncEmitter {
       const state = await this.getState(prev, deployment);
 
       if (state === thresholdStates.LOCKED_IN
-          || state === thresholdStates.STARTED) {
+          || (state === thresholdStates.STARTED && deployment.force)) {
         version |= 1 << deployment.bit;
       }
     }

--- a/lib/mining/template.js
+++ b/lib/mining/template.js
@@ -362,29 +362,6 @@ class BlockTemplate {
   }
 
   /**
-   * Generate a random mask (2 bytes less than target).
-   * @returns {Buffer[]}
-   */
-
-  randomMask() {
-    const mask = random.randomBytes(32);
-
-    for (let i = 0; i < this.target.length; i++) {
-      mask[i] = 0;
-
-      if (this.target[i] !== 0) {
-        if (i + 1 < mask.length)
-          mask[i + 1] = 0;
-        break;
-      }
-    }
-
-    const hash = BLAKE2b.multi(this.prevBlock, mask);
-
-    return [mask, hash];
-  }
-
-  /**
    * Create raw block header with given parameters.
    * @param {Buffer} extraNonce
    * @param {Number} time
@@ -468,7 +445,7 @@ class BlockTemplate {
    */
 
   toCoinbase() {
-    return this.coinbase;
+    return this.coinbase.clone();
   }
 
   /**

--- a/lib/node/rpc.js
+++ b/lib/node/rpc.js
@@ -116,6 +116,7 @@ class RPC extends RPCBase {
     this.boundChain = false;
     this.mask = Buffer.alloc(32, 0x00);
     this.merkleMap = new BufferMap();
+    this.merkleList = [];
     this.pollers = [];
 
     this.init();
@@ -2568,10 +2569,11 @@ class RPC extends RPCBase {
 
       this.refreshBlock();
       this.merkleMap.clear();
+      this.merkleList.length = 0;
     };
 
     this.node.on('connect', refresh);
-    this.node.on('disconnect', refresh);
+    this.node.on('reset', refresh);
 
     if (!this.mempool)
       return;
@@ -2610,16 +2612,6 @@ class RPC extends RPCBase {
 
     let attempt = this.attempt;
 
-    // This check is here to make sure a miner does not
-    // accidentally OOM the node. This means the merkle
-    // map is good for 2 hours without a block.
-    if (this.merkleMap.size >= 720) {
-      this.merkleMap.clear();
-
-      if (attempt)
-        this.merkleMap.set(attempt.witnessRoot, attempt);
-    }
-
     if (attempt) {
       if (attempt.address.isNull()) {
         throw new RPCError(errs.MISC_ERROR,
@@ -2638,9 +2630,13 @@ class RPC extends RPCBase {
 
     attempt = await this.miner.createBlock();
 
+    if (this.merkleMap.size >= 10)
+      this.merkleMap.delete(this.merkleList.shift());
+
     this.attempt = attempt;
     this.lastActivity = util.now();
     this.merkleMap.set(attempt.witnessRoot, attempt);
+    this.merkleList.push(attempt.witnessRoot);
 
     return attempt;
   }

--- a/lib/node/rpc.js
+++ b/lib/node/rpc.js
@@ -115,7 +115,7 @@ class RPC extends RPCBase {
     this.lastActivity = 0;
     this.boundChain = false;
     this.mask = Buffer.alloc(32, 0x00);
-    this.maskMap = new BufferMap();
+    this.merkleMap = new BufferMap();
     this.pollers = [];
 
     this.init();
@@ -1127,35 +1127,34 @@ class RPC extends RPCBase {
    * Mining
    */
 
-  async handleWork(data) {
+  async handleWork(data, mask) {
     const unlock = await this.locker.lock();
     try {
-      return await this._handleWork(data);
+      return await this._handleWork(data, mask);
     } finally {
       unlock();
     }
   }
 
-  async _handleWork(data) {
-    const attempt = this.attempt;
-
-    if (!attempt)
-      return [false, 'no-mining-job'];
-
+  async _handleWork(data, mask) {
     if (data.length !== 256)
       return [false, 'invalid-data-length'];
 
     const hdr = Headers.fromMiner(data);
+    const maskHash = blake2b.multi(hdr.prevBlock, mask);
+
+    if (!hdr.maskHash().equals(maskHash))
+      return [false, 'bad-maskhash'];
+
+    const attempt = this.merkleMap.get(hdr.witnessRoot);
+
+    if (!attempt)
+      return [false, 'stale'];
 
     if (!hdr.prevBlock.equals(attempt.prevBlock)
         || hdr.bits !== attempt.bits) {
       return [false, 'stale'];
     }
-
-    const mask = this.maskMap.get(hdr.maskHash());
-
-    if (!mask)
-      return [false, 'stale'];
 
     const {nonce, time, extraNonce} = hdr;
     const proof = attempt.getProof(nonce, time, extraNonce, mask);
@@ -1186,19 +1185,21 @@ class RPC extends RPCBase {
     return [true, 'valid'];
   }
 
-  async createWork(data) {
+  async createWork() {
     const unlock = await this.locker.lock();
     try {
-      return await this._createWork(data);
+      return await this._createWork();
     } finally {
       unlock();
     }
   }
 
   async _createWork() {
-    const [mask, attempt] = await this.updateWork();
+    const attempt = await this.updateWork();
     const time = attempt.time;
-    const data = attempt.getHeader(0, time, consensus.ZERO_NONCE, mask);
+    const nonce = consensus.ZERO_NONCE;
+    const mask = consensus.ZERO_HASH;
+    const data = attempt.getHeader(0, time, nonce, mask);
 
     return {
       network: this.network.type,
@@ -1215,26 +1216,15 @@ class RPC extends RPCBase {
   }
 
   async getWork(args, help) {
-    if (help || args.length > 1)
-      throw new RPCError(errs.MISC_ERROR, 'getwork ( "maskhash" )');
-
-    if (args.length === 1) {
-      const valid = new Validator(args);
-      const maskHash = valid.bhash(0);
-
-      if (!maskHash)
-        throw new RPCError(errs.TYPE_ERROR, 'Invalid mask hash.');
-
-      if (this.maskMap.has(maskHash))
-        return null;
-    }
+    if (help || args.length !== 0)
+      throw new RPCError(errs.MISC_ERROR, 'getwork');
 
     return this.createWork();
   }
 
   async submitWork(args, help) {
-    if (help || args.length !== 1)
-      throw new RPCError(errs.MISC_ERROR, 'submitwork ( "data" )');
+    if (help || args.length < 1 || args.length > 2)
+      throw new RPCError(errs.MISC_ERROR, 'submitwork ( "data" "mask" )');
 
     const valid = new Validator(args);
     const data = valid.buf(0);
@@ -1242,7 +1232,16 @@ class RPC extends RPCBase {
     if (!data)
       throw new RPCError(errs.TYPE_ERROR, 'Invalid work data.');
 
-    return this.handleWork(data);
+    let mask = consensus.ZERO_HASH;
+
+    if (args.length === 2) {
+      mask = valid.bhash(1);
+
+      if (!mask)
+        throw new RPCError(errs.TYPE_ERROR, 'Invalid mask.');
+    }
+
+    return this.handleWork(data, mask);
   }
 
   async submitBlock(args, help) {
@@ -1488,9 +1487,11 @@ class RPC extends RPCBase {
       vbrequired: 0,
       height: attempt.height,
       previousblockhash: attempt.prevBlock.toString('hex'),
+      merkleroot: undefined,
+      witnessroot: undefined,
       treeroot: attempt.treeRoot.toString('hex'),
       reservedroot: attempt.reservedRoot.toString('hex'),
-      mask: attempt.randomMask()[0].toString('hex'),
+      mask: consensus.ZERO_HASH.toString('hex'), // Compat.
       target: attempt.target.toString('hex'),
       bits: hex32(attempt.bits),
       noncerange:
@@ -1544,14 +1545,10 @@ class RPC extends RPCBase {
     // The client wants a coinbasetxn
     // instead of a coinbasevalue.
     if (coinbase) {
-      const tx = attempt.toCoinbase();
-      const input = tx.inputs[0];
+      const tx = attempt.coinbase;
 
-      // Pop off the nonces.
-      input.witness.pop();
-      input.witness.compile();
-
-      tx.refresh();
+      json.merkleroot = attempt.merkleRoot.toString('hex');
+      json.witnessroot = attempt.witnessRoot.toString('hex');
 
       json.coinbasetxn = {
         data: tx.toHex(),
@@ -2565,7 +2562,6 @@ class RPC extends RPCBase {
 
     this.attempt = null;
     this.lastActivity = 0;
-    this.maskMap.clear();
     this.pollers = [];
 
     for (const job of pollers)
@@ -2578,31 +2574,31 @@ class RPC extends RPCBase {
 
     this.boundChain = true;
 
-    this.node.on('connect', () => {
+    const refresh = () => {
       if (!this.attempt)
         return;
 
       this.refreshBlock();
-    });
+      this.merkleMap.clear();
+    };
+
+    this.node.on('connect', refresh);
+    this.node.on('disconnect', refresh);
 
     if (!this.mempool)
       return;
 
-    this.node.on('tx', () => {
+    const tryRefresh = () => {
       if (!this.attempt)
         return;
 
       if (util.now() - this.lastActivity > 10)
         this.refreshBlock();
-    });
+    };
 
-    this.node.on('claim', () => {
-      if (!this.attempt)
-        return;
-
-      if (util.now() - this.lastActivity > 10)
-        this.refreshBlock();
-    });
+    this.node.on('tx', tryRefresh);
+    this.node.on('claim', tryRefresh);
+    this.node.on('airdrop', tryRefresh);
   }
 
   async getTemplate() {
@@ -2626,6 +2622,16 @@ class RPC extends RPCBase {
 
     let attempt = this.attempt;
 
+    // This check is here to make sure a miner does not
+    // accidentally OOM the node. This means the merkle
+    // map is good for 2 hours without a block.
+    if (this.merkleMap.size >= 720) {
+      this.merkleMap.clear();
+
+      if (attempt)
+        this.merkleMap.set(attempt.witnessRoot, attempt);
+    }
+
     if (attempt) {
       if (attempt.address.isNull()) {
         throw new RPCError(errs.MISC_ERROR,
@@ -2634,11 +2640,7 @@ class RPC extends RPCBase {
 
       this.miner.updateTime(attempt);
 
-      const [mask, maskHash] = attempt.randomMask();
-
-      this.maskMap.set(maskHash, mask);
-
-      return [mask, attempt];
+      return attempt;
     }
 
     if (this.miner.addresses.length === 0) {
@@ -2647,15 +2649,12 @@ class RPC extends RPCBase {
     }
 
     attempt = await this.miner.createBlock();
-    attempt.version = 0;
-
-    const [mask, maskHash] = attempt.randomMask();
 
     this.attempt = attempt;
     this.lastActivity = util.now();
-    this.maskMap.set(maskHash, mask);
+    this.merkleMap.set(attempt.witnessRoot, attempt);
 
-    return [mask, attempt];
+    return attempt;
   }
 
   async addBlock(block) {

--- a/lib/node/rpc.js
+++ b/lib/node/rpc.js
@@ -1322,16 +1322,6 @@ class RPC extends RPCBase {
         }
       }
 
-      // BIP22 states that we can't have coinbasetxn
-      // _and_ coinbasevalue in the same template.
-      // The problem is, many clients _say_ they
-      // support coinbasetxn when they don't (ckpool).
-      // To make matters worse, some clients will
-      // parse an undefined `coinbasevalue` as zero.
-      // Because of all of this, coinbasetxn is
-      // disabled for now.
-      valueCap = true;
-
       if (txnCap && !valueCap) {
         if (this.miner.addresses.length === 0) {
           throw new RPCError(errs.MISC_ERROR,
@@ -1510,7 +1500,7 @@ class RPC extends RPCBase {
       coinbaseaux: {
         flags: attempt.coinbaseFlags.toString('hex')
       },
-      coinbasevalue: undefined,
+      coinbasevalue: attempt.getReward(),
       coinbasetxn: undefined,
       claims: attempt.claims.map((claim) => {
         return {
@@ -1559,8 +1549,6 @@ class RPC extends RPCBase {
         sigops: tx.getSigops() / scale | 0,
         weight: tx.getWeight()
       };
-    } else {
-      json.coinbasevalue = attempt.getReward();
     }
 
     return json;

--- a/test/getwork-test.js
+++ b/test/getwork-test.js
@@ -1,0 +1,196 @@
+/* eslint-env mocha */
+/* eslint prefer-arrow-callback: "off" */
+
+'use strict';
+
+const assert = require('bsert');
+const bio = require('bufio');
+const mine = require('../lib/mining/mine');
+const FullNode = require('../lib/node/fullnode');
+const Headers = require('../lib/primitives/headers');
+const consensus = require('../lib/protocol/consensus');
+
+const node = new FullNode({
+  memory: true,
+  apiKey: 'foo',
+  network: 'regtest',
+  bip37: true,
+  workers: true,
+  plugins: [require('../lib/wallet/plugin')]
+});
+
+const {chain, miner, rpc} = node;
+const {wdb} = node.require('walletdb');
+
+let wallet = null;
+
+describe('Getwork', function() {
+  this.timeout(45000);
+
+  it('should open chain and miner', async () => {
+    await node.open();
+  });
+
+  it('should open walletdb', async () => {
+    wallet = await wdb.create();
+    miner.addresses.length = 0;
+    miner.addAddress(await wallet.receiveAddress());
+  });
+
+  it('should mine 10 blocks', async () => {
+    for (let i = 0; i < 10; i++) {
+      const block = await miner.mineBlock();
+      assert(block);
+      await chain.add(block);
+    }
+
+    await new Promise(r => setTimeout(r, 1000));
+  });
+
+  it('should get and submit work', async () => {
+    const json = await rpc.getWork([]);
+    const data = Buffer.from(json.data, 'hex');
+    const target = Buffer.from(json.target, 'hex');
+    const [nonce, result] = mine(data, target, -1 >>> 0);
+
+    assert.strictEqual(result, true);
+
+    bio.writeU32(data, nonce, 0);
+
+    const [ok, reason] = await rpc.submitWork([data.toString('hex')]);
+
+    assert.strictEqual(ok, true);
+    assert.strictEqual(reason, 'valid');
+  });
+
+  it('should get and submit work (updated time)', async () => {
+    const json1 = await rpc.getWork([]);
+    const data1 = Buffer.from(json1.data, 'hex');
+    const target1 = Buffer.from(json1.target, 'hex');
+    const hdr1 = Headers.fromMiner(data1);
+    const [nonce, result] = mine(data1, target1, -1 >>> 0);
+
+    assert.strictEqual(result, true);
+
+    await new Promise(r => setTimeout(r, 2000));
+
+    const json2 = await rpc.getWork([]);
+    const data2 = Buffer.from(json2.data, 'hex');
+    const hdr2 = Headers.fromMiner(data2);
+
+    assert(hdr1.witnessRoot.equals(hdr2.witnessRoot));
+    assert.notStrictEqual(hdr1.time, hdr2.time);
+
+    bio.writeU32(data1, nonce, 0);
+
+    const [ok, reason] = await rpc.submitWork([data1.toString('hex')]);
+
+    assert.strictEqual(ok, true);
+    assert.strictEqual(reason, 'valid');
+
+    {
+      const [ok, reason] = await rpc.submitWork([data2.toString('hex')]);
+      assert.strictEqual(ok, false);
+      assert.strictEqual(reason, 'stale');
+    }
+  });
+
+  it('should get and submit work (updated mempool - first)', async () => {
+    const json1 = await rpc.getWork([]);
+    const data1 = Buffer.from(json1.data, 'hex');
+    const target1 = Buffer.from(json1.target, 'hex');
+    const hdr1 = Headers.fromMiner(data1);
+    const [nonce, result] = mine(data1, target1, -1 >>> 0);
+
+    assert.strictEqual(result, true);
+
+    rpc.lastActivity -= 11;
+
+    await wallet.send({
+      outputs: [
+        {
+          address: await wallet.receiveAddress(),
+          value: 25 * consensus.COIN
+        }
+      ]
+    });
+
+    await new Promise(r => setTimeout(r, 2000));
+
+    const json2 = await rpc.getWork([]);
+    const data2 = Buffer.from(json2.data, 'hex');
+    const hdr2 = Headers.fromMiner(data2);
+
+    assert(!hdr1.witnessRoot.equals(hdr2.witnessRoot));
+    assert(rpc.attempt && rpc.attempt.witnessRoot.equals(hdr2.witnessRoot));
+
+    bio.writeU32(data1, nonce, 0);
+
+    const [ok, reason] = await rpc.submitWork([data1.toString('hex')]);
+
+    assert.strictEqual(reason, 'valid');
+    assert.strictEqual(ok, true);
+
+    {
+      const [ok, reason] = await rpc.submitWork([data2.toString('hex')]);
+      assert.strictEqual(ok, false);
+      assert.strictEqual(reason, 'stale');
+    }
+  });
+
+  it('should get and submit work (updated mempool - second)', async () => {
+    const json1 = await rpc.getWork([]);
+    const data1 = Buffer.from(json1.data, 'hex');
+    const hdr1 = Headers.fromMiner(data1);
+
+    rpc.lastActivity -= 11;
+
+    await wallet.send({
+      outputs: [
+        {
+          address: await wallet.receiveAddress(),
+          value: 25 * consensus.COIN
+        }
+      ]
+    });
+
+    await new Promise(r => setTimeout(r, 2000));
+
+    const json2 = await rpc.getWork([]);
+    const data2 = Buffer.from(json2.data, 'hex');
+    const target2 = Buffer.from(json2.target, 'hex');
+    const hdr2 = Headers.fromMiner(data2);
+
+    assert(!hdr1.witnessRoot.equals(hdr2.witnessRoot));
+    assert(rpc.attempt && rpc.attempt.witnessRoot.equals(hdr2.witnessRoot));
+
+    const [nonce, result] = mine(data2, target2, -1 >>> 0);
+
+    assert.strictEqual(result, true);
+
+    bio.writeU32(data2, nonce, 0);
+
+    const [ok, reason] = await rpc.submitWork([data2.toString('hex')]);
+
+    assert.strictEqual(reason, 'valid');
+    assert.strictEqual(ok, true);
+
+    {
+      const [ok, reason] = await rpc.submitWork([data1.toString('hex')]);
+      assert.strictEqual(ok, false);
+      assert.strictEqual(reason, 'stale');
+    }
+  });
+
+  it('should check chain', async () => {
+    const block = await chain.getBlock(chain.tip.hash);
+
+    assert.strictEqual(block.txs.length, 3);
+    assert.strictEqual(chain.tip.height, 14);
+    assert.strictEqual(chain.height, 14);
+  });
+
+  it('should cleanup', async () => {
+    await node.close();
+  });
+});

--- a/test/getwork-test.js
+++ b/test/getwork-test.js
@@ -24,7 +24,7 @@ const {wdb} = node.require('walletdb');
 
 let wallet = null;
 
-describe('Getwork', function() {
+describe('Get Work', function() {
   this.timeout(45000);
 
   it('should open chain and miner', async () => {

--- a/test/node-test.js
+++ b/test/node-test.js
@@ -438,6 +438,8 @@ describe('Node', function() {
         vbrequired: 0,
         height: 20,
         previousblockhash: chain.tip.hash.toString('hex'),
+        merkleroot: undefined,
+        witnessroot: undefined,
         treeroot: network.genesis.treeRoot.toString('hex'),
         reservedroot: consensus.ZERO_HASH.toString('hex'),
         mask: json.result.mask,


### PR DESCRIPTION
It appears some (if not most) miners are using `getwork`/`submitwork` instead of `getblocktemplate`. This is presumably because `getwork` is just easier: it requires minimal implementation and serialization on the part of the mining software. `getwork` was originally only included for testing immature mining clients, however, the community's reliance on it requires us to give it a second look.

There is a nasty bug present in `getwork` which causes blocks to be invalidated when transactions enter the mempool. It seems that miners have been patching this bug themselves to avoid mining invalid blocks. I figure we should make an official fix asap.

This PR fixes `getwork` to allow operation on stale blocks with older merkle roots. 

Some things are also simplified: the RPC no longer auto-generates a mask for the client. This really serves no purpose as mining pools should be doing this in their pool software, generating a mask in accordance with their share target. `submitblock` now takes an optional `mask` argument so the pool can notify hsd of the mask it generated.

To encourage the use of `getblocktemplate`, we make it a bit easier to use and migrate to: `{"capabilities":["coinbasetxn"]}` has been re-enabled in a sane way which should not conflict with popular bitcoin mining software (if it has been modified to support handshake). `merkleroot` and `witnessroot` are also added to the template if `coinbasetxn` is present (this assumes the client will not be modifying the coinbase).