### PR TITLE
Inflation bug fix (covert->overt soft-fork)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## unreleased
 
+### Chain & Consensus changes
+
+- A consensus inflation bug has been fixed. Non-upgraded miners should upgrade
+  as soon as possible. See
+  https://handshake.org/notice/2020-04-02-Inflation-Bug-Disclosure.html for
+  more information.
+- A new chain value migration is necessary (related to the above fix). This
+  migration will automatically run on boot and should only take 2-3 minutes.
+  Pruned nodes _cannot_ run this migration. Note that pruned nodes may have an
+  incorrect chain value until they re-sync.
+
 ### Wallet changes
 
 - Fixes a bug that caused rescans to fail if a name being "watched" was ever

--- a/lib/blockchain/chain.js
+++ b/lib/blockchain/chain.js
@@ -58,7 +58,7 @@ class Chain extends AsyncEmitter {
     this.db = new ChainDB(this.options);
 
     this.locker = new Lock(true, BufferMap);
-    this.invalid = new LRU(100, null, BufferMap);
+    this.invalid = new LRU(5000, null, BufferMap);
     this.state = new DeploymentState(this.network.genesis.hash);
 
     this.tip = new ChainEntry();
@@ -641,6 +641,9 @@ class Chain extends AsyncEmitter {
     if (!this.state.hasHardening() && state.hasHardening())
       this.logger.warning('RSA hardening has been activated.');
 
+    if (this.height === this.network.deflationHeight)
+      this.logger.warning('Name claim deflation has been activated.');
+
     this.state = state;
   }
 
@@ -786,7 +789,7 @@ class Chain extends AsyncEmitter {
       throw new VerifyError(block,
         'invalid',
         'bad-cb-amount',
-        100);
+        0);
     }
 
     // Push onto verification queue.
@@ -984,6 +987,46 @@ class Chain extends AsyncEmitter {
             'invalid',
             'bad-claim-commit-hash',
             100);
+        }
+
+        assert(claimed >= 1);
+
+        // Handle inflation-fixing soft-fork.
+        if (height >= network.deflationHeight) {
+          const {claimFrequency} = network.names;
+
+          // Require claim height to be 1 on
+          // initial claims. This makes some
+          // non-contextual verification easier.
+          if (ns.owner.isNull()) {
+            if (claimed !== 1) {
+              throw new VerifyError(tx,
+                'invalid',
+                'bad-claim-height',
+                0);
+            }
+          }
+
+          // Limit the frequency of re-claims.
+          if (!ns.owner.isNull() && height < ns.height + claimFrequency) {
+            throw new VerifyError(tx,
+              'invalid',
+              'bad-claim-frequency',
+              0);
+          }
+
+          // Allow replacement, but require the
+          // same fee, which is then miner-burned.
+          if (!ns.owner.isNull()) {
+            const coin = await this.getCoin(ns.owner.hash, ns.owner.index);
+
+            if (!coin || output.value !== coin.value) {
+              throw new VerifyError(tx,
+                'invalid',
+                'bad-claim-value',
+                0);
+            }
+          }
         }
 
         ns.setHeight(height);
@@ -1467,7 +1510,22 @@ class Chain extends AsyncEmitter {
     // That will be done outside in setBestChain.
     for (let i = connect.length - 1; i >= 1; i--) {
       const entry = connect[i];
-      await this.reconnect(entry);
+
+      try {
+        await this.reconnect(entry);
+      } catch (err) {
+        if (err.type === 'VerifyError') {
+          if (!err.malleated) {
+            while (i--)
+              this.setInvalid(connect[i].hash);
+          }
+
+          if (this.tip.chainwork.lte(tip.chainwork))
+            await this.unreorganize(fork, tip);
+        }
+
+        throw err;
+      }
     }
 
     this.logger.warning(
@@ -1479,6 +1537,61 @@ class Chain extends AsyncEmitter {
     );
 
     await this.emitAsync('reorganize', tip, competitor);
+
+    return fork;
+  }
+
+  /**
+   * Revert a failed reorganization.
+   * @private
+   * @param {ChainEntry} fork - The common ancestor.
+   * @param {ChainEntry} last - The previous valid tip.
+   * @returns {Promise}
+   */
+
+  async unreorganize(fork, last) {
+    const tip = this.tip;
+
+    // Blocks to disconnect.
+    const disconnect = [];
+    let entry = tip;
+    while (!entry.hash.equals(fork.hash)) {
+      disconnect.push(entry);
+      entry = await this.getPrevious(entry);
+      assert(entry);
+    }
+
+    // Blocks to connect.
+    const connect = [];
+    entry = last;
+    while (!entry.hash.equals(fork.hash)) {
+      connect.push(entry);
+      entry = await this.getPrevious(entry);
+      assert(entry);
+    }
+
+    // Disconnect blocks/txs.
+    for (let i = 0; i < disconnect.length; i++) {
+      const entry = disconnect[i];
+      await this.disconnect(entry);
+    }
+
+    // Connect blocks/txs.
+    for (let i = connect.length - 1; i >= 0; i--) {
+      const entry = connect[i];
+      await this.reconnect(entry);
+    }
+
+    this.logger.warning(
+      'Chain un-reorganization: old=%x(%d) new=%x(%d)',
+      tip.hash,
+      tip.height,
+      last.hash,
+      last.height
+    );
+
+    // Treat as a reorganize event.
+    await this.emitAsync('reorganize', tip, last);
   }
 
   /**
@@ -1626,9 +1739,30 @@ class Chain extends AsyncEmitter {
    */
 
   async setBestChain(entry, block, prev, flags) {
+    const tip = this.tip;
+
+    let fork = null;
+
     // A higher fork has arrived.
     // Time to reorganize the chain.
     if (!entry.prevBlock.equals(this.tip.hash)) {
+      try {
+        // Do as much verification
+        // as we can before reorganizing.
+        await this.verify(block, prev, flags);
+      } catch (err) {
+        if (err.type === 'VerifyError') {
+          if (!err.malleated)
+            this.setInvalid(entry.hash);
+
+          this.logger.warning(
+            'Tried to connect invalid block: %x (%d).',
+            entry.hash, entry.height);
+        }
+
+        throw err;
+      }
+
       this.logger.warning('WARNING: Reorganizing chain.');
 
       // In spv-mode, we reset the
@@ -1636,7 +1770,7 @@ class Chain extends AsyncEmitter {
       if (this.options.spv)
         return this.reorganizeSPV(entry);
 
-      await this.reorganize(entry);
+      fork = await this.reorganize(entry);
     }
 
     // Warn of unknown versionbits.
@@ -1657,10 +1791,15 @@ class Chain extends AsyncEmitter {
       if (err.type === 'VerifyError') {
         if (!err.malleated)
           this.setInvalid(entry.hash);
+
         this.logger.warning(
           'Tried to connect invalid block: %x (%d).',
           entry.hash, entry.height);
+
+        if (fork && this.tip.chainwork.lte(tip.chainwork))
+          await this.unreorganize(fork, tip);
       }
+
       throw err;
     }
 

--- a/lib/blockchain/chaindb.js
+++ b/lib/blockchain/chaindb.js
@@ -98,8 +98,8 @@ class ChainDB {
       // Read bitfield.
       this.field = await this.getField();
 
-      // Run chain state migration.
-      await this.migrateChainState();
+      // Run chain state migration (disabled for now).
+      // await this.migrateChainState();
 
       this.logger.info('ChainDB successfully loaded.');
     } else {
@@ -2052,6 +2052,12 @@ class ChainDB {
           continue;
         }
 
+        // Only add value from the first claim.
+        if (output.covenant.isClaim()) {
+          if (output.covenant.getU32(5) !== 1)
+            continue;
+        }
+
         this.pending.add(output);
       }
 
@@ -2133,6 +2139,12 @@ class ChainDB {
         if (output.covenant.type >= types.REGISTER
             && output.covenant.type <= types.REVOKE) {
           continue;
+        }
+
+        // Only remove value from the first claim.
+        if (output.covenant.isClaim()) {
+          if (output.covenant.getU32(5) !== 1)
+            continue;
         }
 
         this.pending.spend(output);

--- a/lib/blockchain/chaindb.js
+++ b/lib/blockchain/chaindb.js
@@ -98,8 +98,8 @@ class ChainDB {
       // Read bitfield.
       this.field = await this.getField();
 
-      // Run chain state migration (disabled for now).
-      // await this.migrateChainState();
+      // Run chain state migration.
+      await this.migrateChainState();
 
       this.logger.info('ChainDB successfully loaded.');
     } else {
@@ -108,6 +108,7 @@ class ChainDB {
       await this.saveFlags();
       await this.saveDeployments();
       await this.saveMigration(0);
+      await this.saveMigration(1);
       await this.saveGenesis();
 
       this.logger.info('ChainDB successfully initialized.');
@@ -132,14 +133,23 @@ class ChainDB {
    */
 
   async migrateChainState() {
-    if (await this.db.has(layout.M.encode(0)))
+    if (await this.db.has(layout.M.encode(1)))
       return;
 
+    if (this.options.spv)
+      return;
+
+    if (this.options.prune) {
+      this.logger.warning('Pruned nodes cannot migrate the chain state.');
+      this.logger.warning('Your total chain value may be inaccurate!');
+      return;
+    }
+
     this.logger.info('Migrating chain state.');
+    this.logger.info('This may take a few minutes...');
 
     const tipHeight = await this.getHeight(this.state.tip);
     const pending = this.state.clone();
-    const view = new CoinView();
 
     pending.coin = 0;
     pending.value = 0;
@@ -149,19 +159,15 @@ class ChainDB {
       const block = await this.getBlock(await this.getHash(height));
       assert(block);
 
+      const view = await this.getBlockView(block);
+
       for (let i = 0; i < block.txs.length; i++) {
         const tx = block.txs[i];
 
         if (i > 0) {
           for (const {prevout} of tx.inputs) {
-            const {hash} = prevout;
             const output = view.getOutput(prevout);
             assert(output);
-
-            assert(view.removeEntry(prevout));
-
-            if (view.get(hash).outputs.size === 0)
-              assert(view.remove(hash));
 
             if (output.covenant.type >= types.REGISTER
                 && output.covenant.type <= types.REVOKE) {
@@ -186,16 +192,20 @@ class ChainDB {
             continue;
           }
 
+          if (output.covenant.isClaim()) {
+            if (output.covenant.getU32(5) !== 1)
+              continue;
+          }
+
           pending.add(output);
         }
-
-        view.addTX(tx, height);
       }
     }
 
     const batch = this.db.batch();
 
     batch.put(layout.M.encode(0), null);
+    batch.put(layout.M.encode(1), null);
     batch.put(layout.R.encode(), pending.encode());
 
     await batch.write();

--- a/lib/covenants/rules.js
+++ b/lib/covenants/rules.js
@@ -654,7 +654,7 @@ rules.hasSaneCovenants = function hasSaneCovenants(tx) {
             return false;
 
           // Must be linked.
-          if (i > tx.inputs.length)
+          if (i >= tx.inputs.length)
             return false;
 
           const input = tx.inputs[i];
@@ -1141,7 +1141,21 @@ rules.verifyCovenants = function verifyCovenants(tx, view, height, network) {
       if (output.value !== data.value - data.fee)
         return -1;
 
-      conjured += data.value;
+      if (data.commitHeight === 0) // Fail early.
+        return -1;
+
+      if (height >= network.deflationHeight) {
+        if (data.commitHeight === 1) {
+          if (data.fee > 1000 * consensus.COIN)
+            return -1;
+
+          conjured += data.value;
+        } else {
+          conjured += output.value;
+        }
+      } else {
+        conjured += data.value;
+      }
 
       if (conjured > consensus.MAX_MONEY)
         return -1;

--- a/lib/mempool/mempool.js
+++ b/lib/mempool/mempool.js
@@ -428,8 +428,10 @@ class Mempool extends EventEmitter {
       // The only things that might make a Claim invalid when rewinding the
       // blockchain is the inception time of the signatures in the DNSSEC proof
       // and the historical block committed to by the covenant.
+      // Note that we kick out replacement claims as a temporary measure.
       if (this.chain.tip.time < entry.inception
           || entry.commitHeight > this.chain.tip.height
+          || (this.network === Network.main && entry.commitHeight !== 1)
           || !await this.chain.isMainHash(entry.commitHash)) {
         // Claim is not still valid, remove from mempool and contract state.
         this.untrackClaim(entry);
@@ -1091,6 +1093,22 @@ class Mempool extends EventEmitter {
 
     if (!data)
       throw new VerifyError(claim, 'invalid', 'bad-claim-data', 100);
+
+    if (this.network === Network.main) {
+      // Ignore replacement claims until soft-fork maturity.
+      if (height < this.network.deflationHeight + 100) {
+        if (data.commitHeight !== 1)
+          throw new VerifyError(claim, 'invalid', 'bad-claim-replacement', 0);
+      }
+    }
+
+    if (data.commitHeight === 1) {
+      if (data.fee > 1000 * consensus.COIN)
+        throw new VerifyError(claim, 'highfee', 'absurdly-high-fee', 0);
+    }
+
+    if (data.version === 31)
+      throw new VerifyError(claim, 'invalid', 'bad-claim-nulldata', 0);
 
     if (tip.time < data.inception || tip.time > data.expiration)
       throw new VerifyError(claim, 'invalid', 'bad-claim-time', 10);

--- a/lib/mining/miner.js
+++ b/lib/mining/miner.js
@@ -290,7 +290,9 @@ class Miner extends EventEmitter {
       if (attempt.updates + 1 > this.options.maxUpdates)
         continue;
 
-      attempt.fees += item.fee;
+      if (item.commitHeight === 1)
+        attempt.fees += item.fee;
+
       attempt.weight += weight;
       attempt.updates += 1;
 

--- a/lib/mining/template.js
+++ b/lib/mining/template.js
@@ -274,6 +274,12 @@ class BlockTemplate {
     input.witness.setData(1, random.randomBytes(8));
     input.witness.compile();
 
+    // Covert soft-fork signaling.
+    const chunk = input.witness.items[1];
+
+    chunk[0] = 0xf0;
+    chunk[1] = 0xba;
+
     // Setup output address (variable size).
     output.address = this.address;
 
@@ -592,8 +598,12 @@ class BlockTemplate {
 
   addClaim(claim, data) {
     const entry = BlockClaim.fromClaim(claim, data);
-    this.fees += entry.fee;
+
+    if (entry.commitHeight === 1)
+      this.fees += entry.fee;
+
     this.claims.push(entry);
+
     return true;
   }
 

--- a/lib/net/pool.js
+++ b/lib/net/pool.js
@@ -2787,7 +2787,8 @@ class Pool extends EventEmitter {
       await this.mempool.addClaim(claim, peer.id);
     } catch (err) {
       if (err.type === 'VerifyError') {
-        peer.reject(packets.types.CLAIM, err);
+        if (err.reason !== 'bad-claim-replacement')
+          peer.reject(packets.types.CLAIM, err);
         this.logger.info(err);
         return;
       }

--- a/lib/node/rpc.js
+++ b/lib/node/rpc.js
@@ -177,6 +177,7 @@ class RPC extends RPCBase {
     this.add('gettxoutsetinfo', this.getTXOutSetInfo);
     this.add('pruneblockchain', this.pruneBlockchain);
     this.add('verifychain', this.verifyChain);
+    this.add('getcovertsignaling', this.getCovertSignaling);
 
     this.add('invalidateblock', this.invalidateBlock);
     this.add('reconsiderblock', this.reconsiderBlock);
@@ -613,6 +614,7 @@ class RPC extends RPCBase {
       chainwork: this.chain.tip.chainwork.toString('hex', 64),
       pruned: this.chain.options.prune,
       softforks: await this.getSoftforks(),
+      deflationary: this.chain.height >= this.network.deflationHeight,
       pruneheight: this.chain.options.prune
         ? Math.max(0, this.chain.height - this.network.block.keepBlocks)
         : null
@@ -1123,6 +1125,57 @@ class RPC extends RPCBase {
     return null;
   }
 
+  async getCovertSignaling(args, help) {
+    if (help || args.length > 1)
+      throw new RPCError(errs.MISC_ERROR, 'getcovertsignaling ( window )');
+
+    const valid = new Validator(args);
+
+    let window = valid.u32(0);
+
+    if (window == null) {
+      if (this.chain.height < this.network.deflationHeight)
+        throw new RPCError(errs.MISC_ERROR, 'Soft-fork not active.');
+
+      window = this.chain.height - this.network.deflationHeight + 1;
+    }
+
+    if (window > this.network.minerWindow)
+      window = this.network.minerWindow;
+
+    let entry = this.chain.tip;
+    let blocks = 0;
+    let total = 0;
+
+    for (let i = 0; i < window && entry; i++) {
+      const block = await this.chain.getBlock(entry.hash);
+
+      if (!block)
+        throw new RPCError(errs.DATABASE_ERROR, 'Not found.');
+
+      const cb = block.txs[0];
+      const {witness} = cb.inputs[0];
+
+      if (witness.items.length >= 2) {
+        const item = witness.items[1];
+
+        if (item.length === 8) {
+          if (item.readUInt16BE(0) === 0xf0ba)
+            blocks += 1;
+        }
+      }
+
+      total += 1;
+      entry = await this.chain.getPrevious(entry);
+    }
+
+    return {
+      blocks,
+      total,
+      perc: blocks / total
+    };
+  }
+
   /*
    * Mining
    */
@@ -1512,14 +1565,26 @@ class RPC extends RPCBase {
       coinbasevalue: undefined,
       coinbasetxn: undefined,
       claims: attempt.claims.map((claim) => {
+        let value = claim.value;
+        let fee = claim.fee;
+
+        // Account for mining software which creates its own
+        // coinbase with something other than `coinbasevalue`.
+        if (attempt.height >= this.network.deflationHeight) {
+          if (claim.commitHeight !== 1) {
+            value = claim.value - claim.fee;
+            fee = 0;
+          }
+        }
+
         return {
           data: claim.blob.toString('hex'),
           name: claim.name.toString('binary'),
           namehash: claim.nameHash.toString('hex'),
           version: claim.address.version,
           hash: claim.address.hash.toString('hex'),
-          value: claim.value,
-          fee: claim.fee,
+          value: value,
+          fee: fee,
           weak: claim.weak,
           commitHash: claim.commitHash.toString('hex'),
           commitHeight: claim.commitHeight,

--- a/lib/protocol/network.js
+++ b/lib/protocol/network.js
@@ -62,6 +62,7 @@ class Network {
     this.selfConnect = options.selfConnect;
     this.requestMempool = options.requestMempool;
     this.claimPrefix = options.claimPrefix;
+    this.deflationHeight = options.deflationHeight;
     this.time = new TimeData();
     this.txStart = options.txStart;
 

--- a/lib/protocol/networks.js
+++ b/lib/protocol/networks.js
@@ -297,6 +297,14 @@ main.names = {
   claimPeriod: (4 * 365) * main.pow.blocksPerDay,
 
   /**
+   * Amount of time required in between
+   * replacement claims.
+   * @const {Number}
+   */
+
+  claimFrequency: 2 * main.pow.blocksPerDay,
+
+  /**
    * Bidding time period.
    * @const {Number}
    */
@@ -574,6 +582,13 @@ main.requestMempool = false;
 
 main.claimPrefix = 'hns-claim:';
 
+/**
+ * Activation height for inflation bug fix.
+ * @const {Number}
+ */
+
+main.deflationHeight = 61043;
+
 /*
  * Testnet
  */
@@ -633,6 +648,7 @@ testnet.names = {
   renewalPeriod: 7 * testnet.pow.blocksPerDay,
   renewalMaturity: 1 * testnet.pow.blocksPerDay,
   claimPeriod: 90 * testnet.pow.blocksPerDay,
+  claimFrequency: 2 * testnet.pow.blocksPerDay,
   biddingPeriod: 1 * testnet.pow.blocksPerDay,
   revealPeriod: 2 * testnet.pow.blocksPerDay,
   treeInterval: testnet.pow.blocksPerDay >>> 2,
@@ -719,6 +735,8 @@ testnet.requestMempool = false;
 
 testnet.claimPrefix = 'hns-testnet:';
 
+testnet.deflationHeight = 0;
+
 /*
  * Regtest
  */
@@ -773,6 +791,7 @@ regtest.names = {
   renewalPeriod: 2500,
   renewalMaturity: 50,
   claimPeriod: 250000,
+  claimFrequency: 0,
   biddingPeriod: 5,
   revealPeriod: 10,
   treeInterval: 5,
@@ -862,6 +881,8 @@ regtest.requestMempool = true;
 
 regtest.claimPrefix = 'hns-regtest:';
 
+regtest.deflationHeight = 200;
+
 /*
  * Simnet
  */
@@ -917,6 +938,7 @@ simnet.names = {
   renewalPeriod: 1250,
   renewalMaturity: 25,
   claimPeriod: 75000,
+  claimFrequency: 0,
   biddingPeriod: 25,
   revealPeriod: 50,
   treeInterval: 2,
@@ -1005,6 +1027,8 @@ simnet.selfConnect = true;
 simnet.requestMempool = false;
 
 simnet.claimPrefix = 'hns-simnet:';
+
+simnet.deflationHeight = 0;
 
 /*
  * Expose

--- a/test/auction-test.js
+++ b/test/auction-test.js
@@ -550,8 +550,111 @@ describe('Auction', function() {
       }
     });
 
+    it('should mine to deflation height', async () => {
+      assert(chain.height < network.deflationHeight - 2);
+
+      while (chain.height < network.deflationHeight - 2) {
+        const block = await cpu.mineBlock();
+        assert(block);
+        assert(await chain.add(block));
+      }
+    });
+
     it('should open a TLD claim for .nl', async () => {
       const claim = await wallet.fakeClaim('nl');
+
+      assert(chain.height === network.deflationHeight - 2);
+
+      const job = await cpu.createJob();
+      const last = job.attempt.fees;
+
+      job.pushClaim(claim, network);
+
+      assert(job.attempt.fees === last + job.attempt.claims[0].fee);
+
+      job.refresh();
+
+      const block = await job.mineAsync();
+
+      try {
+        ownership.ignore = true;
+        assert(await chain.add(block));
+      } finally {
+        ownership.ignore = false;
+      }
+    });
+
+    it('should fail to replace TLD claim for .nl', async () => {
+      const claim = await wallet.fakeClaim('nl', {
+        rate: 2000,
+        commitHeight: 2
+      });
+
+      assert(chain.height === network.deflationHeight - 1);
+
+      const job = await cpu.createJob();
+      job.pushClaim(claim, network);
+      job.refresh();
+
+      const block = await job.mineAsync();
+
+      let err = null;
+
+      ownership.ignore = true;
+
+      try {
+        await chain.add(block);
+      } catch (e) {
+        err = e;
+      }
+
+      ownership.ignore = false;
+
+      assert(err);
+      assert.strictEqual(err.reason, 'bad-claim-value');
+    });
+
+    it('should reject a fee-redeeming coinbase for .nl', async () => {
+      const claim = await wallet.fakeClaim('nl', {
+        commitHeight: 2
+      });
+
+      assert(chain.height === network.deflationHeight - 1);
+
+      const job = await cpu.createJob();
+      const last = job.attempt.fees;
+
+      job.pushClaim(claim, network);
+
+      assert(job.attempt.fees === last);
+
+      job.attempt.fees += job.attempt.claims[0].fee;
+      job.refresh();
+
+      const block = await job.mineAsync();
+
+      let err = null;
+
+      ownership.ignore = true;
+
+      try {
+        await chain.add(block);
+      } catch (e) {
+        err = e;
+      }
+
+      ownership.ignore = false;
+
+      assert(err);
+      assert.strictEqual(err.reason, 'bad-cb-amount');
+    });
+
+    it('should replace TLD claim for .nl', async () => {
+      const claim = await wallet.fakeClaim('nl', {
+        commitHeight: 2
+      });
+
+      assert(chain.height === network.deflationHeight - 1);
 
       const job = await cpu.createJob();
       job.pushClaim(claim, network);
@@ -569,6 +672,8 @@ describe('Auction', function() {
 
     it('should open a TLD claim for .af', async () => {
       const claim = await wallet.fakeClaim('af');
+
+      assert(chain.height === network.deflationHeight);
 
       const job = await cpu.createJob();
       job.pushClaim(claim, network);

--- a/test/invalid-reorg-test.js
+++ b/test/invalid-reorg-test.js
@@ -1,0 +1,266 @@
+/* eslint-env mocha */
+/* eslint prefer-arrow-callback: "off" */
+
+'use strict';
+
+const assert = require('bsert');
+const Chain = require('../lib/blockchain/chain');
+const WorkerPool = require('../lib/workers/workerpool');
+const Miner = require('../lib/mining/miner');
+const MemWallet = require('./util/memwallet');
+const Network = require('../lib/protocol/network');
+
+const network = Network.get('regtest');
+
+const workers = new WorkerPool({
+  enabled: true
+});
+
+describe('Invalid Reorg', function() {
+  for (const mode of ['Front', 'Middle', 'Back', 'Final']) {
+    describe(mode, function() {
+      this.timeout(45000);
+
+      const chain = new Chain({
+        memory: true,
+        network,
+        workers
+      });
+
+      const miner = new Miner({
+        chain,
+        workers
+      });
+
+      const cpu = miner.cpu;
+
+      const wallet = new MemWallet({
+        network
+      });
+
+      chain.on('connect', (entry, block) => {
+        wallet.addBlock(entry, block.txs);
+      });
+
+      chain.on('disconnect', (entry, block) => {
+        wallet.removeBlock(entry, block.txs);
+      });
+
+      let tip1 = null;
+      let tip2 = null;
+
+      const valid = [];
+      const invalid = [];
+
+      before(async () => {
+        await chain.open();
+        await miner.open();
+      });
+
+      after(async () => {
+        await miner.close();
+        await chain.close();
+      });
+
+      it('should add addrs to miner', async () => {
+        miner.addresses.length = 0;
+        miner.addAddress(wallet.getReceive());
+      });
+
+      it('should mine 10 blocks', async () => {
+        for (let i = 0; i < 10; i++) {
+          const block = await cpu.mineBlock();
+          assert(block);
+          assert(await chain.add(block));
+        }
+      });
+
+      if (mode === 'Middle' || mode === 'Back') {
+        it('should mine competing chains', async () => {
+          for (let i = 0; i < 10; i++) {
+            const job1 = await cpu.createJob(tip1);
+            const job2 = await cpu.createJob(tip2);
+
+            const mtx = await wallet.create({
+              outputs: [{
+                address: wallet.getAddress(),
+                value: 10 * 1e8
+              }]
+            });
+
+            assert(job1.addTX(mtx.toTX(), mtx.view));
+            assert(job2.addTX(mtx.toTX(), mtx.view));
+
+            job1.refresh();
+            job2.refresh();
+
+            const blk1 = await job1.mineAsync();
+            const blk2 = await job2.mineAsync();
+
+            const hash1 = blk1.hash();
+            const hash2 = blk2.hash();
+
+            valid.push(hash1);
+            valid.push(hash2);
+
+            assert(await chain.add(blk1));
+            assert(await chain.add(blk2));
+
+            assert.bufferEqual(chain.tip.hash, hash1);
+
+            tip1 = await chain.getEntry(hash1);
+            tip2 = await chain.getEntry(hash2);
+
+            assert(tip1);
+            assert(tip2);
+
+            assert(!await chain.isMainChain(tip2));
+          }
+        });
+      }
+
+      if (mode !== 'Final') {
+        it('should mine competing invalid block', async () => {
+          const job1 = await cpu.createJob();
+          const job2 = await cpu.createJob();
+
+          const mtx = await wallet.create({
+            outputs: [{
+              address: wallet.getAddress(),
+              value: 10 * 1e8
+            }]
+          });
+
+          assert(job1.addTX(mtx.toTX(), mtx.view));
+          assert(job2.addTX(mtx.toTX(), mtx.view));
+
+          job2.attempt.fees += 1000;
+
+          job1.refresh();
+          job2.refresh();
+
+          const blk1 = await job1.mineAsync();
+          const blk2 = await job2.mineAsync();
+
+          const hash1 = blk1.hash();
+          const hash2 = blk2.hash();
+
+          valid.push(hash1);
+          invalid.push(hash2);
+
+          assert(await chain.add(blk1));
+          assert(await chain.add(blk2));
+
+          assert.bufferEqual(chain.tip.hash, hash1);
+
+          tip1 = await chain.getEntry(hash1);
+          tip2 = await chain.getEntry(hash2);
+
+          assert(tip1);
+          assert(tip2);
+
+          assert(!await chain.isMainChain(tip2));
+        });
+      }
+
+      if (mode === 'Front' || mode === 'Middle' || mode === 'Final') {
+        it('should mine competing chains', async () => {
+          for (let i = 0; i < 10; i++) {
+            const job1 = await cpu.createJob(tip1);
+            const job2 = await cpu.createJob(tip2);
+
+            const mtx = await wallet.create({
+              outputs: [{
+                address: wallet.getAddress(),
+                value: 10 * 1e8
+              }]
+            });
+
+            assert(job1.addTX(mtx.toTX(), mtx.view));
+            assert(job2.addTX(mtx.toTX(), mtx.view));
+
+            job1.refresh();
+            job2.refresh();
+
+            const blk1 = await job1.mineAsync();
+            const blk2 = await job2.mineAsync();
+
+            const hash1 = blk1.hash();
+            const hash2 = blk2.hash();
+
+            valid.push(hash1);
+
+            if (mode === 'Final')
+              valid.push(hash2);
+            else
+              invalid.push(hash2);
+
+            assert(await chain.add(blk1));
+            assert(await chain.add(blk2));
+
+            assert.bufferEqual(chain.tip.hash, hash1);
+
+            tip1 = await chain.getEntry(hash1);
+            tip2 = await chain.getEntry(hash2);
+
+            assert(tip1);
+            assert(tip2);
+
+            assert(!await chain.isMainChain(tip2));
+          }
+        });
+      }
+
+      it('should handle a reorg', async () => {
+        assert(chain.tip.hash.equals(tip1.hash));
+        assert(!chain.tip.hash.equals(tip2.hash));
+
+        const job = await cpu.createJob(tip2);
+
+        if (mode === 'Final') {
+          job.attempt.fees += 1000;
+          job.refresh();
+        }
+
+        const blk = await job.mineAsync();
+
+        let err = null;
+
+        try {
+          await chain.add(blk);
+        } catch (e) {
+          err = e;
+        }
+
+        assert(err);
+        assert.strictEqual(err.reason, 'bad-cb-amount');
+      });
+
+      it('should check main chain', async () => {
+        assert(await chain.isMainChain(tip1));
+        assert(chain.tip.hash.equals(tip1.hash));
+
+        for (const hash of valid)
+          assert(!chain.invalid.has(hash));
+
+        for (const hash of invalid)
+          assert(chain.invalid.has(hash));
+      });
+
+      it('should mine a block after a reorg', async () => {
+        const block = await cpu.mineBlock();
+
+        assert(await chain.add(block));
+
+        const hash = block.hash();
+        const entry = await chain.getEntry(hash);
+
+        assert(entry);
+        assert.bufferEqual(chain.tip.hash, entry.hash);
+
+        const result = await chain.isMainChain(entry);
+        assert(result);
+      });
+    });
+  }
+});


### PR DESCRIPTION
On March 24th, @pinheadmz discovered an inflation bug pertaining to replacement name claims. Other Handshake contributors were notified and action was quickly taken to deploy a covert soft-fork in collaboration with various miners. As of this moment, ~90% of the network hashrate is signaling the covert soft-fork, and we have confirmation that at least 93% of the network hashrate is _enforcing_ the soft-fork (but perhaps not signaling).

Chain analysis reveals that __this bug has never been exploited on mainnet__, and is now impossible to exploit given the hashrate enforcing this change.

The inflation bug could be exploited as follows:

1. Create a claim for a reserved name with a chosen fee.
2. Create a replacement claim with another fee.
3. Step 2 can now be repeated infinitely.

_All_ fees will be mined by the miner, and only final output value will actually be received by the name claimant.

Only miners stood to benefit financially from this bug. However, a malicious actor could have effectively destroyed the chain by causing hyper-inflation if they so desired.

The soft-fork works as follows:

- Initial claims are now required to commit to block 1 (note that commitments to block 0 were never allowed).
- Replacement claims (claimHeight > 1) are required to have the same output value as the previous claim output.
- Fees collected from replacement claims are required to be burned by miners (i.e. not added to the reward output).
- A frequency limit has been introduced for claims: consecutive replacement claims must be mined 288 blocks apart.
- A hard fee limit of 1000 coins has be introduced for claims (this prevents a registrar hacker from stealing absurd amounts of coins in collusion with a miner).
- A covert signaling mechanism was added to coinbase creation to track soft-fork enforcement (_not_ a consensus change).

There may have been a "better" way to do this, but the above fix worked nicely as a covert change since it does not modify the manner in which _initial_ name claims are handled. As such, it required no immediate changes to the wallet. The downside here is that replacement claims are now effectively zero-fee from the miner's perspective.

This PR also adds new re-org logic to revert an invalid re-org if a contextual error was encountered when connecting new blocks. This was an issue for miners, particularly in the context of the covert soft-fork deployment.

There is also a lesser bug here: the calculation of the total chain value was including _replacement_ claims. This resulted in a superficial error -- `gettxoutsetinfo` could return the wrong chain value after replacement claims have been mined. This PR includes a migration for this which should only take 2-3 minutes to run on boot.

Once this is merged and released, it is important that non-upgraded miners (~7% of them) upgrade immediately.

See https://handshake.org/notice/2020-04-02-Inflation-Bug-Disclosure.html for more information.

Much praise to @pinheadmz for discovering this bug! And a thank you to everyone who helped resolve this crisis.