### PR TITLE
wallet: accept language option for mnemonic when creating new wallet

### DIFF
--- a/lib/hd/mnemonic.js
+++ b/lib/hd/mnemonic.js
@@ -74,7 +74,9 @@ class Mnemonic extends bio.Struct {
 
     if (options.language) {
       assert(typeof options.language === 'string');
-      assert(Mnemonic.languages.indexOf(options.language) !== -1);
+      if (Mnemonic.languages.indexOf(options.language) === -1)
+        throw new Error('Unknown language.');
+
       this.language = options.language;
     }
 

--- a/lib/wallet/http.js
+++ b/lib/wallet/http.js
@@ -283,6 +283,7 @@ class HTTP extends Server {
       let master = valid.str('master');
       let mnemonic = valid.str('mnemonic');
       let accountKey = valid.str('accountKey');
+      const language = valid.str('language');
 
       if (master)
         master = HDPrivateKey.fromBase58(master, this.network);
@@ -303,7 +304,8 @@ class HTTP extends Server {
         master: master,
         mnemonic: mnemonic,
         accountKey: accountKey,
-        watchOnly: valid.bool('watchOnly')
+        watchOnly: valid.bool('watchOnly'),
+        language: language
       });
 
       const balance = await wallet.getBalance();

--- a/lib/wallet/wallet.js
+++ b/lib/wallet/wallet.js
@@ -98,7 +98,8 @@ class Wallet extends EventEmitter {
       return this;
 
     let key = options.master;
-    let id, token, mnemonic;
+    let mnemonic = options.mnemonic;
+    let id, token;
 
     if (key) {
       if (typeof key === 'string')
@@ -107,7 +108,12 @@ class Wallet extends EventEmitter {
       assert(HD.isPrivate(key),
         'Must create wallet with hd private key.');
     } else {
-      mnemonic = new Mnemonic(options.mnemonic);
+      if (typeof mnemonic === 'string')
+        mnemonic = new Mnemonic({ phrase: mnemonic });
+
+      if (!mnemonic)
+        mnemonic = new Mnemonic({ language: options.language });
+
       key = HD.fromMnemonic(mnemonic, options.bip39Passphrase);
     }
 

--- a/test/wallet-test.js
+++ b/test/wallet-test.js
@@ -27,6 +27,7 @@ const Output = require('../lib/primitives/output');
 const Script = require('../lib/script/script');
 const policy = require('../lib/protocol/policy');
 const HDPrivateKey = require('../lib/hd/private');
+const Mnemonic = require('../lib/hd/mnemonic');
 const Wallet = require('../lib/wallet/wallet');
 const rules = require('../lib/covenants/rules');
 const {types, hashName} = rules;
@@ -132,6 +133,24 @@ describe('Wallet', function() {
     const wallet1 = await wdb.create();
     const wallet2 = await wdb.get(wallet1.id);
     assert(wallet1 === wallet2);
+  });
+
+  it('should create wallet with spanish mnemonic', async () => {
+    const wallet1 = await wdb.create({language: 'spanish'});
+    const phrase = wallet1.master.mnemonic.phrase;
+    for (const word of phrase.split(' ')) {
+      const language = Mnemonic.getLanguage(word);
+      assert.strictEqual(language, 'spanish');
+      // Comprobar la cordura
+      assert.notStrictEqual(language, 'english');
+    }
+
+    // Verificar
+    const wallet2 = await wdb.create({mnemonic: phrase});
+    assert.deepStrictEqual(
+      await wallet1.receiveAddress(),
+      await wallet2.receiveAddress()
+    );
   });
 
   it('should sign/verify p2pkh tx', async () => {

--- a/test/wallet-test.js
+++ b/test/wallet-test.js
@@ -1377,9 +1377,7 @@ describe('Wallet', function() {
   });
 
   it('should yield different keys when bip39Passphrase is supplied', async () => {
-    const wallet = await wdb.create({
-      mnemonic: {bits: 256}
-    });
+    const wallet = await wdb.create();
 
     const wallet2 = await wdb.create({
       mnemonic: wallet.master.mnemonic.toString()


### PR DESCRIPTION
Closes https://github.com/handshake-org/hsd/issues/587

Once https://github.com/handshake-org/hs-client/pull/39 is merged together:

```sh
$ hsw-cli --network=regtest --id=cartera --language=spanish mkwallet
{
  "network": "regtest",
  "wid": 1,
  "id": "cartera",
  "watchOnly": false,
  "accountDepth": 1,
  "token": "251e4f2b6a238cf3491ee783bc2d0ab09a8aeed8fb81296cc81d1bbd026c1812",
  "tokenDepth": 0,
  "master": {
    "encrypted": false
  },
  "balance": {
    "account": -1,
    "tx": 0,
    "coin": 0,
    "unconfirmed": 0,
    "confirmed": 0,
    "lockedUnconfirmed": 0,
    "lockedConfirmed": 0
  }
}

$ hsw-cli --network=regtest --id=cartera master
{
  "encrypted": false,
  "key": {
    "xprivkey": "rprvKE8qsHtkmUxUSR1stB2VJX3ibU3WzvUWZXxrzTJph7Sy91AVQJwBPVdE9HxZEkH6MfeDME26YLtmUZ46p1EDpn2HV16rpFGyJ81A6ikrKxV4"
  },
  "mnemonic": {
    "bits": 256,
    "language": "spanish",
    "entropy": "2ff615cbe0665107f3f28665fee8ab7755500159a6c22118b80f0bc94f99d62e",
    "phrase": "chancla perder inicio radical goma lote saber este grada vencer cara tribu faltar abono grave silencio borde reja acusar aula muela ronco fiebre sapo"
  }
}

```