### PR TITLE
wallet: pass passphrase + TX options to sendRedeemAll())

### DIFF
--- a/lib/wallet/http.js
+++ b/lib/wallet/http.js
@@ -1160,13 +1160,15 @@ class HTTP extends Server {
 
       assert(broadcast ? sign : true, 'Must sign when broadcasting.');
 
-      if (!name) {
-        const tx = await req.wallet.sendRedeemAll();
-        return res.json(200, tx.getJSON(this.network));
-      }
-
       const options = TransactionOptions.fromValidator(valid);
-      const mtx = await req.wallet.createRedeem(name, options);
+
+      let mtx;
+
+      if (!name) {
+        mtx = await req.wallet.createRedeemAll(options);
+      } else {
+        mtx = await req.wallet.createRedeem(name, options);
+      }
 
       if (broadcast) {
         const tx = await req.wallet.sendMTX(mtx, passphrase);

--- a/lib/wallet/rpc.js
+++ b/lib/wallet/rpc.js
@@ -2197,8 +2197,8 @@ class RPC extends RPCBase {
   }
 
   _validateRedeem(args, help, method) {
-    if (help || args.length < 1 || args.length > 2)
-      throw new RPCError(errs.MISC_ERROR, `${method} "name" ( "account" )`);
+    if (help || args.length > 2)
+      throw new RPCError(errs.MISC_ERROR, `${method} ("name") ( "account" )`);
 
     const valid = new Validator(args);
     const name = valid.str(0);

--- a/test/wallet-rpc-test.js
+++ b/test/wallet-rpc-test.js
@@ -466,6 +466,11 @@ describe('Wallet RPC Methods', function() {
   });
 
   describe('auction RPC', () => {
+    // Prevent mempool from sending duplicate TXs back to the walletDB and txdb.
+    // This will prevent a race condition when we need to remove spent (but
+    // unconfirmed) outputs from the wallet so they can be reused in other tests.
+    node.mempool.emit = () => {};
+
     const wallet = wclient.wallet('primary');
 
     it('should do an auction', async () => {

--- a/test/wallet-rpc-test.js
+++ b/test/wallet-rpc-test.js
@@ -11,16 +11,17 @@ const HDPrivateKey = require('../lib/hd/private');
 const Script = require('../lib/script/script');
 const Address = require('../lib/primitives/address');
 const rules = require('../lib/covenants/rules');
-const network = Network.get('regtest');
-const mnemonics = require('./data/mnemonic-english.json');
-// Commonly used test mnemonic
-const phrase = mnemonics[0][1];
-// First 200 addresses derived from watch only wallet
-const addresses = require('./data/addresses.json');
-const rules = require('../lib/covenants/rules');
+
 const {types} = rules;
 const {forValue} = require('./util/common');
 
+// Commonly used test mnemonic
+const mnemonics = require('./data/mnemonic-english.json');
+const phrase = mnemonics[0][1];
+// First 200 addresses derived from watch only wallet
+const addresses = require('./data/addresses.json');
+
+const network = Network.get('regtest');
 const {
   treeInterval,
   biddingPeriod,
@@ -471,7 +472,14 @@ describe('Wallet RPC Methods', function() {
     // unconfirmed) outputs from the wallet so they can be reused in other tests.
     node.mempool.emit = () => {};
 
-    const wallet = wclient.wallet('primary');
+    let wallet;
+    before(async () => {
+      await wclient.createWallet('auctionRPCWallet');
+      wallet = wclient.wallet('auctionRPCWallet');
+      await wclient.execute('selectwallet', ['auctionRPCWallet']);
+      const addr = await wclient.execute('getnewaddress', []);
+      await nclient.execute('generatetoaddress', [10, addr]);
+    });
 
     it('should do an auction', async () => {
       const NAME1 = rules.grindName(5, 2, network);

--- a/test/wallet-rpc-test.js
+++ b/test/wallet-rpc-test.js
@@ -17,6 +17,15 @@ const mnemonics = require('./data/mnemonic-english.json');
 const phrase = mnemonics[0][1];
 // First 200 addresses derived from watch only wallet
 const addresses = require('./data/addresses.json');
+const rules = require('../lib/covenants/rules');
+const {types} = rules;
+const {forValue} = require('./util/common');
+
+const {
+  treeInterval,
+  biddingPeriod,
+  revealPeriod
+} = network.names;
 
 const ports = {
   p2p: 14331,
@@ -47,6 +56,8 @@ const wclient = new WalletClient({
   port: ports.wallet,
   apiKey: 'bar'
 });
+
+const {wdb} = node.require('walletdb');
 
 describe('Wallet RPC Methods', function() {
   this.timeout(15000);
@@ -451,6 +462,117 @@ describe('Wallet RPC Methods', function() {
           message: 'Invalid name.'
         });
       }
+    });
+  });
+
+  describe('auction RPC', () => {
+    const wallet = wclient.wallet('primary');
+
+    it('should do an auction', async () => {
+      const NAME1 = rules.grindName(5, 2, network);
+      const NAME2 = rules.grindName(6, 3, network);
+      const addr = await wclient.execute('getnewaddress', []);
+      await nclient.execute('generatetoaddress', [10, addr]);
+      await forValue(wdb, 'height', node.chain.height);
+
+      await wclient.execute('sendopen', [NAME1]);
+      await wclient.execute('sendopen', [NAME2]);
+      await nclient.execute('generatetoaddress', [treeInterval + 1, addr]);
+      await forValue(wdb, 'height', node.chain.height);
+
+      // NAME1 gets 3 bids, NAME2 gets 4.
+      await wclient.execute('sendbid', [NAME1, 1, 2]);
+      await wclient.execute('sendbid', [NAME1, 3, 4]);
+      await wclient.execute('sendbid', [NAME1, 5, 6]);
+
+      await wclient.execute('sendbid', [NAME2, 1, 2]);
+      await wclient.execute('sendbid', [NAME2, 3, 4]);
+      await wclient.execute('sendbid', [NAME2, 5, 6]);
+      await wclient.execute('sendbid', [NAME2, 7, 8]);
+      await nclient.execute('generatetoaddress', [biddingPeriod, addr]);
+      await forValue(wdb, 'height', node.chain.height);
+
+      // Works with and without specifying name.
+      const createRevealName = await wclient.execute('createreveal', [NAME1]);
+      const createRevealAll = await wclient.execute('createreveal', []);
+      const sendRevealName = await wclient.execute('sendreveal', [NAME1]);
+
+      // Un-send so we can try again.
+      await node.mempool.reset();
+      await wallet.abandon(sendRevealName.hash);
+      const sendRevealAll = await wclient.execute('sendreveal', []);
+
+      // If we don't specify the name, all 7 bids are revealed.
+      // If we DO specify the name, only those 3 are revealed.
+      assert.strictEqual(
+        createRevealAll.outputs.filter(
+          output => output.covenant.type === types.REVEAL
+        ).length,
+        7
+      );
+      assert.strictEqual(
+        createRevealName.outputs.filter(
+          output => output.covenant.type === types.REVEAL
+        ).length,
+        3
+      );
+      assert.strictEqual(
+        sendRevealAll.outputs.filter(
+          output => output.covenant.type === types.REVEAL
+        ).length,
+        7
+      );
+      assert.strictEqual(
+        sendRevealName.outputs.filter(
+          output => output.covenant.type === types.REVEAL
+        ).length,
+        3
+      );
+
+      await nclient.execute('generatetoaddress', [revealPeriod, addr]);
+      await forValue(wdb, 'height', node.chain.height);
+
+      // Works with and without specifying name.
+      const createRedeemName = await wclient.execute('createredeem', [NAME1]);
+      const createRedeemAll = await wclient.execute('createredeem', []);
+      const sendRedeemName = await wclient.execute('sendredeem', [NAME1]);
+
+      // Un-send so we can try again.
+      await node.mempool.reset();
+      await wallet.abandon(sendRedeemName.hash);
+      const sendRedeemAll = await wclient.execute('sendredeem', []);
+
+      // If we don't specify the name, all 5 losing reveals are redeemed.
+      // If we DO specify the name, only those 2 are redeemed.
+      assert.strictEqual(
+        createRedeemAll.outputs.filter(
+          output => output.covenant.type === types.REDEEM
+        ).length,
+        5
+      );
+      assert.strictEqual(
+        createRedeemName.outputs.filter(
+          output => output.covenant.type === types.REDEEM
+        ).length,
+        2
+      );
+      assert.strictEqual(
+        sendRedeemAll.outputs.filter(
+          output => output.covenant.type === types.REDEEM
+        ).length,
+        5
+      );
+      assert.strictEqual(
+        sendRedeemName.outputs.filter(
+          output => output.covenant.type === types.REDEEM
+        ).length,
+        2
+      );
+
+      // Confirm wallet has won both names.
+      await wclient.execute('sendupdate', [NAME1, {'records':[]}]);
+      await wclient.execute('sendupdate', [NAME2, {'records':[]}]);
+      await nclient.execute('generatetoaddress', [1, addr]);
     });
   });
 });


### PR DESCRIPTION
Closes https://github.com/handshake-org/hsd/issues/586

When a user tries to redeem multiple losing bids for multiple names by calling `sendRedeem` with `name: null`, the http module calls a specific function `sendRedeemAll()`. This function was not getting passed the wallet passphrase, and so encrypted wallets would always fail. 

This PR simply passes the passphrase (and the rest of the TX options like `subtractFee`, etc) to that function.