### PR TITLE
[getwork-RPC] Add the fee to the return result of getwork.

### DIFF
--- a/lib/node/rpc.js
+++ b/lib/node/rpc.js
@@ -1260,7 +1260,8 @@ class RPC extends RPCBase {
       data: data.toString('hex'),
       target: attempt.target.toString('hex'),
       height: attempt.height,
-      time: this.network.now()
+      time: this.network.now(),
+      fee: attempt.fees
     };
   }
 


### PR DESCRIPTION
For mining pool development, I think it would be more convenient to have FEE as one of the results returned by getWork.