### PR TITLE
dns: fix root server dnssec proofs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,11 @@ when users need to call `rpc importnonce` to repair unknown blinds. The complete
 - Wallet RPC `getnames` (and HTTP endpoint `/wallet/:id/name`) now accept a
 boolean parameter "own" (default: `false`) that filters out names the wallet does not own.
 
+### DNS changes
+
+- DNSSEC proofs from the root name server were fixed, particularly around non-existent
+domains. The empty zone proofs were replaced with minimally covering NSEC records.
+
 ### Other changes
 
 - The logging module `blgr` has been updated. Log files will now be rolled over

--- a/bench/nsec.js
+++ b/bench/nsec.js
@@ -1,0 +1,16 @@
+'use strict';
+
+const bench = require('./bench');
+const nsec = require('../lib/dns/nsec');
+const {TYPE_MAP_EMPTY} = require('../lib/dns/common');
+
+const tld = 'dollarydoo';
+const ops = 100000;
+
+const end = bench('nsec');
+for (let i = 0; i < ops; i++) {
+  const prev = nsec.prevName(tld);
+  const next = nsec.nextName(tld);
+  nsec.create(prev, next, TYPE_MAP_EMPTY);
+}
+end(ops);

--- a/lib/dns/common.js
+++ b/lib/dns/common.js
@@ -1,0 +1,50 @@
+/*!
+ * common.js - dns constants for hsd
+ * Copyright (c) 2021, The Handshake Developers (MIT License).
+ * https://github.com/handshake-org/hsd
+ */
+
+'use strict';
+
+/**
+ * @module dns/common
+ */
+
+exports.DUMMY = Buffer.alloc(0);
+
+// About one mainnet Urkel Tree interval.
+// (60 seconds * 10 minutes * 36)
+exports.DEFAULT_TTL = 21600;
+
+// NS SOA RRSIG NSEC DNSKEY
+// Types available for the root "."
+exports.TYPE_MAP_ROOT = Buffer.from('000722000000000380', 'hex');
+
+// RRSIG NSEC
+exports.TYPE_MAP_EMPTY =  Buffer.from('0006000000000003', 'hex');
+
+// NS RRSIG NSEC
+exports.TYPE_MAP_NS = Buffer.from('0006200000000003', 'hex');
+
+// TXT RRSIG NSEC
+exports.TYPE_MAP_TXT = Buffer.from('0006000080000003', 'hex');
+
+exports.hsTypes = {
+  DS: 0,
+  NS: 1,
+  GLUE4: 2,
+  GLUE6: 3,
+  SYNTH4: 4,
+  SYNTH6: 5,
+  TXT: 6
+};
+
+exports.hsTypesByVal = {
+  [exports.hsTypes.DS]: 'DS',
+  [exports.hsTypes.NS]: 'NS',
+  [exports.hsTypes.GLUE4]: 'GLUE4',
+  [exports.hsTypes.GLUE6]: 'GLUE6',
+  [exports.hsTypes.SYNTH4]: 'SYNTH4',
+  [exports.hsTypes.SYNTH6]: 'SYNTH6',
+  [exports.hsTypes.TXT]: 'TXT'
+};

--- a/lib/dns/nsec.js
+++ b/lib/dns/nsec.js
@@ -27,9 +27,9 @@ function nextName(tld) {
   // increment last character by one
   if (tld.length === 63) {
     // Assuming no escaped octets are present
-    const next = Buffer.from(tld, 'ascii');
-    next[next.length-1]++;
-    return next.toString() + '.';
+    let last = tld.charCodeAt(62);
+    last = String.fromCharCode(last + 1);
+    return tld.slice(0, -1) + last + '.';
   }
 
   return tld + '\\000.';
@@ -42,9 +42,9 @@ function prevName(tld) {
 
   // Decrement the last character by 1
   // assuming no escaped octets are present
-  let prev = Buffer.from(tld, 'ascii');
-  prev[prev.length-1]--;
-  prev = prev.toString();
+  let last = tld.charCodeAt(tld.length - 1);
+  last = String.fromCharCode(last - 1);
+  tld = tld.slice(0, -1) + last;
 
   // See RFC4034 6.1 Canonical DNS Name Order
   // https://tools.ietf.org/html/rfc4034#section-6.1
@@ -54,11 +54,11 @@ function prevName(tld) {
   // smaller name is `helln` append `\255`
   // to ensure that helln\255 > hellna
   // while keeping helln\255 < hello
-  if (prev.length < 63) {
-    prev += '\\255';
+  if (tld.length < 63) {
+    tld += '\\255';
   }
 
-  return util.fqdn(prev);
+  return util.fqdn(tld);
 }
 
 exports.create = create;

--- a/lib/dns/nsec.js
+++ b/lib/dns/nsec.js
@@ -1,0 +1,82 @@
+'use strict';
+
+const assert = require('bsert');
+const {wire, util} = require('bns');
+const {Record, NSECRecord, types} = wire;
+
+// NS SOA RRSIG NSEC DNSKEY
+// Types available for the root "."
+const TYPE_MAP_ROOT = Buffer.from('000722000000000380', 'hex');
+
+// RRSIG NSEC
+const TYPE_MAP_EMPTY =  Buffer.from('0006000000000003', 'hex');
+
+// NS RRSIG NSEC
+const TYPE_MAP_NS = Buffer.from('0006200000000003', 'hex');
+
+// TXT RRSIG NSEC
+const TYPE_MAP_TXT = Buffer.from('0006000080000003', 'hex');
+
+function create(name, nextDomain, typeBitmap) {
+  const rr = new Record();
+  const rd = new NSECRecord();
+  rr.name = util.fqdn(name);
+  rr.type = types.NSEC;
+  rr.ttl = 86400;
+
+  rd.nextDomain = util.fqdn(nextDomain);
+  rd.typeBitmap = typeBitmap;
+  rr.data = rd;
+
+  return rr;
+}
+
+// find the successor of a top level name
+function nextName(tld) {
+  tld = util.trimFQDN(tld.toLowerCase());
+
+  // if the label is already 63 octets
+  // increment last character by one
+  if(tld.length === 63) {
+    // assuming no escaped octets are present
+    const next = Buffer.from(tld, 'ascii');
+    next[next.length-1]++;
+    return next.toString() + '.';
+  }
+
+  return tld + '\\000.';
+}
+
+// find the predecessor of a top level name
+function prevName(tld) {
+  tld = util.trimFQDN(tld.toLowerCase());
+  assert(tld.length !== 0);
+
+  // decrement the last character by 1
+  // assuming no escaped octets are present
+  let prev = Buffer.from(tld, 'ascii');
+  prev[prev.length-1]--;
+  prev = prev.toString();
+
+  // See RFC4034 6.1 Canonical DNS Name Order
+  // https://tools.ietf.org/html/rfc4034#section-6.1
+  // Appending \255 prevents names that begin
+  // with the decremented name from falling
+  // in range i.e if the name is `hello` a lexically
+  // smaller name is `helln` append `\255`
+  // to ensure that helln\255 > hellna
+  // while keeping helln\255 < hello
+  if (prev.length < 63) {
+    prev += '\\255';
+  }
+
+  return util.fqdn(prev);
+}
+
+exports.TYPE_MAP_ROOT = TYPE_MAP_ROOT;
+exports.TYPE_MAP_EMPTY = TYPE_MAP_EMPTY;
+exports.TYPE_MAP_NS = TYPE_MAP_NS;
+exports.TYPE_MAP_TXT = TYPE_MAP_TXT;
+exports.create = create;
+exports.prevName = prevName;
+exports.nextName = nextName;

--- a/lib/dns/nsec.js
+++ b/lib/dns/nsec.js
@@ -3,26 +3,14 @@
 const assert = require('bsert');
 const {wire, util} = require('bns');
 const {Record, NSECRecord, types} = wire;
-
-// NS SOA RRSIG NSEC DNSKEY
-// Types available for the root "."
-const TYPE_MAP_ROOT = Buffer.from('000722000000000380', 'hex');
-
-// RRSIG NSEC
-const TYPE_MAP_EMPTY =  Buffer.from('0006000000000003', 'hex');
-
-// NS RRSIG NSEC
-const TYPE_MAP_NS = Buffer.from('0006200000000003', 'hex');
-
-// TXT RRSIG NSEC
-const TYPE_MAP_TXT = Buffer.from('0006000080000003', 'hex');
+const {DEFAULT_TTL} = require('./common');
 
 function create(name, nextDomain, typeBitmap) {
   const rr = new Record();
   const rd = new NSECRecord();
   rr.name = util.fqdn(name);
   rr.type = types.NSEC;
-  rr.ttl = 86400;
+  rr.ttl = DEFAULT_TTL;
 
   rd.nextDomain = util.fqdn(nextDomain);
   rd.typeBitmap = typeBitmap;
@@ -31,14 +19,14 @@ function create(name, nextDomain, typeBitmap) {
   return rr;
 }
 
-// find the successor of a top level name
+// Find the successor of a top level name
 function nextName(tld) {
   tld = util.trimFQDN(tld.toLowerCase());
 
-  // if the label is already 63 octets
+  // If the label is already 63 octets
   // increment last character by one
-  if(tld.length === 63) {
-    // assuming no escaped octets are present
+  if (tld.length === 63) {
+    // Assuming no escaped octets are present
     const next = Buffer.from(tld, 'ascii');
     next[next.length-1]++;
     return next.toString() + '.';
@@ -47,12 +35,12 @@ function nextName(tld) {
   return tld + '\\000.';
 }
 
-// find the predecessor of a top level name
+// Find the predecessor of a top level name
 function prevName(tld) {
   tld = util.trimFQDN(tld.toLowerCase());
   assert(tld.length !== 0);
 
-  // decrement the last character by 1
+  // Decrement the last character by 1
   // assuming no escaped octets are present
   let prev = Buffer.from(tld, 'ascii');
   prev[prev.length-1]--;
@@ -62,7 +50,7 @@ function prevName(tld) {
   // https://tools.ietf.org/html/rfc4034#section-6.1
   // Appending \255 prevents names that begin
   // with the decremented name from falling
-  // in range i.e if the name is `hello` a lexically
+  // in range i.e. if the name is `hello` a lexically
   // smaller name is `helln` append `\255`
   // to ensure that helln\255 > hellna
   // while keeping helln\255 < hello
@@ -73,10 +61,6 @@ function prevName(tld) {
   return util.fqdn(prev);
 }
 
-exports.TYPE_MAP_ROOT = TYPE_MAP_ROOT;
-exports.TYPE_MAP_EMPTY = TYPE_MAP_EMPTY;
-exports.TYPE_MAP_NS = TYPE_MAP_NS;
-exports.TYPE_MAP_TXT = TYPE_MAP_TXT;
 exports.create = create;
 exports.prevName = prevName;
 exports.nextName = nextName;

--- a/lib/dns/resource.js
+++ b/lib/dns/resource.js
@@ -14,6 +14,14 @@ const bio = require('bufio');
 const key = require('./key');
 const nsec = require('./nsec');
 const {Struct} = bio;
+const {
+  DUMMY,
+  DEFAULT_TTL,
+  TYPE_MAP_EMPTY,
+  TYPE_MAP_NS,
+  TYPE_MAP_TXT,
+  hsTypes
+} = require('./common');
 
 const {
   sizeName,
@@ -37,40 +45,6 @@ const {
   DSRecord,
   types
 } = wire;
-
-const {
-  TYPE_MAP_EMPTY,
-  TYPE_MAP_NS,
-  TYPE_MAP_TXT
-} = nsec;
-
-/*
- * Constants
- */
-
-const DUMMY = Buffer.alloc(0);
-
-const DEFAULT_TTL = 21600;
-
-const hsTypes = {
-  DS: 0,
-  NS: 1,
-  GLUE4: 2,
-  GLUE6: 3,
-  SYNTH4: 4,
-  SYNTH6: 5,
-  TXT: 6
-};
-
-const hsTypesByVal = {
-  [hsTypes.DS]: 'DS',
-  [hsTypes.NS]: 'NS',
-  [hsTypes.GLUE4]: 'GLUE4',
-  [hsTypes.GLUE6]: 'GLUE6',
-  [hsTypes.SYNTH4]: 'SYNTH4',
-  [hsTypes.SYNTH6]: 'SYNTH6',
-  [hsTypes.TXT]: 'TXT'
-};
 
 /**
  * Resource
@@ -280,17 +254,14 @@ class Resource extends Struct {
     return zone;
   }
 
-  toReferral(name, type, tld) {
+  toReferral(name, type, isTLD) {
     const res = new Message();
 
     // no DS referrals for TLDs
-    const badReferral = tld && type === types.DS;
+    const badReferral = isTLD && type === types.DS;
 
     if (this.hasNS() && !badReferral) {
-      res.authority = [
-        ...this.toNS(name),
-        ...this.toDS(name)
-      ];
+      res.authority = this.toNS(name).concat(this.toDS(name));
 
       res.additional = this.toGlue(name);
 
@@ -315,7 +286,7 @@ class Resource extends Struct {
   toNSEC(name) {
     let typeMap = TYPE_MAP_EMPTY;
 
-    if(this.hasNS())
+    if (this.hasNS())
       typeMap = TYPE_MAP_NS;
     else if (this.hasType(hsTypes.TXT))
       typeMap = TYPE_MAP_TXT;
@@ -358,8 +329,7 @@ class Resource extends Struct {
     }
 
     // Nope, we may need a referral
-    if (res.answer.length === 0
-      && res.authority.length === 0) {
+    if (res.answer.length === 0 && res.authority.length === 0) {
       return this.toReferral(name, type, true);
     }
 
@@ -968,8 +938,6 @@ function createAAAA(name, ttl, address) {
  * Expose
  */
 
-exports.types = hsTypes;
-exports.typesByVal = hsTypesByVal;
 exports.Resource = Resource;
 exports.DS = DS;
 exports.NS = NS;

--- a/lib/dns/resource.js
+++ b/lib/dns/resource.js
@@ -12,6 +12,7 @@ const base32 = require('bcrypto/lib/encoding/base32');
 const {IP} = require('binet');
 const bio = require('bufio');
 const key = require('./key');
+const nsec = require('./nsec');
 const {Struct} = bio;
 
 const {
@@ -36,6 +37,12 @@ const {
   DSRecord,
   types
 } = wire;
+
+const {
+  TYPE_MAP_EMPTY,
+  TYPE_MAP_NS,
+  TYPE_MAP_TXT
+} = nsec;
 
 /*
  * Constants
@@ -273,10 +280,13 @@ class Resource extends Struct {
     return zone;
   }
 
-  toReferral(name) {
+  toReferral(name, type, tld) {
     const res = new Message();
 
-    if (this.hasNS()) {
+    // no DS referrals for TLDs
+    const badReferral = tld && type === types.DS;
+
+    if (this.hasNS() && !badReferral) {
       res.authority = [
         ...this.toNS(name),
         ...this.toDS(name)
@@ -284,18 +294,33 @@ class Resource extends Struct {
 
       res.additional = this.toGlue(name);
 
-      // Note: should have nsec unsigned zone proof.
       if (this.hasDS()) {
-        // DS records are the only record type
-        // the root zone is actually authoritative over.
-        res.aa = true;
         key.signZSK(res.authority, types.DS);
+      } else {
+        // unsigned zone proof
+        res.authority.push(this.toNSEC(name));
+        key.signZSK(res.authority, types.NSEC);
       }
     } else {
       // Needs SOA.
+      res.aa = true;
+      // negative answer proof
+      res.authority.push(this.toNSEC(name));
+      key.signZSK(res.authority, types.NSEC);
     }
 
     return res;
+  }
+
+  toNSEC(name) {
+    let typeMap = TYPE_MAP_EMPTY;
+
+    if(this.hasNS())
+      typeMap = TYPE_MAP_NS;
+    else if (this.hasType(hsTypes.TXT))
+      typeMap = TYPE_MAP_TXT;
+
+    return nsec.create(name, nsec.nextName(name), typeMap);
   }
 
   toDNS(name, type) {
@@ -307,7 +332,7 @@ class Resource extends Struct {
     // Referral.
     if (labels.length > 1) {
       const tld = util.from(name, labels, -1);
-      return this.toReferral(tld);
+      return this.toReferral(tld, type, false);
     }
 
     // Potentially an answer.
@@ -318,10 +343,6 @@ class Resource extends Struct {
     // and therefore are not signed by the root ZSK.
     // The only records root is authoritative over is DS.
     switch (type) {
-      case types.NS:
-        res.authority = this.toNS(name);
-        res.additional = this.toGlue(name);
-        break;
       case types.TXT:
         if (!this.hasNS()) {
           res.aa = true;
@@ -336,10 +357,10 @@ class Resource extends Struct {
         break;
     }
 
-    // Nope, we need a referral.
+    // Nope, we may need a referral
     if (res.answer.length === 0
-        && res.authority.length === 0) {
-      return this.toReferral(name);
+      && res.authority.length === 0) {
+      return this.toReferral(name, type, true);
     }
 
     return res;

--- a/lib/dns/server.js
+++ b/lib/dns/server.js
@@ -22,6 +22,12 @@ const reserved = require('../covenants/reserved');
 const {Resource} = require('./resource');
 const key = require('./key');
 const nsec = require('./nsec');
+const {
+  DEFAULT_TTL,
+  TYPE_MAP_ROOT,
+  TYPE_MAP_EMPTY,
+  TYPE_MAP_NS
+} = require('./common');
 
 const {
   DNSServer,
@@ -40,12 +46,6 @@ const {
   types,
   codes
 } = wire;
-
-const {
-  TYPE_MAP_ROOT,
-  TYPE_MAP_EMPTY,
-  TYPE_MAP_NS
-} = nsec;
 
 /*
  * Constants
@@ -417,15 +417,13 @@ class RootServer extends DNSServer {
       // https://tools.ietf.org/html/rfc4470
 
       // Proving the name doesn't exist
-      const nameSet = [];
       const prev = nsec.prevName(tld);
       const next = nsec.nextName(tld);
-      nameSet.push(nsec.create(prev, next, TYPE_MAP_EMPTY));
+      const nameSet = [nsec.create(prev, next, TYPE_MAP_EMPTY)];
       key.signZSK(nameSet, types.NSEC);
 
       // Proving a wildcard doesn't exist
-      const wildcardSet = [];
-      wildcardSet.push(nsec.create('!.', '+.', TYPE_MAP_EMPTY));
+      const wildcardSet = [nsec.create('!.', '+.', TYPE_MAP_EMPTY)];
       key.signZSK(wildcardSet, types.NSEC);
 
       res.authority = res.authority.concat(nameSet, wildcardSet);
@@ -529,7 +527,7 @@ class RootServer extends DNSServer {
     rd.refresh = 1800;
     rd.retry = 900;
     rd.expire = 604800;
-    rd.minttl = 86400;
+    rd.minttl = DEFAULT_TTL;
 
     return rr;
   }
@@ -752,7 +750,7 @@ function toKey(name, type) {
 function hasValidOwner(section, owner) {
   owner = util.fqdn(owner);
 
-  for(const rr of section) {
+  for (const rr of section) {
     if (rr.type === types.NS)
       continue;
 

--- a/lib/dns/server.js
+++ b/lib/dns/server.js
@@ -21,6 +21,7 @@ const rules = require('../covenants/rules');
 const reserved = require('../covenants/reserved');
 const {Resource} = require('./resource');
 const key = require('./key');
+const nsec = require('./nsec');
 
 const {
   DNSServer,
@@ -36,18 +37,19 @@ const {
   AAAARecord,
   NSRecord,
   SOARecord,
-  NSECRecord,
   types,
   codes
 } = wire;
+
+const {
+  TYPE_MAP_ROOT,
+  TYPE_MAP_EMPTY
+} = nsec;
 
 /*
  * Constants
  */
 
-// NS SOA RRSIG NSEC DNSKEY
-// Possibly add A, AAAA, and DS
-const TYPE_MAP = Buffer.from('000722000000000380', 'hex');
 const RES_OPT = { inet6: false, tcp: true };
 const CACHE_TTL = 30 * 60 * 1000;
 
@@ -211,9 +213,6 @@ class RootServer extends DNSServer {
     if (!this.lookup)
       throw new Error('Tree not available.');
 
-    if (!rules.verifyName(name))
-      return null;
-
     const hash = rules.hashName(name);
     const data = await this.lookup(hash);
 
@@ -280,7 +279,7 @@ class RootServer extends DNSServer {
           key.signZSK(res.answer, types.DS);
           break;
         default:
-          // Empty Proof:
+          // Minimally covering NSEC proof:
           res.authority.push(this.toNSEC());
           key.signZSK(res.authority, types.NSEC);
           res.authority.push(this.toSOA());
@@ -320,6 +319,20 @@ class RootServer extends DNSServer {
       res.answer.push(rr);
       key.signZSK(res.answer, rr.type);
 
+      return res;
+    }
+
+    // REFUSED for invalid names
+    // this simplifies NSEC proofs
+    // by avoiding octets like \000
+    // Also, this decreases load on
+    // the server since it avoids signing
+    // useless proofs for invalid TLDs
+    // (These requests are most
+    // likely bad anyways)
+    if (!rules.verifyName(tld)) {
+      const res = new Message();
+      res.code = codes.REFUSED;
       return res;
     }
 
@@ -368,11 +381,23 @@ class RootServer extends DNSServer {
       // not possible for SPV nodes since they
       // can't arbitrarily iterate over the tree.
       //
-      // Instead, we give a phony proof, which
-      // makes the root zone look empty.
-      res.authority.push(this.toNSEC());
-      res.authority.push(this.toNSEC());
-      key.signZSK(res.authority, types.NSEC);
+      // Instead, we give a minimally covering
+      // NSEC record based on rfc4470
+      // https://tools.ietf.org/html/rfc4470
+
+      // Proving the name doesn't exist
+      const nameSet = [];
+      const prev = nsec.prevName(tld);
+      const next = nsec.nextName(tld);
+      nameSet.push(nsec.create(prev, next, TYPE_MAP_EMPTY));
+      key.signZSK(nameSet, types.NSEC);
+
+      // Proving a wildcard doesn't exist
+      const wildcardSet = [];
+      wildcardSet.push(nsec.create('!.', '+.', TYPE_MAP_EMPTY));
+      key.signZSK(wildcardSet, types.NSEC);
+
+      res.authority = res.authority.concat(nameSet, wildcardSet);
       res.authority.push(this.toSOA());
       key.signZSK(res.authority, types.SOA);
 
@@ -514,15 +539,8 @@ class RootServer extends DNSServer {
   }
 
   toNSEC() {
-    const rr = new Record();
-    const rd = new NSECRecord();
-    rr.name = '.';
-    rr.type = types.NSEC;
-    rr.ttl = 86400;
-    rr.data = rd;
-    rd.nextDomain = '.';
-    rd.typeBitmap = TYPE_MAP;
-    return rr;
+    const next = nsec.nextName('.');
+    return nsec.create('.', next, TYPE_MAP_ROOT);
   }
 }
 

--- a/lib/dns/server.js
+++ b/lib/dns/server.js
@@ -43,7 +43,8 @@ const {
 
 const {
   TYPE_MAP_ROOT,
-  TYPE_MAP_EMPTY
+  TYPE_MAP_EMPTY,
+  TYPE_MAP_NS
 } = nsec;
 
 /*
@@ -350,12 +351,46 @@ class RootServer extends DNSServer {
         const res = await this.icann.lookup(tld);
 
         if (res.ad && res.code !== codes.NXDOMAIN) {
+          // answer must be a referral since lookup
+          // function always asks for NS
+          assert(res.code === codes.NOERROR);
+          assert(res.answer.length === 0);
+          assert(hasValidOwner(res.authority, tld));
+
           res.ad = false;
-          res.aa = true;
           res.question = [qs];
-          key.signZSK(res.authority, types.DS);
-          key.signZSK(res.authority, types.NSEC);
-          key.signZSK(res.authority, types.NSEC3);
+          const secure = util.hasType(res.authority, types.DS);
+
+          // no DS referrals for TLDs
+          if (type === types.DS && labels.length === 1) {
+            const dsSet = util.extractSet(res.authority,
+              util.fqdn(tld), types.DS);
+
+            res.aa = true;
+            res.answer = dsSet;
+            key.signZSK(res.answer, types.DS);
+            res.authority = [];
+            res.additional = [];
+
+            if (res.answer.length === 0) {
+              res.authority.push(this.toSOA());
+              key.signZSK(res.authority, types.SOA);
+            }
+          }
+
+          // No DS we must add a minimally covering proof
+          if (!secure) {
+            // Replace any NSEC/NSEC3 records
+            const filterTypes = [types.NSEC, types.NSEC3];
+            res.authority = util.filterSet(res.authority, ...filterTypes);
+            const next = nsec.nextName(tld);
+            const rr = nsec.create(tld, next, TYPE_MAP_NS);
+            res.authority.push(rr);
+            key.signZSK(res.authority, types.NSEC);
+          } else {
+            key.signZSK(res.authority, types.DS);
+          }
+
           return res;
         }
       }
@@ -712,6 +747,20 @@ function toKey(name, type) {
   key += type.toString(10);
 
   return key;
+}
+
+function hasValidOwner(section, owner) {
+  owner = util.fqdn(owner);
+
+  for(const rr of section) {
+    if (rr.type === types.NS)
+      continue;
+
+    if (!util.equal(rr.name, owner))
+      return false;
+  }
+
+  return true;
 }
 
 /*

--- a/lib/dns/server.js
+++ b/lib/dns/server.js
@@ -404,9 +404,7 @@ class RootServer extends DNSServer {
     const resource = Resource.decode(data);
     const res = resource.toDNS(name, type);
 
-    if (res.answer.length === 0
-        && res.authority.length === 0) {
-      res.aa = true;
+    if (res.answer.length === 0 && res.aa) {
       res.authority.push(this.toSOA());
       key.signZSK(res.authority, types.SOA);
     }

--- a/lib/dns/server.js
+++ b/lib/dns/server.js
@@ -274,10 +274,6 @@ class RootServer extends DNSServer {
           res.answer.push(key.zsk.deepClone());
           key.signKSK(res.answer, types.DNSKEY);
           break;
-        case types.DS:
-          res.answer.push(key.ds.deepClone());
-          key.signZSK(res.answer, types.DS);
-          break;
         default:
           // Minimally covering NSEC proof:
           res.authority.push(this.toNSEC());

--- a/test/data/ns-icann.json
+++ b/test/data/ns-icann.json
@@ -1,0 +1,118 @@
+{
+  "com.": {
+    "id": 0,
+    "opcode": "QUERY",
+    "code": "NOERROR",
+    "qr": true,
+    "aa": false,
+    "tc": false,
+    "rd": false,
+    "ra": false,
+    "z": false,
+    "ad": true,
+    "cd": false,
+    "question": [
+      {
+        "name": "com.",
+        "class": "IN",
+        "type": "NS"
+      }
+    ],
+    "answer": [
+    ],
+    "authority": [
+      {
+        "name": "com.",
+        "ttl": 172800,
+        "class": "IN",
+        "type": "NS",
+        "data": {
+          "ns": "a.gtld-servers.net."
+        }
+      },
+      {
+        "name": "com.",
+        "ttl": 86400,
+        "class": "IN",
+        "type": "DS",
+        "data": {
+          "keyTag": 30909,
+          "algorithm": 8,
+          "digestType": 2,
+          "digest": "e2d3c916f6deeac73294e8268fb5885044a833fc5459588f4a9184cfc41a5766",
+          "algName": "RSASHA256",
+          "hashName": "SHA256"
+        }
+      }
+    ],
+    "additional": [
+      {
+        "name": "a.gtld-servers.net.",
+        "ttl": 172800,
+        "class": "IN",
+        "type": "A",
+        "data": {
+          "address": "192.5.6.30"
+        }
+      }
+    ]
+  },
+  "cf.": {
+    "id":0,
+    "opcode":"QUERY",
+    "code":"NOERROR",
+    "qr":true,
+    "aa":false,
+    "tc":false,
+    "rd":false,
+    "ra":false,
+    "z":false,
+    "ad":true,
+    "cd":false,
+    "question":[
+      {
+        "name":"cf.",
+        "class":"IN",
+        "type":"NS"
+      }
+    ],
+    "answer":[
+    ],
+    "authority":[
+      {
+        "name":"cf.",
+        "ttl":172800,
+        "class":"IN",
+        "type":"NS",
+        "data":{
+          "ns":"a.ns.cf."
+        }
+      },
+      {
+        "name":"cf.",
+        "ttl":86400,
+        "class":"IN",
+        "type":"NSEC",
+        "data":{
+          "nextDomain":"cfa.",
+          "typeBitmap":[
+            2,
+            46,
+            47
+          ]
+        }
+      }
+    ],
+    "additional":[
+      {
+        "name":"a.ns.cf.",
+        "ttl":172800,
+        "class":"IN",
+        "type":"A",
+        "data":{
+          "address":"185.21.168.17"
+        }
+      }
+    ]
+  }
+}

--- a/test/data/ns-names.json
+++ b/test/data/ns-names.json
@@ -1,0 +1,58 @@
+{
+  "0c452105532473920739ba0da9ede7f1da8c8eb9c23fd089be97a486ee23bdc9":
+  {
+    "name": "proofofconcept",
+    "records": [
+      {
+        "type": "GLUE4",
+        "ns": "ns.proofofconcept.",
+        "address": "127.0.0.1"
+      },
+      {
+        "type": "TXT",
+        "txt": [
+          "A simple social network for Handshake"
+        ]
+      },
+      {
+        "type": "DS",
+        "keyTag": 17552,
+        "algorithm": 8,
+        "digestType": 2,
+        "digest": "bbbe70af5cd965360442cbef40e3299344af493d339592b93daa29f7839c1d58"
+      }
+    ]
+  },
+  "b92ad996982b44fbea27d833c52e3fb0d6192d63835a13c61dfeb0126e2ee2ef":
+  {
+    "name": "nb",
+    "records": [
+      {
+        "type": "GLUE4",
+        "ns": "ns1.nb.",
+        "address": "127.0.0.1"
+      },
+      {
+        "type": "NS",
+        "ns": "ns1.nb."
+      }
+    ]
+  },
+  "bc288c7f5acb52989a274384dc65e49872b13f9ef9be9dc26f398e1b3c0df356":
+  {
+    "name": "schematic",
+    "records": [
+      {
+        "type": "TXT",
+        "txt": [
+          "a text record"
+        ]
+      }
+    ]
+  },
+  "1478e0b76739f400397c4315aa7eb10ad0b45116b3ccf3b8b735345c23f56091":
+  {
+    "name": "empty-name",
+    "records": []
+  }
+}

--- a/test/ns-test.js
+++ b/test/ns-test.js
@@ -1,11 +1,14 @@
 'use strict';
 
 const assert = require('bsert');
-const {wire} = require('bns');
+const {wire, util, encoding} = require('bns');
 const {RootServer} = require('../lib/dns/server');
 const {Resource} = require('../lib/dns/resource');
 const NameState = require('../lib/covenants/namestate');
 const rules = require('../lib/covenants/rules');
+const nsec = require('../lib/dns/nsec.js');
+const nameData = require('./data/ns-names.json');
+const icannData = require('./data/ns-icann.json');
 
 describe('RootServer', function() {
   const ns = new RootServer({
@@ -267,3 +270,334 @@ describe('RootServer Plugins', function() {
     assert.strictEqual(sig.type, wire.types.RRSIG);
   });
 });
+
+describe('RootServer DNSSEC', function () {
+  const ns = new RootServer({
+    port: 25349, // regtest
+    lookup: (hash) => {
+      assert(hash instanceof Buffer);
+      const key = hash.toString('hex');
+      const data = nameData[key];
+      if (!data)
+        return null;
+
+      const namestate = new NameState();
+      namestate.data = Resource.fromJSON(data).encode();
+      return namestate.encode();
+    }
+  });
+
+  ns.icann = {
+    lookup: (name) => {
+      name = util.fqdn(name);
+      const data = icannData[name];
+
+      if (data)
+        return wire.Message.fromJSON(data);
+
+      const res = new wire.Message();
+      res.code = wire.codes.NXDOMAIN;
+      res.ad = true;
+      return res;
+    }
+  };
+
+  before(async () => {
+    await ns.open();
+  });
+
+  after(async () => {
+    await ns.close();
+  });
+
+  const resolve = (qname, qtype) => {
+    const req = {
+      question: [
+        new wire.Question(qname, qtype)
+      ]
+    };
+    return ns.resolve(req);
+  };
+
+  it('should refuse invalid names', async () => {
+    const qname = 'example\\000';
+    const res = await resolve(qname, wire.types.NS);
+    assert.strictEqual(res.code, wire.codes.REFUSED);
+  });
+
+  it('should prove NXDOMAIN', async () => {
+    const qnames = [
+      'icecream.',
+      'this-domain-name-has-sixty-three-octets-taking-max-label-length.'
+    ];
+
+    for(const qname of qnames) {
+      const res = await resolve(qname, wire.types.NS);
+      assert(res.aa);
+      assert.strictEqual(res.code, wire.codes.NXDOMAIN);
+      assert.strictEqual(res.answer.length, 0);
+      assert.strictEqual(res.additional.length, 0);
+      assert(util.hasType(res.authority, wire.types.SOA));
+
+      const nameProof = findCoveringNSEC(res.authority, qname);
+      assert(nameProof.found);
+    }
+  });
+
+  it('should create minimally covering NSEC records', async () => {
+    const qname = 'icecream.';
+    const res = await resolve(qname, wire.types.NS);
+
+    assert(res.aa);
+    assert.strictEqual(res.code, wire.codes.NXDOMAIN);
+    assert.strictEqual(res.answer.length, 0);
+    assert.strictEqual(res.additional.length, 0);
+
+    const authority = res.authority;
+    assert(util.hasType(authority, wire.types.SOA));
+
+    const nameProof = findCoveringNSEC(authority, qname);
+    assert(nameProof.found);
+
+    // no other names must be covered by the 'icecream.' proof
+    // names like 'icecreal\255a.' are covered but these octets
+    // are not allowed in the root zone
+    // these are close names to 'icecream.'
+    const closeNames = ['icecreal.', 'icecrean.',
+      'icecreal0.', 'icecrea-a.', 'icecreama.'];
+
+    for(const name of closeNames) {
+      const covering = findCoveringNSEC(authority, name);
+      assert(!covering.found);
+    }
+
+    const wildcard = nameProof.wildcardNSEC;
+    // test it minimally covers wildcard
+    // characters like ",#,$,%,&,',),(,* are covered
+    // but not allowed in the root zone
+    assert(!cover('0.', wildcard.name, wildcard.data.nextDomain));
+    assert(!cover('a-m.', wildcard.name, wildcard.data.nextDomain));
+    assert(!cover('z.', wildcard.name, wildcard.data.nextDomain));
+  });
+
+  it('should prove non-existence of a type in the zone apex', async () => {
+    const qname = '.';
+    const res = await resolve(qname, wire.types.A);
+    assert(res.aa);
+    assert.strictEqual(res.code, wire.codes.NOERROR);
+    assert.strictEqual(res.answer.length, 0);
+    assert.strictEqual(res.additional.length, 0);
+    assert(util.hasType(res.authority, wire.types.SOA));
+
+    // check NSEC proof
+    const set = util.extractSet(res.authority, qname, wire.types.NSEC);
+    assert.strictEqual(set.length, 1);
+    const proof = set[0];
+
+    assert.strictEqual(proof.data.typeBitmap, nsec.TYPE_MAP_ROOT);
+    assert(cover('.', proof.name, proof.data.nextDomain));
+    assert(!cover('0.', proof.name, proof.data.nextDomain));
+    assert(!cover('aa.', proof.name, proof.data.nextDomain));
+  });
+
+  // Some tests must check both Handshake
+  // and ICANN names
+  //
+  // In the test data:
+  // 'proofofconcept.' and 'com.' are signed zones
+  // 'nb.' and 'cf.' are unsigned (no DS record)
+  // 'schematic.' only contains a TXT record.
+  // 'empty-name' has no records.
+  it('should be authoritative over DS for names in the root zone', async () => {
+    // example:
+    // ;; QUESTION
+    // ;proofofconcept.  IN    DS
+    //
+    // 1. Answer must have AA bit.
+    // 2. DS record must be in the answers section
+    const qnames = ['proofofconcept.', 'com.'];
+
+    for(const qname of qnames) {
+      const res = await resolve(qname, wire.types.DS);
+      assert(res.aa);
+      assert.strictEqual(res.code, wire.codes.NOERROR);
+      assert.strictEqual(res.answer.length, 2);
+      assert.strictEqual(res.authority.length, 0);
+      assert.strictEqual(res.additional.length, 0);
+      assert(util.hasType(res.answer, wire.types.DS));
+    }
+  });
+
+  it('should add DS to referral answers', async () => {
+    // ;; QUESTION
+    // ;proofofconcept.  IN    A
+    //
+    // 1. no AA bit
+    // 2. DS record in authority section
+    const queries = [
+      {qname: 'proofofconcept.', qtype: wire.types.A},
+      {qname: 'proofofconcept.', qtype: wire.types.NS},
+      {qname: 'example.proofofconcept.', qtype: wire.types.AAAA},
+      {qname: 'com.', qtype: wire.types.A},
+      {qname: 'com.', qtype: wire.types.NS},
+      {qname: 'example.com.', qtype: wire.types.AAAA},
+      // delegated sub-tree DS must NOT be authoritative
+      {qname: 'example.proofofconcept.', qtype: wire.types.DS},
+      {qname: 'example.com.', qtype: wire.types.DS}
+    ];
+
+    for (const q of queries) {
+      const res = await resolve(q.qname, q.qtype);
+      assert(!res.aa);
+      assert.strictEqual(res.code, wire.codes.NOERROR);
+      assert.strictEqual(res.answer.length, 0);
+
+      assert(util.hasType(res.authority, wire.types.DS));
+      assert(util.hasType(res.authority, wire.types.NS));
+      assert(!util.hasType(res.authority, wire.types.SOA));
+    }
+  });
+
+  it('should add insecure delegation proof to DS lookups', async () => {
+    // example:
+    // ;; QUESTION
+    // ;nb.  IN    DS
+    //
+    // 1. Answer must have the AA bit
+    // 2. NSEC in authority section
+    const qnames = ['nb.', 'cf.'];
+
+    for(const qname of qnames) {
+      const res = await resolve(qname, wire.types.DS);
+      assert(res.aa);
+      assert.strictEqual(res.code, wire.codes.NOERROR);
+      assert.strictEqual(res.answer.length, 0);
+      assert.strictEqual(res.additional.length, 0);
+      assert(util.hasType(res.authority, wire.types.SOA));
+
+      const set = util.extractSet(res.authority, qname, wire.types.NSEC);
+      assert.strictEqual(set.length, 1);
+      const proof = set[0];
+      // NSEC must be exact match
+      assert.strictEqual(qname, proof.name);
+      assert.strictEqual(proof.data.typeBitmap, nsec.TYPE_MAP_NS);
+    }
+  });
+
+  it('should add insecure delegation proof to referral answers', async () => {
+    // example:
+    // ;; QUESTION
+    // ;nb.  IN    A
+    //
+    // 1. Answer must be referral (no AA bit)
+    // 2. DS record in authority section
+    const queries = [
+      {name: 'nb.', type: wire.types.NS},
+      {name: 'nb.', type: wire.types.AAAA},
+      {name: 'dot.nb.', type: wire.types.A},
+      {name: 'cf.', type: wire.types.NS},
+      {name: 'cf.', type: wire.types.AAAA},
+      {name: 'dot.cf.', type: wire.types.A}
+    ];
+
+    for (const q of queries) {
+      const res = await resolve(q.name, q.type);
+      assert(!res.aa);
+      assert.strictEqual(res.code, wire.codes.NOERROR);
+      assert.strictEqual(res.answer.length, 0);
+      assert(!util.hasType(res.authority, wire.types.SOA));
+
+      // must have NSEC
+      const labels = util.split(q.name);
+      let tld = util.label(q.name, labels, -1);
+      tld = util.fqdn(tld);
+
+      const set = util.extractSet(res.authority, tld, wire.types.NSEC);
+      assert.strictEqual(set.length, 1);
+      assert.strictEqual(set[0].data.typeBitmap, nsec.TYPE_MAP_NS);
+    }
+  });
+
+  it('should prove non-existence of a type for non-delegated names', async () => {
+    // ;; QUESTION
+    // ;schematic.  IN    A
+    //
+    // the names 'schematic' and 'empty-name'
+    // don't have NS records so we are authoritative
+    // over all records (root zone only supports TXT)
+    // we must add a proof showing which
+    // types exist to prove non-existence
+    // of the requested type
+    const queries = [
+      {name: 'schematic.', type: wire.types.A, bitmap: nsec.TYPE_MAP_TXT},
+      {name: 'empty-name.', type: wire.types.TXT, bitmap: nsec.TYPE_MAP_EMPTY}
+    ];
+
+    for (const query of queries) {
+      const res = await resolve(query.name, query.type);
+      assert(res.aa);
+      assert.strictEqual(res.code, wire.codes.NOERROR);
+      assert.strictEqual(res.answer.length, 0);
+      assert.strictEqual(res.additional.length, 0);
+      assert(util.hasType(res.authority, wire.types.SOA));
+
+      const set = util.extractSet(res.authority, query.name, wire.types.NSEC);
+      assert.strictEqual(set.length, 1);
+      const proof = set[0];
+      assert.strictEqual(proof.data.typeBitmap, query.bitmap);
+    }
+  });
+});
+
+/*
+ * Helpers
+ */
+
+// compare two labels lexicographically
+function compare(a, b) {
+  // 63 octets + 2 octets for length and zero suffix.
+  const buf = Buffer.alloc(65 * 2);
+
+  // convert to wire format
+  const [off1, lc1] = encoding.writeName(buf, a, 0, null, false);
+  const [off2, lc2] = encoding.writeName(buf, b, 65, null, false);
+  assert(lc1 === 1 && lc1 === lc2);
+
+  const name1 = buf.slice(1, off1 - 1);
+  const name2 = buf.slice(66, off2 - 1);
+  return name1.compare(name2);
+}
+
+// tests whether sname is between owner and next.
+function cover(sname, owner, next) {
+  return compare(owner, sname) <= 0 &&
+    compare(next, sname) === 1;
+}
+
+// finds a covering NSEC record for sname in section
+// and an NSEC record for the wildcard.
+function findCoveringNSEC(section, sname) {
+  const result = {
+    found: false,
+    nameNSEC: null,
+    wildcardNSEC: null
+  };
+
+  for (const rr of section) {
+    if (rr.type !== wire.types.NSEC)
+      continue;
+
+    if (cover(sname, rr.name, rr.data.nextDomain)) {
+      result.nameNSEC = rr;
+      continue;
+    }
+
+    if (cover('*.', rr.name, rr.data.nextDomain))
+      result.wildcardNSEC = rr;
+  }
+
+  result.found = result.nameNSEC !== null
+    && result.wildcardNSEC !== null;
+
+  return result;
+}

--- a/test/resource-test.js
+++ b/test/resource-test.js
@@ -110,7 +110,7 @@ describe('Resource', function() {
     const res = Resource.fromJSON(json);
     const msg = res.toDNS('hns.', types.TXT);
 
-    assert(msg.aa);
+    assert(!msg.aa);
     assert(msg.answer.length === 0);
   });
 


### PR DESCRIPTION
This PR uses epsilon functions optimized for handshake root zone based on [RFC4470](https://tools.ietf.org/html/rfc4470) to find minimally covering NSEC records. 

Closes #574 and closes #513 (a minor change is needed in bns to check for bogus but shouldn't require other changes in hsd)

One issue with compact NSEC proofs is that due to qname minimization a compact proof may require multiple NODATA lookups `test.example.doesntexist` may need three lookups. The change to these proofs was adding a wildcard NSEC record to get NXDOMAIN responses. The response is a tiny bit larger (only for NXDOMAIN case) than compact proofs (~400 bytes vs. ~524 bytes for average length names) but covers all names underneath the TLD limits the number of proofs that need to be signed.

This PR fixes dnssec denial of existence in hsd root server (which is important for DANE) and several other inconsistencies related to how DS and referrals are handled necessary to make NSEC/DS answers valid. It makes hsd root server compatible with external recursive resolvers like Bind, Unbound, Knot resolver ... etc without having to disable DNSSEC or ignore bogus errors in libunbound used by hsd.

### Summary of changes:

* Replaces empty zone proofs with minimally covering NSEC records
* Fix ICANN insecure delegation proofs 
* No referrals for negative DS answers since root zone is authoritative (referral answers must only be for delegated sub-trees).
* Fix ICANN DS answers since it used to send referrals for all questions
* NSEC bitmap now shows correct types available for a name like TXT records (if no delegation)
* Clean up SOA and AA bit handling for handshake and ICANN names
* Remove DS from root zone it should only exist in parent zone 

I added tests that have examples of these changes and should cover various cases.

#### Edge cases

For weird queries like `dig @127.0.0.1 -p 5349 example\\000test a` this PR sends REFUSED.
this simplifies the predecessor/successor functions and avoids signing useless NXDOMAIN proofs for invalid names.

I was curious how Cloudflare deals with this and they avoid creating NSEC records for weird names. They send an NXDOMAIN response without signing it resulting in SERVFAIL `dig @8.8.8.8 example\\000test.cloudflare.com a` but I think it's better to send a REFUSED answer than an invalid answer. They do this because they have a special handling for this case in their 1.1.1.1 resolver