### PR TITLE
wallet-http: do not return until deepclean is done

### DIFF
--- a/lib/wallet/http.js
+++ b/lib/wallet/http.js
@@ -215,9 +215,9 @@ class HTTP extends Server {
         'Deep Clean requires I_HAVE_BACKED_UP_MY_WALLET=true'
       );
 
-      res.json(200, { success: true });
-
       await this.wdb.deepClean();
+
+      res.json(200, { success: true });
     });
 
     // Resend


### PR DESCRIPTION
This swaps 2 lines in wallet/http for `deepclean`, so the HTTP response does not return until walletDB is done with deep clean. It should be a relatively fast operation for most wallets (it doesn't have a built-in rescan any more). Worst case is the http request times out, but I think thats preferable to no one ever knowing when deep clean is done.