### PR TITLE
net: restore easyhandshake dns seed

### DIFF
--- a/lib/protocol/networks.js
+++ b/lib/protocol/networks.js
@@ -49,8 +49,8 @@ main.type = 'main';
  */
 
 main.seeds = [
-  'hs-mainnet.bcoin.ninja' // Christopher Jeffrey
-  // 'seed.easyhandshake.com' // Matthew Zipkin
+  'hs-mainnet.bcoin.ninja', // Christopher Jeffrey
+  'seed.easyhandshake.com' // Matthew Zipkin
 ];
 
 /**


### PR DESCRIPTION
Closes #540 

The easyhandshake DNS seed was disabled over a year ago in bbac8dd943767da62e46e52f93227b3da1048e17 when the network protocol version was bumbed (easyhandshake stayed on the old code to act like a "bridge" if the network partitioned). I think it's safe to put it back.

Reviewers can test by:
- `rm ~/.hsd/hosts.json`
- clear out the contents of the array in https://github.com/handshake-org/hsd/blob/master/lib/net/seeds/main.js
- start `hsd`

These log messages should be expected:

```
[warning] (net) Could not find enough peers.
[warning] (net) Hitting DNS seeds...
[info] (hostlist) Resolving host: hs-mainnet.bcoin.ninja.
[info] (hostlist) Resolving host: seed.easyhandshake.com.
...
[info] (net) Resolved 24 hosts from DNS seeds.
```

...followed by a healthy peer count and network connection.

Issue #540 also mentions signing the results with DNSSEC. I think that is a cool idea and could be added in a future PR to /lib/node/seeder.js -- However, I am upset that my hosting provider (Namecheap) doesn't allow me to insert a DS record in my zone `easyhandshake.com`. I can add an NS record (that's how the seeder works) and I can set Namecheap to sign my zone with DNSSEC, but there is no way to continue a secure chain of delegation! Bummer. Stay tuned on that one...

