### PR TITLE
Update documented reference for Git clone to https: URI.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ __HSD__ is an implementation of the [Handshake][handshake] Protocol.
 ### Building From Source
 
 ```
-$ git clone git://github.com/handshake-org/hsd.git
+$ git clone https://github.com/handshake-org/hsd.git
 $ cd hsd
 $ npm install --production
 $ ./bin/hsd


### PR DESCRIPTION
The git URI scheme usually implies the unsecured native Git protocol
which is vulnerable to man-in-the-middle attacks. Using TLS based HTTP
should be an obvious security improvement.