### PR TITLE
signmessage rejects multisig wallet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # HSD Release Notes & Changelog
 
+## unreleased
+### RPC Changes
+
+- New methods:
+  - `signmessagewithname`: Like `signmessage` but uses a name instead of an address. The owner's address will be used to sign the message.
+  - `verifymessagewithname`: Like `verifymessage` but uses a name instead of an address. The owner's address will be used to verify the message.
 ## v2.4.0
 
 ### Chain & Consensus changes

--- a/lib/wallet/rpc.js
+++ b/lib/wallet/rpc.js
@@ -1569,11 +1569,12 @@ class RPC extends RPCBase {
     const str = valid.str(1, '');
 
     const addr = parseAddress(b58, this.network);
-    if (addr.version !== 0 || addr.hash.length !== 20)
+    if (!addr.isPubkeyhash()) {
       throw new RPCError(
         errs.INVALID_ADDRESS_OR_KEY,
-        'Cannot sign with multisig wallet'
+        'Version 0 pubkeyhash address required for signing.'
       );
+    }
 
     const ring = await wallet.getKey(addr.getHash());
 

--- a/lib/wallet/rpc.js
+++ b/lib/wallet/rpc.js
@@ -1568,9 +1568,11 @@ class RPC extends RPCBase {
     const b58 = valid.str(0, '');
     const str = valid.str(1, '');
 
-    const addr = parseHash(b58, this.network);
+    const addr = parseAddress(b58, this.network);
+    if (addr.version !== 0 || addr.hash.length !== 20)
+      throw new RPCError(errs.INVALID_ADDRESS_OR_KEY, 'Cannot sign with multisig wallet');
 
-    const ring = await wallet.getKey(addr);
+    const ring = await wallet.getKey(addr.getHash());
 
     if (!ring)
       throw new RPCError(errs.WALLET_ERROR, 'Address not found.');

--- a/lib/wallet/rpc.js
+++ b/lib/wallet/rpc.js
@@ -1570,7 +1570,10 @@ class RPC extends RPCBase {
 
     const addr = parseAddress(b58, this.network);
     if (addr.version !== 0 || addr.hash.length !== 20)
-      throw new RPCError(errs.INVALID_ADDRESS_OR_KEY, 'Cannot sign with multisig wallet');
+      throw new RPCError(
+        errs.INVALID_ADDRESS_OR_KEY,
+        'Cannot sign with multisig wallet'
+      );
 
     const ring = await wallet.getKey(addr.getHash());
 

--- a/test/wallet-rpc-test.js
+++ b/test/wallet-rpc-test.js
@@ -312,5 +312,42 @@ describe('Wallet RPC Methods', function() {
       assert.strictEqual(info.walletid, 'primary');
       assert.strictEqual(info.height, node.chain.height);
     });
+
+    describe('multisig', () => {
+      const multiSigWalletId = 'foobar';
+
+      before(async () => {
+        // Create multisig wallet
+        const response = await wclient.createWallet(multiSigWalletId, {
+          type: 'multisig',
+          mnemonic: mnemonics[1][1],
+          passphrase:'secret456',
+          m: 2,
+          n: 2,
+        });
+        assert.equal(response.id, multiSigWalletId);
+        
+        await wclient.addSharedKey(multiSigWalletId, 'default', xpub.xpubkey(network.type))
+
+        const info = await wclient.getAccount(multiSigWalletId, 'default');
+        assert.equal(info.watchOnly, false);
+      });
+
+      it('should signmessage with address', async () => {
+        await wclient.execute('selectwallet', [multiSigWalletId]);
+        const address = await wclient.execute('getnewaddress');
+
+        await assert.rejects(async () => {
+          await wclient.execute('signmessage', [
+            address,
+            message
+          ]);
+        }, {
+          type: 'RPCError',
+          message: 'Invalid address.'
+        });
+      });
+    })
+    
   });
 });

--- a/test/wallet-rpc-test.js
+++ b/test/wallet-rpc-test.js
@@ -344,7 +344,7 @@ describe('Wallet RPC Methods', function() {
           ]);
         }, {
           type: 'RPCError',
-          message: 'Invalid address.'
+          message: 'Cannot sign with multisig wallet'
         });
       });
     })

--- a/test/wallet-rpc-test.js
+++ b/test/wallet-rpc-test.js
@@ -330,10 +330,12 @@ describe('Wallet RPC Methods', function() {
         await wclient.addSharedKey(multiSigWalletId, 'default', xpub.xpubkey(network.type));
 
         const info = await wclient.getAccount(multiSigWalletId, 'default');
+        assert.equal(info.initialized, true);
+        assert.equal(info.type, 'multisig');
         assert.equal(info.watchOnly, false);
       });
 
-      it('should signmessage with address', async () => {
+      it('should not signmessage with address from multisig wallet', async () => {
         await wclient.execute('selectwallet', [multiSigWalletId]);
         const address = await wclient.execute('getnewaddress');
 
@@ -344,7 +346,7 @@ describe('Wallet RPC Methods', function() {
           ]);
         }, {
           type: 'RPCError',
-          message: 'Cannot sign with multisig wallet'
+          message: 'Version 0 pubkeyhash address required for signing.'
         });
       });
     });

--- a/test/wallet-rpc-test.js
+++ b/test/wallet-rpc-test.js
@@ -323,11 +323,11 @@ describe('Wallet RPC Methods', function() {
           mnemonic: mnemonics[1][1],
           passphrase:'secret456',
           m: 2,
-          n: 2,
+          n: 2
         });
         assert.equal(response.id, multiSigWalletId);
-        
-        await wclient.addSharedKey(multiSigWalletId, 'default', xpub.xpubkey(network.type))
+
+        await wclient.addSharedKey(multiSigWalletId, 'default', xpub.xpubkey(network.type));
 
         const info = await wclient.getAccount(multiSigWalletId, 'default');
         assert.equal(info.watchOnly, false);
@@ -347,7 +347,6 @@ describe('Wallet RPC Methods', function() {
           message: 'Cannot sign with multisig wallet'
         });
       });
-    })
-    
+    });
   });
 });


### PR DESCRIPTION
#606 item 1: signmessage should only work for public-key-hash addresses.

Note: I'm reusing the `INVALID_ADDRESS_OR_KEY`, not sure if it would be better to have its own error code.