### PR TITLE
ci: switch to vendored jsdoc

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -13,7 +13,7 @@ jobs:
       with:
           node-version: 12.x
     - run: |
-        npm install -g jsdoc
+        npm install -g @hns-dev/bsdoc
         jsdoc -c jsdoc.json
     - name: Deploy
       uses: peaceiris/actions-gh-pages@v3

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -23,7 +23,7 @@ jobs:
 
     - name: Install
       run: sudo apt-get install -y libunbound-dev |
-           npm install nyc coveralls bslint jsdoc
+           npm install nyc coveralls bslint @hns-dev/bsdoc
 
     - name: Lint
       run: npm run lint


### PR DESCRIPTION
Needed to prevent CI failures [like this one](https://github.com/handshake-org/hsd/runs/2834823661?check_suite_focus=true) in the future by locking down dependencies that can introduce subtle errors [like this](https://github.com/markedjs/marked/issues/2106).

https://github.com/pinheadmz/bsdoc

https://www.npmjs.com/package/@hns-dev/bsdoc