### PR TITLE
wallet: enable re-claiming of reserved names using new protocol rules from recent soft fork

### DIFF
--- a/lib/covenants/ownership.js
+++ b/lib/covenants/ownership.js
@@ -14,6 +14,7 @@ const blake2b = require('bcrypto/lib/blake2b');
 const StubResolver = require('bns/lib/resolver/stub');
 const BNSOwnership = require('bns/lib/ownership');
 const consensus = require('../protocol/consensus');
+const Network = require('../protocol/network');
 const reserved = require('./reserved');
 const {Proof: BNSProof} = BNSOwnership;
 
@@ -116,6 +117,35 @@ class Ownership extends BNSOwnership {
     const prefix = network.claimPrefix;
 
     return util.startsWith(txt, prefix);
+  }
+
+  decodeData(txt, network) {
+    if (typeof network === 'string')
+      network = Network.get(network);
+
+    assert(network && typeof network.claimPrefix === 'string');
+
+    const prefix = network.claimPrefix;
+    const b32 = txt.substring(prefix.length);
+    const raw = base32.decode(b32);
+
+    const br = bio.read(raw);
+    const version = br.readU8();
+    const size = br.readU8();
+    const hash = br.readBytes(size);
+    const fee = br.readVarint();
+    const commitHash = br.readHash();
+    const commitHeight = br.readU32();
+
+    return {
+      address: {
+        version,
+        hash: hash.toString('hex')
+      },
+      fee,
+      commitHash: commitHash.toString('hex'),
+      commitHeight
+    };
   }
 
   parseData(proof, target, [txt], network) {

--- a/lib/wallet/client.js
+++ b/lib/wallet/client.js
@@ -9,6 +9,7 @@
 const assert = require('bsert');
 const {NodeClient} = require('hs-client');
 const TX = require('../primitives/tx');
+const Coin = require('../primitives/coin');
 const NameState = require('../covenants/namestate');
 
 const parsers = {
@@ -80,6 +81,11 @@ class WalletClient extends NodeClient {
   async getNameStatus(nameHash) {
     const json = await super.getNameStatus(nameHash);
     return NameState.fromJSON(json);
+  }
+
+  async getCoin(hash, index) {
+    const json = super.getCoin(hash, index);
+    return Coin.fromJSON(json);
   }
 }
 

--- a/lib/wallet/nodeclient.js
+++ b/lib/wallet/nodeclient.js
@@ -234,6 +234,17 @@ class NodeClient extends AsyncEmitter {
   async getNameStatus(nameHash) {
     return this.node.getNameStatus(nameHash);
   }
+
+  /**
+   * Get UTXO.
+   * @param {Hash} hash
+   * @param {Number} index
+   * @returns {Object}
+   */
+
+  async getCoin(hash, index) {
+    return this.node.getCoin(hash, index);
+  }
 }
 
 /*

--- a/lib/wallet/wallet.js
+++ b/lib/wallet/wallet.js
@@ -1372,7 +1372,7 @@ class Wallet extends EventEmitter {
 
     if (ns && !ns.owner.isNull()) {
       const coin = await this.wdb.getCoin(ns.owner.hash, ns.owner.index);
-      assert(coin);
+      assert(coin, 'Coin not found for name owner.');
       fee = item.value - coin.value;
     }
 

--- a/lib/wallet/wallet.js
+++ b/lib/wallet/wallet.js
@@ -1300,13 +1300,8 @@ class Wallet extends EventEmitter {
 
     const ns = await this.getNameState(nameHash);
 
-    if (ns) {
-      if (!ns.isExpired(height, network))
-        throw new Error('Name already claimed.');
-    } else {
-      if (!await this.wdb.isAvailable(nameHash))
-        throw new Error('Name is not available.');
-    }
+    if (!await this.wdb.isAvailable(nameHash))
+      throw new Error('Name is not available.');
 
     const item = reserved.get(nameHash);
     assert(item);
@@ -1364,20 +1359,20 @@ class Wallet extends EventEmitter {
     if (this.wdb.height < 1)
       throw new Error('Chain too immature for name claim.');
 
-    let commitHash = (await this.wdb.getBlock(1)).hash;
     let commitHeight = 1;
+    if (ns && ns.claimed)
+      commitHeight = ns.claimed + 1;
 
-    if (options.commitHeight != null) {
-      const block = await this.wdb.getBlock(options.commitHeight);
+    const commitHash = (await this.wdb.getBlock(commitHeight)).hash;
 
-      if (!block)
-        throw new Error('Block not found.');
+    let fee = Math.min(item.value, minFee);
 
-      commitHeight = block.height;
-      commitHash = block.hash;
+    if (ns && !ns.owner.isNull()) {
+      const coin = await this.getCoin(ns.owner.hash, ns.owner.index);
+      assert(coin);
+      fee = item.value - coin.value;
     }
 
-    const fee = Math.min(item.value, minFee);
     const acct = options.account || 0;
     const address = await this.receiveAddress(acct);
     const txt = ownership.createData(address,
@@ -1437,16 +1432,6 @@ class Wallet extends EventEmitter {
     // TODO: Handle expired behavior.
     if (!rules.isReserved(nameHash, height, network))
       throw new Error('Name is not reserved.');
-
-    const ns = await this.getNameState(nameHash);
-
-    if (ns) {
-      if (!ns.isExpired(height, network))
-        throw new Error('Name already claimed.');
-    } else {
-      if (!await this.wdb.isAvailable(nameHash))
-        throw new Error('Name is not available.');
-    }
 
     const {proof, txt} = await this._createClaim(name, options);
 

--- a/lib/wallet/wallet.js
+++ b/lib/wallet/wallet.js
@@ -1298,7 +1298,10 @@ class Wallet extends EventEmitter {
     if (!rules.isReserved(nameHash, height, network))
       throw new Error('Name is not reserved.');
 
-    const ns = await this.getNameState(nameHash);
+    // Must get this from chain (not walletDB) in case
+    // this name has already been claimed by an attacker
+    // and we are trying to replace that claim.
+    const ns = await this.wdb.getNameStatus(nameHash);
 
     if (!await this.wdb.isAvailable(nameHash))
       throw new Error('Name is not available.');
@@ -1368,13 +1371,14 @@ class Wallet extends EventEmitter {
     let fee = Math.min(item.value, minFee);
 
     if (ns && !ns.owner.isNull()) {
-      const coin = await this.getCoin(ns.owner.hash, ns.owner.index);
+      const coin = await this.wdb.getCoin(ns.owner.hash, ns.owner.index);
       assert(coin);
       fee = item.value - coin.value;
     }
 
     const acct = options.account || 0;
     const address = await this.receiveAddress(acct);
+
     const txt = ownership.createData(address,
                                      fee,
                                      commitHash,

--- a/lib/wallet/walletdb.js
+++ b/lib/wallet/walletdb.js
@@ -27,6 +27,7 @@ const records = require('./records');
 const NullClient = require('./nullclient');
 const layout = layouts.wdb;
 const tlayout = layouts.txdb;
+const {states} = require('../covenants/namestate');
 
 const {
   ChainState,
@@ -704,14 +705,17 @@ class WalletDB extends EventEmitter {
   }
 
   /**
-   * Test whether name is available.
+   * Test whether name is available for CLAIM.
    * @param {Buffer} nameHash
    * @returns {Boolean}
    */
 
   async isAvailable(nameHash) {
     const ns = await this.getNameStatus(nameHash);
-    return ns.state(this.height + 1, this.network) === 0;
+    const state = ns.state(this.height + 1, this.network);
+    return state === states.OPENING
+        || state === states.LOCKED
+        || (state === states.CLOSED && !ns.registered);
   }
 
   /**

--- a/lib/wallet/walletdb.js
+++ b/lib/wallet/walletdb.js
@@ -705,6 +705,17 @@ class WalletDB extends EventEmitter {
   }
 
   /**
+   * Get UTXO from node.
+   * @param {Hash} hash
+   * @param {Number} index
+   * @returns {Object}
+   */
+
+  async getCoin(hash, index) {
+    return this.client.getCoin(hash, index);
+  }
+
+  /**
    * Test whether name is available for CLAIM.
    * @param {Buffer} nameHash
    * @returns {Boolean}

--- a/test/claim-test.js
+++ b/test/claim-test.js
@@ -1,0 +1,176 @@
+/* eslint-env mocha */
+/* eslint prefer-arrow-callback: "off" */
+/* eslint no-implicit-coercion: "off" */
+
+'use strict';
+
+const assert = require('bsert');
+const Network = require('../lib/protocol/network');
+const Address = require('../lib/primitives/address');
+const FullNode = require('../lib/node/fullnode');
+const consensus = require('../lib/protocol/consensus');
+const ownership = require('../lib/covenants/ownership');
+const reserved = require('../lib/covenants/reserved');
+const {Resource} = require('../lib/dns/resource');
+
+const network = Network.get('regtest');
+
+const node = new FullNode({
+  memory: true,
+  network: 'regtest',
+  plugins: [require('../lib/wallet/plugin')]
+});
+
+const {wdb} = node.require('walletdb');
+let wallet, addr, claim, reclaim, rereclaim, finalOwner;
+
+const CLOUDFLARE = reserved.getByName('cloudflare');
+
+// Keep track of expected on-chain total value
+let AUDIT = consensus.GENESIS_REWARD;
+const REWARD = consensus.BASE_REWARD;
+
+function check() {
+  assert.strictEqual(AUDIT, node.chain.db.state.value);
+}
+
+async function mineBlocks(n, addr) {
+  addr = addr ? addr : new Address().toString('regtest');
+  for (let i = 0; i < n; i++) {
+    const block = await node.miner.mineBlock(null, addr);
+    await node.chain.add(block);
+    AUDIT += REWARD;
+  }
+
+  // Don't worry about decreasing block subsidies
+  if (node.chain.height >= network.halvingInterval)
+    assert(false, 'Too many blocks for this test!');
+}
+
+describe('Reserved Name Claims', function() {
+  before(async () => {
+    await node.open();
+
+    wallet = await wdb.create();
+    addr = await wallet.receiveAddress();
+  });
+
+  after(async () => {
+    await node.close();
+  });
+
+  // Reset the ownership flag after every test,
+  // even if the test fails. This should keep this
+  // modification isolated from other tests.
+  beforeEach(() => {
+    ownership.ignore = true;
+  });
+
+  afterEach(() => {
+    ownership.ignore = false;
+  });
+
+  it('should fund wallet', async () => {
+    await mineBlocks(20, addr);
+    check();
+  });
+
+  it('should send initial CLAIM', async () => {
+    claim = await wallet.sendFakeClaim('cloudflare');
+    check();
+    await mineBlocks(1);
+    AUDIT += CLOUDFLARE.value;
+    check();
+
+    // Miner got a fee from the CLAIM
+    const fee = claim.getFee(network);
+    const tip = await node.chain.getBlock(node.chain.tip.hash);
+    const cbOut = tip.txs[0].outputs[0].value;
+    assert.strictEqual(cbOut, REWARD + fee);
+  });
+
+  it('should send re-CLAIM', async () => {
+    reclaim = await wallet.sendFakeClaim('cloudflare');
+    check();
+    await mineBlocks(1);
+    check();
+
+    // Miner didn't get a fee from the re-CLAIM
+    const tip = await node.chain.getBlock(node.chain.tip.hash);
+    const cbOut = tip.txs[0].outputs[0].value;
+    assert.strictEqual(cbOut, REWARD);
+
+    // Initial claim and re-claim have same value & fee
+    // but commit to different blocks
+    const initial = claim.getData(network);
+    const update = reclaim.getData(network);
+    assert.strictEqual(initial.value, update.value);
+    assert.strictEqual(initial.fee, update.fee);
+    assert.notStrictEqual(initial.commitHeight, update.commitHeight);
+    assert.notStrictEqual(initial.commitHash, update.commitHash);
+  });
+
+  it('should send re-re-CLAIM', async () => {
+    rereclaim = await wallet.sendFakeClaim('cloudflare');
+    check();
+    await mineBlocks(1);
+    check();
+
+    // Miner didn't get a fee from the re-re-CLAIM
+    const tip = await node.chain.getBlock(node.chain.tip.hash);
+    const cbOut = tip.txs[0].outputs[0].value;
+    assert.strictEqual(cbOut, REWARD);
+
+    // Initial claim and re-claim have same value & fee
+    // but commit to different blocks
+    const initial = reclaim.getData(network);
+    const update = rereclaim.getData(network);
+    assert.strictEqual(initial.value, update.value);
+    assert.strictEqual(initial.fee, update.fee);
+    assert.notStrictEqual(initial.commitHeight, update.commitHeight);
+    assert.notStrictEqual(initial.commitHash, update.commitHash);
+
+    finalOwner = await node.chain.getCoin(tip.txs[0].hash(), 1);
+  });
+
+  it('should check UTXO set', async () => {
+    const state = node.chain.db.state;
+    assert.strictEqual(state.burned, 0);
+    assert.strictEqual(state.value, AUDIT);
+    // Genesis block coinbase is spendable
+    assert.strictEqual(state.tx, node.chain.height + 1);
+    // Only block subsidies and one CLAIM -- why just one
+    // even though we sent three claims? Because re-claims
+    // do not get counted in ChainState. Their value is
+    // also ignored, just like unsepndable `nulldata` outputs.
+    assert.strictEqual(state.coin, node.chain.height + 2);
+  });
+
+  it('should REGISTER reserved name', async () => {
+    const ns = await node.chain.db.getNameStateByName('cloudflare');
+    assert(ns);
+    assert(!ns.isNull());
+    const coin = await node.chain.db.getCoin(ns.owner.hash, ns.owner.index);
+    assert(coin);
+
+    await mineBlocks(network.names.lockupPeriod + 1);
+    check();
+
+    const resource = Resource.fromJSON({
+      records: [{type: 'TXT', txt: ['#CooperationGood']}]
+    });
+    const register = await wallet.sendUpdate('cloudflare', resource);
+    check();
+    await mineBlocks(1);
+    check();
+
+    // Register definitely spent the third CLAIM output
+    assert.bufferEqual(register.inputs[0].prevout.toKey(), finalOwner.toKey());
+  });
+
+  it('should check UTXO set again', async () => {
+    const state = node.chain.db.state;
+    // Claimed names have 0 value, nothing is burned
+    assert.strictEqual(state.burned, 0);
+  });
+});

--- a/test/claim-test.js
+++ b/test/claim-test.js
@@ -70,8 +70,8 @@ describe('Reserved Name Claims', function() {
     ownership.ignore = false;
   });
 
-  it('should fund wallet', async () => {
-    await mineBlocks(20, addr);
+  it('should fund wallet and activate soft fork', async () => {
+    await mineBlocks(network.deflationHeight + 1, addr);
     check();
   });
 

--- a/test/ownership-test.js
+++ b/test/ownership-test.js
@@ -1,0 +1,42 @@
+'use strict';
+
+const assert = require('bsert');
+const ownership = require('../lib/covenants/ownership');
+const Address = require('../lib/primitives/address');
+const Network = require('../lib/protocol/network');
+const network = Network.get('regtest');
+
+describe('Ownership', function() {
+  it('should encode / decode ownership TXT data', () => {
+    const block1Hash =
+      '0025f4480dadc61f13f507af9c9c9d06373fed38727ea467b6b2d5b09d522164';
+    const claim = {
+      name: 'bitcoin',
+      target: 'bitcoin.com.',
+      value: 503513487,
+      size: 4194,
+      fee: 20960,
+      address: 'rs1qjvvwkq2hq3cz5kmgz80v0a2l625ktdjtn60dpw',
+      txt: 'hns-regtest:aakjgghlaflqi4bklnubdxwh6vp5fklfwzf73ycraa' +
+           's7isanvxdb6e7va6xzzhe5ay3t73jyoj7kiz5wwlk3bhksefsacaaaaafk5pvj'
+    };
+
+    const claimAddress = Address.fromString(claim.address, 'regtest');
+    const decoded = ownership.decodeData(claim.txt, 'regtest');
+    assert.strictEqual(decoded.address.version, claimAddress.version);
+    assert.strictEqual(decoded.address.hash, claimAddress.hash.toString('hex'));
+    assert.strictEqual(decoded.fee, claim.fee);
+    assert.strictEqual(decoded.commitHash, block1Hash);
+    assert.strictEqual(decoded.commitHeight, 1);
+
+    // (address, fee, commitHash, commitHeight, network)
+    const encoded = ownership.createData(
+      claimAddress,
+      claim.fee,
+      Buffer.from(block1Hash, 'hex'),
+      1,
+      network
+    );
+    assert.strictEqual(encoded, claim.txt);
+  });
+});


### PR DESCRIPTION
Background: https://handshake.org/notice/2020-04-02-Inflation-Bug-Disclosure.html

Relevant section:

> NEW PROTOCOL RULES
> A CLAIM must commit to a mainnet block hash. By default, all claims commit to block 1. The existing rules already require that subsequent re-claims commit to higher block heights. This makes it easy to determine in the software when a claim is being re-submitted (commitHeight > 1). The following new rules are enforced by the soft-fork code:
> 
> • An initial CLAIM MUST commit to block 1.
> • An initial CLAIM MUST pay a fee less than 1,000 HNS.
> • A re-claim MUST pay the exact same fee as the initial CLAIM.
> • The fees from any re-claim MUST NOT be collected by the miner: they are "burned" or, more accurately, already exist in a previous block.
> • A re-claim can not be mined until 288 blocks have passed since the last CLAIM or re-claim.

This PR modifies the wallet `makeClaim` path to enable this action. The wallet will have to ask the fullnode for the UTXO that currently owns the reserved name in LOCKED state to determine the correct values for the updated claim. That means that this can only be done with a full node (not SPV, but pruned is OK).

### Soft fork considerations

- A miner that has not upgraded and fails to follow the new protocol rules when including a re-claim in a block will produce an invalid block. The covert signaling mechanism from the soft fork deployment indicates that 88% of miners have upgraded, but I suspect it is actually 100%. We know some pools upgraded that are whatever reason not signaling in blocks:

```
--> hsd-rpc getcovertsignaling
{
  "blocks": 1772,
  "total": 2016,
  "perc": 0.878968253968254
}
```


- Non-upgraded relay nodes and Bob Wallets will interpret a valid re-claim in a valid block as generating new coins when in fact it is not. This will only affect that node's chainstate when reporting total chain value, no other functions are affected. The chainstate is fixed automatically by upgrading to v2.4.0 which migrates  on boot. According to my seed node, well over half the network has already upgraded:

```
  '/hnsd:1.0.0/' => 36,
  '/hsd:2.0.1/' => 1,
  '/hsd:2.0.2/' => 6,
  '/hsd:2.0.3/' => 1,
  '/hsd:2.1.1/' => 2,
  '/hsd:2.1.2/' => 1,
  '/hsd:2.1.3/' => 4,
  '/hsd:2.1.5/' => 26,
  '/hsd:2.2.0/' => 33,
  '/hsd:2.3.0/' => 31,
  '/hsd:2.4.0/' => 146,
  '/hsd:2.4.0/hmail.app/' => 1,
  '/hsd:2.4.0/sinpapeles/' => 2
```

TODO:
- [x] add test for `ownership.decodeData()`