### PR TITLE
wallet: create batch transactions with multiple covenants

### DIFF
--- a/lib/wallet/rpc.js
+++ b/lib/wallet/rpc.js
@@ -198,6 +198,7 @@ class RPC extends RPCBase {
     this.add('sendcancel', this.sendCancel);
     this.add('sendfinalize', this.sendFinalize);
     this.add('sendrevoke', this.sendRevoke);
+    this.add('sendbatch', this.sendBatch);
     this.add('importnonce', this.importNonce);
     this.add('createopen', this.createOpen);
     this.add('createbid', this.createBid);
@@ -209,6 +210,7 @@ class RPC extends RPCBase {
     this.add('createcancel', this.createCancel);
     this.add('createfinalize', this.createFinalize);
     this.add('createrevoke', this.createRevoke);
+    this.add('createbatch', this.createBatch);
 
     // Compat
     this.add('getauctions', this.getNames);
@@ -2449,7 +2451,6 @@ class RPC extends RPCBase {
 
     return mtx.getJSON(this.network);
   }
-
   _validateRevoke(args, help, method) {
     if (help || args.length < 1 || args.length > 2)
       throw new RPCError(errs.MISC_ERROR, `${method} "name" ( "account" )`);
@@ -2462,6 +2463,150 @@ class RPC extends RPCBase {
       throw new RPCError(errs.TYPE_ERROR, 'Invalid name.');
 
     return {name, account};
+  }
+
+  async sendBatch(args, help) {
+    const [actions, options] = this._validateBatch(args, help, 'sendbatch');
+    const wallet = this.wallet;
+    const tx = await wallet.sendBatch(actions, options);
+
+    return tx.getJSON(this.network);
+  }
+
+  async createBatch(args, help) {
+    const [actions, options] = this._validateBatch(args, help, 'sendbatch');
+    const wallet = this.wallet;
+    const mtx = await wallet.createBatch(actions, options);
+
+    return mtx.getJSON(this.network);
+  }
+
+ _validateBatch(args, help, method) {
+  if (help || args.length < 1 || args.length > 2) {
+      throw new RPCError(errs.MISC_ERROR,
+        `${method} ["type", ...args] ( options )`);
+    }
+
+    const valid = new Validator(args);
+    const check = valid.array(0);
+    const options = valid.obj(1);
+    const actions = [];
+
+    for (const action of check) {
+      assert(
+        Array.isArray(action),
+        'Actions must be arrays'
+      );
+
+      const type = action.shift();
+      assert(
+        typeof type === 'string',
+        'Actions must start with type (string)'
+      );
+
+      switch (type) {
+        case 'NONE': {
+          assert(
+            action.length === 2,
+            'NONE action requires 2 arguments: address, value'
+          );
+          const {addr, value} = this._validateSendToAddress(action);
+          actions.push([type, addr, value]);
+          break;
+        }
+        case 'OPEN': {
+          assert(
+            action.length === 1,
+            'OPEN action requires 1 argument: name'
+          );
+          const {name} = this._validateOpen(action);
+          actions.push([type, name]);
+          break;
+        }
+        case 'BID': {
+          assert(
+            action.length === 3,
+            'BID action requires 3 arguments: name, bid, value'
+          );
+          const {name, bid, value} = this._validateBid(action);
+          actions.push([type, name, bid, value]);
+          break;
+        }
+        case 'REVEAL': {
+          assert(
+            action.length === 0 || action.length === 1,
+            'REVEAL action can only have 1 argument: name'
+          );
+          const {name} = this._validateReveal(action);
+          if (name)
+            actions.push([type, name]);
+          else
+            actions.push([type]);
+          break;
+        }
+        case 'REDEEM': {
+          assert(
+            action.length === 0 || action.length === 1,
+            'REDEEM action can only have 1 argument: name'
+          );
+          const {name} = this._validateRedeem(action);
+          if (name)
+            actions.push([type, name]);
+          else
+            actions.push([type]);
+          break;
+        }
+        case 'UPDATE': {
+          assert(
+            action.length === 2,
+            'UPDATE action requires 2 arguments: name, data'
+          );
+          const {name, resource} = this._validateUpdate(action);
+          actions.push([type, name, resource]);
+          break;
+        }
+        case 'TRANSFER': {
+          assert(
+            action.length === 2,
+            'TRANSFER action requires 2 arguments: name, address'
+          );
+          const {name, address} = this._validateTransfer(action);
+          actions.push([type, name, address]);
+          break;
+        }
+        case 'FINALIZE': {
+          assert(
+            action.length === 1,
+            'FINALIZE action requires 1 argument: name'
+          );
+          const {name} = this._validateFinalize(action);
+          actions.push([type, name]);
+          break;
+        }
+        case 'CANCEL': {
+          assert(
+            action.length === 1,
+            'CANCEL action requires 1 argument: name'
+          );
+          const {name} = this._validateCancel(action);
+          actions.push([type, name]);
+          break;
+        }
+        case 'REVOKE': {
+          assert(
+            action.length === 1,
+            'REVOKE action requires 1 argument: name'
+          );
+          const {name} = this._validateRevoke(action);
+          actions.push([type, name]);
+          break;
+        }
+        default:
+          throw new Error(`Unknown action type: ${type}`);
+      }
+    }
+
+    return [actions, options];
   }
 
   async importNonce(args, help) {

--- a/lib/wallet/wallet.js
+++ b/lib/wallet/wallet.js
@@ -3475,6 +3475,150 @@ class Wallet extends EventEmitter {
   }
 
   /**
+   * Make a batch transaction with multiple actions.
+   * @param {Array} actions
+   * @param {Object} options
+   * @returns {MTX}
+   */
+
+  async makeBatch(actions, options) {
+    assert(Array.isArray(actions));
+
+    const force = false;
+    const acct = options ? options.account || 0 : 0;
+    const mtx = new MTX();
+
+    // "actions" are arrays that start with a covenant type (or meta-type)
+    // followed by the arguments expected by the corresponding "make" function.
+    for (const action of actions) {
+      assert(Array.isArray(action));
+
+      const type = action.shift();
+      assert(typeof type === 'string');
+
+      switch (type) {
+        case 'NONE':
+          assert(action.length === 2);
+          await this.createTX(
+            {outputs: [{
+              address: action[0],
+              value: action[1]
+            }]},
+            force,
+            mtx
+          );
+          break;
+        case 'OPEN':
+          assert(action.length === 1);
+          await this.makeOpen(...action, force, acct, mtx);
+          break;
+        case 'BID':
+          assert(action.length === 3);
+          await this.makeBid(...action, acct, mtx);
+          break;
+        case 'REVEAL':
+          if (action.length === 1) {
+            await this.makeReveal(...action, acct, mtx);
+          } else {
+            assert(action.length === 0);
+            await this.makeRevealAll(mtx);
+          }
+          break;
+        case 'REDEEM':
+          if (action.length === 1) {
+            await this.makeRedeem(...action, acct, mtx);
+          } else {
+            assert(action.length === 0);
+            await this.makeRedeemAll(mtx);
+          }
+          break;
+        case 'UPDATE':
+          assert(action.length === 2);
+          await this.makeUpdate(...action, acct, mtx);
+          break;
+        case 'TRANSFER':
+          assert(action.length === 2);
+          await this.makeTransfer(...action, acct, mtx);
+          break;
+        case 'FINALIZE':
+          assert(action.length === 1);
+          await this.makeFinalize(...action, acct, mtx);
+          break;
+        case 'CANCEL':
+          assert(action.length === 1);
+          await this.makeCancel(...action, acct, mtx);
+          break;
+        case 'REVOKE':
+          assert(action.length === 1);
+          await this.makeRevoke(...action, acct, mtx);
+          break;
+        default:
+          throw new Error(`Unknown action type: ${type}`);
+      }
+    }
+
+    return mtx;
+  }
+
+  /**
+   * Make a batch transaction with multiple actions.
+   * @param {Array} actions
+   * @param {Object} options
+   * @returns {MTX}
+   */
+
+  async _createBatch(actions, options) {
+    const mtx = await this.makeBatch(actions, options);
+    await this.fill(mtx, options);
+    return this.finalize(mtx, options);
+  }
+
+  /**
+   * Make a batch transaction with multiple actions.
+   * @param {Array} actions
+   * @param {Object} options
+   * @returns {MTX}
+   */
+
+  async createBatch(actions, options) {
+    const unlock = await this.fundLock.lock();
+    try {
+      return await this._createBatch(actions, options);
+    } finally {
+      unlock();
+    }
+  }
+
+  /**
+   * Create and send a batch transaction with multiple actions.
+   * @param {Array} actions
+   * @param {Object} options
+   * @returns {TX}
+   */
+
+  async _sendBatch(actions, options) {
+    const passphrase = options ? options.passphrase : null;
+    const mtx = await this._createBatch(actions, options);
+    return this.sendMTX(mtx, passphrase);
+  }
+
+  /**
+   * Create and send a batch transaction with multiple actions.
+   * @param {Array} actions
+   * @param {Object} options
+   * @returns {TX}
+   */
+
+  async sendBatch(actions, options) {
+    const unlock = await this.fundLock.lock();
+    try {
+      return await this._sendBatch(actions, options);
+    } finally {
+      unlock();
+    }
+  }
+
+  /**
    * Finalize and template an MTX.
    * @param {MTX} mtx
    * @param {Object} options

--- a/lib/wallet/wallet.js
+++ b/lib/wallet/wallet.js
@@ -1569,10 +1569,11 @@ class Wallet extends EventEmitter {
    * @param {String} name
    * @param {Number|String} acct
    * @param {Boolean} force
-   * @returns {MTX}
+   * @param {MTX?} mtx
+   * @returns {MTX?}
    */
 
-  async makeOpen(name, force, acct) {
+  async makeOpen(name, force, acct, mtx) {
     assert(typeof name === 'string');
     assert(typeof force === 'boolean');
     assert((acct >>> 0) === acct || typeof acct === 'string');
@@ -1618,7 +1619,8 @@ class Wallet extends EventEmitter {
     output.covenant.pushU32(0);
     output.covenant.push(rawName);
 
-    const mtx = new MTX();
+    if (!mtx)
+      mtx = new MTX();
     mtx.outputs.push(output);
 
     if (await this.txdb.isDoubleOpen(mtx))
@@ -1698,10 +1700,11 @@ class Wallet extends EventEmitter {
    * @param {Number} value
    * @param {Number} lockup
    * @param {Number|String} acct
+   * @param {MTX?} mtx
    * @returns {MTX}
    */
 
-  async makeBid(name, value, lockup, acct) {
+  async makeBid(name, value, lockup, acct, mtx) {
     assert(typeof name === 'string');
     assert(Number.isSafeInteger(value) && value >= 0);
     assert(Number.isSafeInteger(lockup) && lockup >= 0);
@@ -1752,7 +1755,8 @@ class Wallet extends EventEmitter {
     output.covenant.push(rawName);
     output.covenant.pushHash(blind);
 
-    const mtx = new MTX();
+    if (!mtx)
+      mtx = new MTX();
     mtx.outputs.push(output);
 
     return mtx;
@@ -1903,10 +1907,11 @@ class Wallet extends EventEmitter {
    * Make a reveal MTX.
    * @param {String} name
    * @param {(Number|String)?} acct
+   * @param {MTX?} mtx
    * @returns {MTX}
    */
 
-  async makeReveal(name, acct) {
+  async makeReveal(name, acct, mtx) {
     assert(typeof name === 'string');
 
     if (acct != null) {
@@ -1938,8 +1943,10 @@ class Wallet extends EventEmitter {
 
     const bids = await this.getBids(nameHash);
 
-    const mtx = new MTX();
+    if (!mtx)
+      mtx = new MTX();
 
+    let pushed = 0;
     for (const {prevout, own} of bids) {
       if (!own)
         continue;
@@ -1975,9 +1982,10 @@ class Wallet extends EventEmitter {
 
       mtx.addOutpoint(prevout);
       mtx.outputs.push(output);
+      pushed++;
     }
 
-    if (mtx.outputs.length === 0)
+    if (pushed === 0)
       throw new Error('No bids to reveal.');
 
     return mtx;
@@ -2044,15 +2052,18 @@ class Wallet extends EventEmitter {
 
   /**
    * Make a reveal MTX.
+   * @param {MTX?} mtx
    * @returns {MTX}
    */
 
-  async makeRevealAll() {
+  async makeRevealAll(mtx) {
     const height = this.wdb.height + 1;
     const network = this.network;
     const bids = await this.getBids();
-    const mtx = new MTX();
+    if (!mtx)
+      mtx = new MTX();
 
+    let pushed = 0;
     for (const {nameHash, prevout, own} of bids) {
       if (!own)
         continue;
@@ -2100,9 +2111,10 @@ class Wallet extends EventEmitter {
 
       mtx.addOutpoint(prevout);
       mtx.outputs.push(output);
+      pushed++;
     }
 
-    if (mtx.outputs.length === 0)
+    if (pushed === 0)
       throw new Error('No bids to reveal.');
 
     return mtx;
@@ -2166,10 +2178,11 @@ class Wallet extends EventEmitter {
    * Make a redeem MTX.
    * @param {String} name
    * @param {(Number|String)?} acct
+   * @param {MTX?} mtx
    * @returns {MTX}
    */
 
-  async makeRedeem(name, acct) {
+  async makeRedeem(name, acct, mtx) {
     assert(typeof name === 'string');
 
     if (!rules.verifyName(name))
@@ -2199,8 +2212,10 @@ class Wallet extends EventEmitter {
 
     const reveals = await this.txdb.getReveals(nameHash);
 
-    const mtx = new MTX();
+    if (!mtx)
+      mtx = new MTX();
 
+    let pushed = 0;
     for (const {prevout, own} of reveals) {
       const {hash, index} = prevout;
 
@@ -2233,9 +2248,10 @@ class Wallet extends EventEmitter {
       output.covenant.pushU32(ns.height);
 
       mtx.outputs.push(output);
+      pushed++;
     }
 
-    if (mtx.outputs.length === 0)
+    if (pushed === 0)
       throw new Error('No reveals to redeem.');
 
     return mtx;
@@ -2305,15 +2321,18 @@ class Wallet extends EventEmitter {
   /**
    * Make a redeem MTX.
    * @param {String} name
+   * @param {MTX?} mtx
    * @returns {MTX}
    */
 
-  async makeRedeemAll() {
+  async makeRedeemAll(mtx) {
     const height = this.wdb.height + 1;
     const network = this.network;
     const reveals = await this.txdb.getReveals();
-    const mtx = new MTX();
+    if (!mtx)
+      mtx = new MTX();
 
+    let pushed = 0;
     for (const {nameHash, prevout, own} of reveals) {
       const {hash, index} = prevout;
 
@@ -2355,9 +2374,10 @@ class Wallet extends EventEmitter {
       output.covenant.pushU32(ns.height);
 
       mtx.outputs.push(output);
+      pushed++;
     }
 
-    if (mtx.outputs.length === 0)
+    if (pushed === 0)
       throw new Error('No reveals to redeem.');
 
     return mtx;
@@ -2424,10 +2444,11 @@ class Wallet extends EventEmitter {
    * @private
    * @param {String} name
    * @param {Resource?} resource
+   * @param {MTX?} mtx
    * @returns {MTX}
    */
 
-  async _makeRegister(name, resource) {
+  async _makeRegister(name, resource, mtx) {
     assert(typeof name === 'string');
     assert(!resource || (resource instanceof Resource));
 
@@ -2490,7 +2511,8 @@ class Wallet extends EventEmitter {
 
     output.covenant.pushHash(await this.wdb.getRenewalBlock());
 
-    const mtx = new MTX();
+    if (!mtx)
+      mtx = new MTX();
     mtx.addOutpoint(ns.owner);
     mtx.outputs.push(output);
 
@@ -2502,10 +2524,11 @@ class Wallet extends EventEmitter {
    * @param {String} name
    * @param {Resource} resource
    * @param {(Number|String)?} acct
+   * @param {MTX?} mtx
    * @returns {MTX}
    */
 
-  async makeUpdate(name, resource, acct) {
+  async makeUpdate(name, resource, acct, mtx) {
     assert(typeof name === 'string');
     assert(resource instanceof Resource);
 
@@ -2536,7 +2559,7 @@ class Wallet extends EventEmitter {
       throw new Error(`Account does not own: "${name}".`);
 
     if (coin.covenant.isReveal() || coin.covenant.isClaim())
-      return this._makeRegister(name, resource);
+      return this._makeRegister(name, resource, mtx);
 
     if (ns.isExpired(height, network))
       throw new Error('Name has expired!');
@@ -2570,7 +2593,8 @@ class Wallet extends EventEmitter {
     output.covenant.pushU32(ns.height);
     output.covenant.push(raw);
 
-    const mtx = new MTX();
+    if (!mtx)
+      mtx = new MTX();
     mtx.addOutpoint(ns.owner);
     mtx.outputs.push(output);
 
@@ -2647,10 +2671,11 @@ class Wallet extends EventEmitter {
    * @private
    * @param {String} name
    * @param {(Number|String)?} acct
+   * @param {MTX?} mtx
    * @returns {MTX}
    */
 
-  async makeRenewal(name, acct) {
+  async makeRenewal(name, acct, mtx) {
     assert(typeof name === 'string');
 
     if (!rules.verifyName(name))
@@ -2709,7 +2734,8 @@ class Wallet extends EventEmitter {
     output.covenant.pushU32(ns.height);
     output.covenant.pushHash(await this.wdb.getRenewalBlock());
 
-    const mtx = new MTX();
+    if (!mtx)
+      mtx = new MTX();
     mtx.addOutpoint(ns.owner);
     mtx.outputs.push(output);
 
@@ -2782,10 +2808,11 @@ class Wallet extends EventEmitter {
    * @param {String} name
    * @param {Address} address
    * @param {(Number|String)?} acct
+   * @param {MTX?} mtx
    * @returns {MTX}
    */
 
-  async makeTransfer(name, address, acct) {
+  async makeTransfer(name, address, acct, mtx) {
     assert(typeof name === 'string');
     assert(address instanceof Address);
 
@@ -2843,7 +2870,8 @@ class Wallet extends EventEmitter {
     output.covenant.pushU8(address.version);
     output.covenant.push(address.hash);
 
-    const mtx = new MTX();
+    if (!mtx)
+      mtx = new MTX();
     mtx.addOutpoint(ns.owner);
     mtx.outputs.push(output);
 
@@ -2924,10 +2952,11 @@ class Wallet extends EventEmitter {
    * @private
    * @param {String} name
    * @param {(Number|String)?} acct
+   * @param {MTX?} mtx
    * @returns {MTX}
    */
 
-  async makeCancel(name, acct) {
+  async makeCancel(name, acct, mtx) {
     assert(typeof name === 'string');
 
     if (!rules.verifyName(name))
@@ -2979,7 +3008,8 @@ class Wallet extends EventEmitter {
     output.covenant.pushU32(ns.height);
     output.covenant.push(EMPTY);
 
-    const mtx = new MTX();
+    if (!mtx)
+      mtx = new MTX();
     mtx.addOutpoint(ns.owner);
     mtx.outputs.push(output);
 
@@ -3052,10 +3082,11 @@ class Wallet extends EventEmitter {
    * @private
    * @param {String} name
    * @param {(Number|String)?} acct
+   * @param {MTX?} mtx
    * @returns {MTX}
    */
 
-  async makeFinalize(name, acct) {
+  async makeFinalize(name, acct, mtx) {
     assert(typeof name === 'string');
 
     if (!rules.verifyName(name))
@@ -3123,7 +3154,8 @@ class Wallet extends EventEmitter {
     output.covenant.pushU32(ns.renewals);
     output.covenant.pushHash(await this.wdb.getRenewalBlock());
 
-    const mtx = new MTX();
+    if (!mtx)
+      mtx = new MTX();
     mtx.addOutpoint(ns.owner);
     mtx.outputs.push(output);
 
@@ -3195,10 +3227,11 @@ class Wallet extends EventEmitter {
    * Make a revoke MTX.
    * @param {String} name
    * @param {(Number|String)?} acct
+   * @param {MTX?} mtx
    * @returns {MTX}
    */
 
-  async makeRevoke(name, acct) {
+  async makeRevoke(name, acct, mtx) {
     assert(typeof name === 'string');
 
     if (!rules.verifyName(name))
@@ -3254,7 +3287,8 @@ class Wallet extends EventEmitter {
     output.covenant.pushHash(nameHash);
     output.covenant.pushU32(ns.height);
 
-    const mtx = new MTX();
+    if (!mtx)
+      mtx = new MTX();
     mtx.addOutpoint(ns.owner);
     mtx.outputs.push(output);
 
@@ -3391,12 +3425,18 @@ class Wallet extends EventEmitter {
    * to avoid sorting), set locktime, and template it.
    * @param {Object} options - See {@link Wallet#fund options}.
    * @param {Object[]} options.outputs - See {@link MTX#addOutput}.
+   * @param {Object[]} options.outputs - See {@link MTX#addOutput}.
+   * @param {MTX?} mtx
    * @returns {Promise} - Returns {@link MTX}.
    */
 
-  async createTX(options, force) {
+  async createTX(options, force, mtx) {
     const outputs = options.outputs;
-    const mtx = new MTX();
+    let finish = false;
+    if (!mtx) {
+      finish = true;
+      mtx = new MTX();
+    }
 
     assert(Array.isArray(outputs), 'Outputs must be an array.');
     assert(outputs.length > 0, 'At least one output required.');
@@ -3419,6 +3459,14 @@ class Wallet extends EventEmitter {
 
       mtx.outputs.push(output);
     }
+
+    // If a MTX was passed in to this function as an argument,
+    // we assume the caller is constructing a bigger TX and
+    // may still have more ins/out to add to it.
+    // That caller will have to call fund() and finalize()
+    // on their own when they are ready.
+    if (!finish)
+      return mtx;
 
     // Fill the inputs with unspents
     await this.fund(mtx, options, force);

--- a/test/wallet-rpc-test.js
+++ b/test/wallet-rpc-test.js
@@ -588,4 +588,98 @@ describe('Wallet RPC Methods', function() {
       await nclient.execute('generatetoaddress', [1, addr]);
     });
   });
+
+  describe('Batches', function() {
+    let addr;
+
+    before(async () => {
+      await wclient.createWallet('batchWallet');
+      wclient.wallet('batchWallet');
+      await wclient.execute('selectwallet', ['batchWallet']);
+      addr = await wclient.execute('getnewaddress', []);
+      await nclient.execute('generatetoaddress', [100, addr]);
+    });
+
+    it('should send multiple OPENs', async () => {
+      const tx = await wclient.execute(
+        'sendbatch',
+        [
+          [['OPEN', 'abc123'], ['OPEN', 'def456'], ['OPEN', 'ghi789']]
+        ]
+      );
+      assert(tx.outputs.length === 4);
+      await nclient.execute('generatetoaddress', [7, addr]);
+    });
+
+    it('should send multiple BIDs', async () => {
+      const tx = await wclient.execute(
+        'sendbatch',
+        [
+          [
+            ['BID', 'abc123', 1, 1],
+            ['BID', 'def456', 2, 2],
+            ['BID', 'ghi789', 3, 3],
+            ['BID', 'ghi789', 4, 4]
+          ]
+        ]
+      );
+      assert(tx.outputs.length === 5);
+      await nclient.execute('generatetoaddress', [7, addr]);
+    });
+
+    it('should send multiple REVEALs', async () => {
+      const tx = await wclient.execute(
+        'sendbatch',
+        [
+          [
+            ['REVEAL', 'abc123'],
+            ['REVEAL', 'def456']
+          ]
+        ]
+      );
+      assert(tx.outputs.length === 3);
+      await nclient.execute('generatetoaddress', [1, addr]);
+    });
+
+    it('should send REVEAL all', async () => {
+      const tx = await wclient.execute(
+        'sendbatch',
+        [
+          [
+            ['REVEAL']
+          ]
+        ]
+      );
+      assert(tx.outputs.length === 3);
+      await nclient.execute('generatetoaddress', [10, addr]);
+    });
+
+    it('should send REDEEM all', async () => {
+      const tx = await wclient.execute(
+        'sendbatch',
+        [
+          [
+            ['REDEEM']
+          ]
+        ]
+      );
+      assert(tx.outputs.length === 2);
+      await nclient.execute('generatetoaddress', [1, addr]);
+    });
+
+    it('should send multiple REGISTERs', async () => {
+      const tx = await wclient.execute(
+        'sendbatch',
+        [
+          [
+            ['UPDATE', 'abc123', {'records': [{'type': 'TXT', 'txt':['abc']}]}],
+            ['UPDATE', 'def456', {'records': [{'type': 'TXT', 'txt':['def']}]}],
+            ['UPDATE', 'ghi789', {'records': [{'type': 'TXT', 'txt':['ghi']}]}]
+          ]
+        ]
+      );
+      assert(tx.outputs.length === 4);
+      await nclient.execute('generatetoaddress', [1, addr]);
+    });
+  });
 });


### PR DESCRIPTION
Creates batching functions in the wallet and exposes two new RPC calls: `sendbatch` and `createbatch`. The argument is an array of "actions". Actions are an array that starts with a string indicating the action type (usually a covenant but could also be meta-covenant type like `CANCEL`) followed by the arguments expected by the corresponding `make___()` function.

Examples:

```
# open multiple names in one TX
hsw-rpc sendbatch [['OPEN', 'menace'], ['OPEN', 'to'], ['OPEN', 'the'], ['OPEN', 'network']]

# send bids (with lockups) for multiple names in one TX:
hsw-rpc sendbatch [['BID', 'menace', 100, 100], ['BID', 'to', 1, 2], ['BID', 'the', 30, 40], ['BID', 'network', 100, 100]]

# mix and match!!!
hsw-rpc sendbatch [['REDEEM', 'menace'], ['REDEEM', 'to'], ['UPDATE', 'the', {"records":[]}], ['UPDATE', 'network', {"records":[]}]]

# even works with NONE!
hsw-rpc sendbatch '[["OPEN", "heynicetomeetyou"], ["NONE", "rs1qruzqgxl4qvs4fj3v8k6zjxwem6236pam0tjv7w", 1.123456]]'
```

TODO:
- [ ] lots more tests