### PR TITLE
migrations: ignore migration flag if db is brand new

### DIFF
--- a/lib/migrations/migrator.js
+++ b/lib/migrations/migrator.js
@@ -138,11 +138,19 @@ class Migrator {
 
   async migrate() {
     const version = await this.ldb.get(this.layout.V.encode());
-
-    if (version === null && this.migrateFlag !== -1)
-      throw new Error('Database does not exist.');
+    const lastID = this.getLastMigrationID();
 
     if (version === null) {
+      if (this.migrateFlag !== -1) {
+        if (this.migrateFlag !== lastID) {
+          throw new Error(
+            `Migrate flag ${this.migrateFlag} does not match last ID: ${lastID}`
+          );
+        }
+
+        this.logger.warning('Fresh start, ignoring migration flag.');
+      }
+
       const state = new MigrationState();
       state.nextMigration = this.getLastMigrationID() + 1;
 
@@ -157,7 +165,6 @@ class Migrator {
     await this.verifyDB();
     await this.checkMigrations();
 
-    const lastID = this.getLastMigrationID();
     let state = await this.getState();
 
     if (this.migrateFlag !== -1 && this.migrateFlag !== lastID) {


### PR DESCRIPTION
A user has already reported an issue with a deployment in which they use a single configuration file (a Dockerfile with command line options) that can end up being run on both brand new and old, not-yet-migrated nodes.

The problem is we currently throw an error if `--chain-migrate` is passed to a brand new node:

```
--> hsd --chain-migrate=2 --prefix=~/Desktop/hsd-fresh
[info] (chain) Chain is loading.
[info] (chain) Checkpoints are enabled.
[info] (chaindb) Opening ChainDB...
Error: Database does not exist.
    at ChainMigrator.migrate (/Users/matthewzipkin/Desktop/work/hsd/lib/migrations/migrator.js:143:13)
    at async ChainDB.open (/Users/matthewzipkin/Desktop/work/hsd/lib/blockchain/chaindb.js:83:5)
    at async Chain.open (/Users/matthewzipkin/Desktop/work/hsd/lib/blockchain/chain.js:86:5)
    at async FullNode.open (/Users/matthewzipkin/Desktop/work/hsd/lib/node/fullnode.js:258:5)
    at async /Users/matthewzipkin/Desktop/work/hsd/bin/node:55:3
```

This PR downgrades that error to a warning in the log.

I'm not sure if there's any case where this could be otherwise problematic, or if we need to protect users from something bad happening. Otherwise, a possible workaround is to continue using the same Dockerfile for all deployments, but just add `chain-migrate: 1` into `hsd.conf` in the old nodes only, to trigger the migration.