### PR TITLE
Use synth address for root server NS

### DIFF
--- a/lib/dns/server.js
+++ b/lib/dns/server.js
@@ -189,8 +189,8 @@ class RootServer extends DNSServer {
     });
 
     this.on('query', (req, res) => {
-      this.logMessage('DNS Request:', req);
-      this.logMessage('DNS Response:', res);
+      this.logMessage('\n\nDNS Request:', req);
+      this.logMessage('\n\nDNS Response:', res);
     });
 
     return this;
@@ -693,8 +693,8 @@ class RecursiveServer extends DNSServer {
     });
 
     this.on('query', (req, res) => {
-      this.logMessage('DNS Request:', req);
-      this.logMessage('DNS Response:', res);
+      this.logMessage('\n\nDNS Request:', req);
+      this.logMessage('\n\nDNS Response:', res);
     });
 
     return this;

--- a/lib/dns/server.js
+++ b/lib/dns/server.js
@@ -298,16 +298,24 @@ class RootServer extends DNSServer {
     const tld = util.label(name, labels, -1);
 
     // Handle reverse pointers.
-    if (tld === '_synth' && labels.length === 2 && name[0] === '_') {
-      const hash = util.label(name, labels, -2);
-      const ip = IP.map(base32.decodeHex(hash.substring(1)));
+    if (tld === '_synth' && labels.length <= 2 && name[0] === '_') {
       const res = new Message();
       const rr = new Record();
 
       res.aa = true;
-
       rr.name = name;
       rr.ttl = 21600;
+
+      // TLD '._synth' is being queried on its own, send SOA
+      // so recursive asks again with complete synth record.
+      if (labels.length === 1) {
+        res.authority.push(this.toSOA());
+        key.signZSK(res.authority, types.SOA);
+        return res;
+      }
+
+      const hash = util.label(name, labels, -2);
+      const ip = IP.map(base32.decodeHex(hash.substring(1)));
 
       if (IP.isIPv4(ip)) {
         rr.type = types.A;

--- a/lib/dns/server.js
+++ b/lib/dns/server.js
@@ -130,10 +130,16 @@ class RootServer extends DNSServer {
 
     this.cache = new RootCache(3000);
 
-    this.initNode();
-
     if (options)
       this.initOptions(options);
+
+    // Create SYNTH record to use for root zone NS
+    let ip = IP.toBuffer(this.publicHost);
+    if (IP.family(this.publicHost) === 4)
+      ip = ip.slice(12);
+    this.synth = `_${base32.encodeHex(ip)}._synth.`;
+
+    this.initNode();
   }
 
   initOptions(options) {
@@ -539,14 +545,15 @@ class RootServer extends DNSServer {
     rr.type = types.NS;
     rr.ttl = 518400;
     rr.data = rd;
-    rd.ns = '.';
+    rd.ns = this.synth;
     return rr;
   }
 
+  // Glue only
   toA() {
     const rr = new Record();
     const rd = new ARecord();
-    rr.name = '.';
+    rr.name = this.synth;
     rr.type = types.A;
     rr.ttl = 518400;
     rr.data = rd;
@@ -554,10 +561,11 @@ class RootServer extends DNSServer {
     return rr;
   }
 
+  // Glue only
   toAAAA() {
     const rr = new Record();
     const rd = new AAAARecord();
-    rr.name = '.';
+    rr.name = this.synth;
     rr.type = types.AAAA;
     rr.ttl = 518400;
     rr.data = rd;


### PR DESCRIPTION
Closes https://github.com/handshake-org/hsd/issues/400

- [x] TODO: Needs tests

Also imports a fix from hnsd PR https://github.com/handshake-org/hnsd/pull/67 which returns empty SOA if `_synth` is queried by itself (encourages the recursive resolver to ask again with the full synth address)

Third commit adds newlines `\n\n` before DNS messages in the log. These messages are only printed at `--log-level=spam` anyway and improve readability a whole heckuva lot:

<img width="506" alt="Screen Shot 2021-08-31 at 10 01 25 AM" src="https://user-images.githubusercontent.com/2084648/131523072-30d3a937-3bbf-40f3-b5c2-49d9692f75e0.png">
