### PR TITLE
[consensus] Cache namestates for block verification

### DIFF
--- a/lib/blockchain/chain.js
+++ b/lib/blockchain/chain.js
@@ -3605,6 +3605,7 @@ class ChainOptions {
     this.indexAddress = false;
 
     this.entryCache = 5000;
+    this.nameCache = 5000;
     this.maxOrphans = 20;
     this.checkpoints = true;
     this.chainMigrate = -1;
@@ -3703,6 +3704,11 @@ class ChainOptions {
     if (options.entryCache != null) {
       assert((options.entryCache >>> 0) === options.entryCache);
       this.entryCache = options.entryCache;
+    }
+
+    if (options.nameCache != null) {
+      assert((options.nameCache >>> 0) === options.nameCache);
+      this.nameCache = options.nameCache;
     }
 
     if (options.maxOrphans != null) {

--- a/lib/blockchain/chain.js
+++ b/lib/blockchain/chain.js
@@ -328,6 +328,21 @@ class Chain extends AsyncEmitter {
   }
 
   /**
+   * Test whether the height is potentially
+   * an ancestor of a checkpoint.
+   * @param {Number} height
+   * @returns {Boolean}
+   */
+
+  isHistoricalHeight(height) {
+    if (this.options.checkpoints) {
+      if (height <= this.network.lastCheckpoint)
+        return true;
+    }
+    return false;
+  }
+
+  /**
    * Contextual verification for a block, including
    * version deployments (IsSuperMajority), versionbits,
    * coinbase height, finality checks.
@@ -902,6 +917,18 @@ class Chain extends AsyncEmitter {
 
       if (!covenant.isName())
         continue;
+
+      // BID and REDEEM covenants to do not update NameState.
+      // Therefore, if we are still inside checkpoints we can simply
+      // assume these covenants are valid without checking anything,
+      // or even getting and decoding the NameState from the cache/tree.
+      // We could skip checks for ALL covenant types under checkpoints,
+      // but since the other types modify the NameState we still
+      // need to get the data, and the checks themselves are cheap.
+      if (this.isHistoricalHeight(height)) {
+        if (covenant.isBid() || covenant.isRedeem())
+          continue;
+      }
 
       const nameHash = covenant.getHash(0);
       const start = covenant.getU32(1);

--- a/lib/blockchain/chaindb.js
+++ b/lib/blockchain/chaindb.js
@@ -67,14 +67,7 @@ class ChainDB {
 
     // Keeps a copy of all NameStates in memory
     // for their entire auction cycle.
-    const size =
-      consensus.MAX_BLOCK_OPENS *
-      (
-        this.network.names.treeInterval + 1 +
-        this.network.names.biddingPeriod +
-        this.network.names.revealPeriod
-      );
-    this.nameCache = new LRU(size, null, BufferMap);
+    this.nameCache = new LRU(this.options.nameCache, null, BufferMap);
   }
 
   /**

--- a/lib/blockchain/chaindb.js
+++ b/lib/blockchain/chaindb.js
@@ -65,8 +65,8 @@ class ChainDB {
     this.cacheHash = new LRU(this.options.entryCache, null, BufferMap);
     this.cacheHeight = new LRU(this.options.entryCache);
 
-    // Keeps a copy of all NameStates in memory
-    // for their entire auction cycle.
+    // Cache last-inserted NameStates in memory
+    // to avoid some expensive Urkel Tree lookups.
     this.nameCache = new LRU(this.options.nameCache, null, BufferMap);
   }
 

--- a/lib/blockchain/chaindb.js
+++ b/lib/blockchain/chaindb.js
@@ -64,6 +64,17 @@ class ChainDB {
 
     this.cacheHash = new LRU(this.options.entryCache, null, BufferMap);
     this.cacheHeight = new LRU(this.options.entryCache);
+
+    // Keeps a copy of all NameStates in memory
+    // for their entire auction cycle.
+    const size =
+      consensus.MAX_BLOCK_OPENS *
+      (
+        this.network.names.treeInterval + 1 +
+        this.network.names.biddingPeriod +
+        this.network.names.revealPeriod
+      );
+    this.nameCache = new LRU(size, null, BufferMap);
   }
 
   /**
@@ -212,6 +223,7 @@ class ChainDB {
   async close() {
     await this.tree.close();
     this.txn = this.tree.txn();
+    this.nameCache.reset();
     return this.db.close();
   }
 
@@ -1187,7 +1199,10 @@ class ChainDB {
    */
 
   async getNameState(nameHash) {
-    const raw = await this.txn.get(nameHash);
+    let raw = this.nameCache.get(nameHash);
+
+    if (!raw)
+      raw = await this.txn.get(nameHash);
 
     if (!raw)
       return null;
@@ -1922,10 +1937,13 @@ class ChainDB {
 
       if (ns.isNull()) {
         await this.txn.remove(nameHash);
+        this.nameCache.remove(nameHash);
         continue;
       }
 
-      await this.txn.insert(nameHash, ns.encode());
+      const raw = ns.encode();
+      await this.txn.insert(nameHash, raw);
+      this.nameCache.set(nameHash, raw);
     }
 
     if ((entry.height % this.network.names.treeInterval) === 0) {

--- a/lib/node/fullnode.js
+++ b/lib/node/fullnode.js
@@ -64,6 +64,7 @@ class FullNode extends Node {
       prune: this.config.bool('prune'),
       checkpoints: this.config.bool('checkpoints'),
       entryCache: this.config.uint('entry-cache'),
+      nameCache: this.config.uint('name-cache'),
       chainMigrate: this.config.uint('chain-migrate'),
       indexTX: this.config.bool('index-tx'),
       indexAddress: this.config.bool('index-address')

--- a/test/chain-checkpoints-test.js
+++ b/test/chain-checkpoints-test.js
@@ -83,6 +83,7 @@ async function mineBlock(mtxs, claims, airdrops, label) {
   await chainGenerator.add(block);
 
   labels.push(label);
+  return block;
 }
 
 async function mineBlocks(n, label) {
@@ -345,6 +346,82 @@ describe('Checkpoints', function() {
       assert.deepStrictEqual(chain.tip.getJSON(), chainGenerator.tip.getJSON());
       assert.bufferEqual(chain.db.field.field, chainGenerator.db.field.field);
       assert.deepStrictEqual(chain.db.field, chainGenerator.db.field);
+    });
+
+    describe('Bypass NameState checks for BIDs under checkpoints', function() {
+      let name;
+      let invalidBlockEntry;
+
+      before(async () => {
+        name = rules.grindName(5, chainGenerator.height - 5, network);
+      });
+
+      after(async () => {
+        network.checkpointMap = {};
+        network.lastCheckpoint = 0;
+      });
+
+      it('should OPEN new auction', async () => {
+        const open = await wallet.sendOpen(name);
+        const block = await mineBlock([open], null, null, 'open new auction');
+
+        // Test chain still in sync
+        await chain.add(block);
+        assert.deepStrictEqual(
+          chain.db.state.getJSON(), chainGenerator.db.state.getJSON()
+        );
+        assert.deepStrictEqual(chain.tip.getJSON(), chainGenerator.tip.getJSON());
+        assert.bufferEqual(chain.db.field.field, chainGenerator.db.field.field);
+        assert.deepStrictEqual(chain.db.field, chainGenerator.db.field);
+      });
+
+      it('should mine an invalid BID in last checkpoint block', async () => {
+        // Name has not actually reached the bidding phase yet.
+        // We will force the wallet to create an invalid BID.
+        const restore = wallet.height;
+        wallet.height += network.names.treeInterval + 2;
+        const bid = await wallet.sendBid(name, 100, 200);
+        wallet.height = restore;
+
+        // This block is invalid!
+        const job = await cpu.createJob();
+        job.pushTX(bid.toTX());
+        job.refresh();
+        const invalidBlock = await job.mineAsync();
+
+        // Make this block the LAST CHECKPOINT
+        const height = chainGenerator.height + 1;
+        network.checkpointMap[height] = invalidBlock.hash();
+        network.lastCheckpoint = height;
+
+        // This will not throw even though the block is invalid
+        invalidBlockEntry = await chain.add(invalidBlock);
+
+        // Confirm that was the last checkpoint block
+        assert.strictEqual(invalidBlockEntry.height, network.lastCheckpoint);
+        assert.strictEqual(chain.height, network.lastCheckpoint);
+      });
+
+      it('should detect an invalid BID after last checkpoint block', async () => {
+        // Name has not actually reached the bidding phase yet.
+        // We will force the wallet into creating an invalid BID.
+        const restore = wallet.height;
+        wallet.height += network.names.treeInterval + 2;
+        const bid = await wallet.createBid(name, 300, 400);
+        wallet.height = restore;
+
+        // This block is invalid!
+        const job = await cpu.createJob(invalidBlockEntry);
+        job.pushTX(bid.toTX());
+        job.refresh();
+        const invalidBlock = await job.mineAsync();
+
+        // Now that we are 1 block past checkpoints we will throw
+        await assert.rejects(
+          chain.add(invalidBlock),
+          {reason: 'bad-bid-state'}
+        );
+      });
     });
   });
 });

--- a/test/chain-checkpoints-test.js
+++ b/test/chain-checkpoints-test.js
@@ -202,6 +202,22 @@ describe('Checkpoints', function() {
 
     await mineBlock([register1, register2], null, null, 'registers');
     await mineBlocks(10, 'after registers');
+
+    // No redeem for one-bid name1
+    const redeem2 = await wallet.sendRedeem(name2);
+    const redeem3 = await wallet.sendRedeem(name3);
+    await mineBlock([redeem2, redeem3], null, null, 'redeems');
+
+    const transfer1 = await wallet.sendTransfer(name1, wallet.getReceive());
+    const transfer2 = await wallet.sendTransfer(name2, wallet.getReceive());
+    await mineBlock([transfer1, transfer2], null, null, 'transfers');
+    await mineBlocks(network.names.lockupPeriod, 'after transfers');
+
+    const finalize1 = await wallet.sendCancel(name1);
+    await mineBlock([finalize1], null, null, 'finalize');
+
+    const revoke1 = await wallet.sendRevoke(name1);
+    await mineBlock([revoke1], null, null, 'revoke');
   });
 
   it('should bid in multiple blocks', async () => {

--- a/test/util/memwallet.js
+++ b/test/util/memwallet.js
@@ -1728,6 +1728,12 @@ class MemWallet {
     return mtx;
   }
 
+  async sendRedeem(name, options) {
+    const mtx = await this.createRedeem(name, options);
+    this.addTX(mtx.toTX());
+    return mtx;
+  }
+
   async sendRegister(name, resource, options) {
     const mtx = await this.createRegister(name, resource, options);
     this.addTX(mtx.toTX());


### PR DESCRIPTION
Closes https://github.com/handshake-org/hsd/issues/620

This PR attempts to use a cache to reduce the amount of Urkel Tree _reads_ when verifying blocks by keeping a cache of NameState objects in memory.

I'm not totally thrilled about the improvement so far but it looks like a speedup of about 10%:

```
# With NS Cache
Height: 54000 Total block processing time: 981962.5032880028 (0.27276736202444524 hours)
Total time elapsed: 1050000ms (0.2916666666666667 hours)

# Current Master Branch 754ca248b
Height: 54000 Total block processing time: 1188079.0263799946 (0.33002195177222066 hours)
Total time elapsed: 1232000ms (0.34222222222222226 hours)
```

The cache size I set to experiment with is huge and cost an additional 1.5 GB of RAM ;-) But we can of course tune that way down. I chose this size cache to start because it should be big enough to store the maximum possible simultaneous auctions on chain (Max # of OPENs per block * number of blocks in complete auction)