### PR TITLE
pkg: update bcfg

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,14 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@handshake-org/bcfg": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/@handshake-org/bcfg/-/bcfg-0.1.7.tgz",
+      "integrity": "sha512-tJ9ExRY2a8da+OI5hVvxIuMiBAtlvqrVQwgBD5AtGkm5l9fDlz9awzzl74j0hf8pxoeSQCdWbw6fpSjDz7lhZQ==",
+      "requires": {
+        "bsert": "~0.0.10"
+      }
+    },
     "bcfg": {
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/bcfg/-/bcfg-0.1.6.tgz",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "node": ">=8.0.0"
   },
   "dependencies": {
-    "bcfg": "~0.1.6",
+    "@handshake-org/bcfg": "~0.1.7",
     "bcrypto": "~5.4.0",
     "bdb": "~1.3.0",
     "bdns": "~0.1.5",


### PR DESCRIPTION
See https://github.com/bcoin-org/bcfg/pull/6

Instead of waiting for @chjj to merge, tag, release, and publish `bcfg` for this fix I'm going to try something new: I forked `bcfg` into `handshake-org` where I can merge, tag and release. @chjj recently also enabled my npm account to publish to the `@handshake-org` namespace, so that's where we can source small dependencies like this.