### PR TITLE
Wallet.fund() messes up existing inputs

### DIFF
--- a/lib/primitives/mtx.js
+++ b/lib/primitives/mtx.js
@@ -158,11 +158,19 @@ class MTX extends TX {
   addCoin(coin) {
     assert(coin instanceof Coin, 'Cannot add non-coin.');
 
-    const input = Input.fromCoin(coin);
+    // Avoid duplicate inputs
+    for (const input of this.inputs) {
+      const {hash, index} = input.prevout;
+      if (hash.equals(coin.hash) && index === coin.index) {
+        this.view.addCoin(coin);
+        return input;
+      }
+    }
 
+    // Coin represents a new input.
+    const input = Input.fromCoin(coin);
     this.inputs.push(input);
     this.view.addCoin(coin);
-
     return input;
   }
 

--- a/lib/primitives/mtx.js
+++ b/lib/primitives/mtx.js
@@ -1146,11 +1146,13 @@ class MTX extends TX {
     // (pre-signed) inputs OR add new "preferred" inputs for covenants.
     // The logic below was moved here from CoinSelector.fund() in case
     // the old method was used and "preferred" coins are not yet in the view.
-    if (this.inputs.length > 0) {
-      const inputPrevoutKeys = this.inputs.map(input => input.prevout.toKey());
+    for (const input of this.inputs) {
+      const {prevout} = input;
+      if (this.view.hasEntry(prevout))
+        continue;
+
       for (const coin of coins) {
-        const key = coin.toKey();
-        if (inputPrevoutKeys.some(prevout => prevout.equals(key))) {
+        if (prevout.hash.equals(coin.hash) && prevout.index === coin.index) {
           this.view.addCoin(coin);
         }
       }

--- a/lib/primitives/mtx.js
+++ b/lib/primitives/mtx.js
@@ -1122,11 +1122,19 @@ class MTX extends TX {
     assert(options, 'Options are required.');
     assert(options.changeAddress, 'Change address is required.');
 
+    // Hack in place to ensure backward compataibility with previous hack
+    if (this.inputs.length > 0) {
+      const inputPrevoutKeys = this.inputs.map(input => input.prevout.toKey());
+      for (const coin of coins) {
+        const {hash, index} = coin;
+        const key = Outpoint.toKey(hash, index);
+        if ( inputPrevoutKeys.some(prevout => prevout.equals(key)) ) {
+          this.view.addCoin(coin);
+        }
+      }
+    }
     // Select necessary coins.
     const select = await this.selectCoins(coins, options);
-
-    // Make sure we empty the input array.
-    this.inputs.length = 0;
 
     // Add coins to transaction.
     for (const coin of select.chosen)
@@ -1424,6 +1432,7 @@ class CoinSelector {
    */
 
   constructor(tx, options) {
+    this.parent = tx;
     this.tx = tx.clone();
     this.coins = [];
     this.outputValue = 0;
@@ -1569,6 +1578,12 @@ class CoinSelector {
       for (let i = 0; i < this.tx.inputs.length; i++) {
         const {prevout} = this.tx.inputs[i];
         this.inputs.set(prevout.toKey(), i);
+        const coin = this.parent.view.getCoin(prevout);
+        // If the coin is not in the view, it's value cannot be known,
+        // therefore it can't be funded correctly.
+        if(!coin)
+          throw new Error('Could not resolve input coin value');
+        this.tx.view.addCoin(coin);
       }
     }
   }
@@ -1585,7 +1600,6 @@ class CoinSelector {
     this.chosen = [];
     this.change = 0;
     this.fee = CoinSelector.MIN_FEE;
-    this.tx.inputs.length = 0;
 
     switch (this.selection) {
       case 'all':
@@ -1688,33 +1702,6 @@ class CoinSelector {
    */
 
   fund() {
-    // Ensure all preferred inputs first.
-    if (this.inputs.size > 0) {
-      const coins = [];
-
-      for (let i = 0; i < this.inputs.size; i++)
-        coins.push(null);
-
-      for (const coin of this.coins) {
-        const {hash, index} = coin;
-        const key = Outpoint.toKey(hash, index);
-        const i = this.inputs.get(key);
-
-        if (i != null) {
-          coins[i] = coin;
-          this.inputs.delete(key);
-        }
-      }
-
-      if (this.inputs.size > 0)
-        throw new Error('Could not resolve preferred inputs.');
-
-      for (const coin of coins) {
-        this.tx.addCoin(coin);
-        this.chosen.push(coin);
-      }
-    }
-
     if (this.isFull())
       return;
 

--- a/lib/primitives/mtx.js
+++ b/lib/primitives/mtx.js
@@ -1122,17 +1122,26 @@ class MTX extends TX {
     assert(options, 'Options are required.');
     assert(options.changeAddress, 'Change address is required.');
 
-    // Hack in place to ensure backward compataibility with previous hack
+    // Ensure backward compatibility with the old API:
+    // Inputs to MTX were added with mtx.addOutpoint() and then later
+    // CoinSelector.fund() was expected to match those outpoints with coins
+    // from the wallet. The problem with this is that when CoinSelector
+    // initialized, it wiped out all the inputs, including some that may have
+    // already been signed outside the wallet for custom scripts or CoinJoins.
+    // With the new API, mtx.addCoin() can be used to either fund existing
+    // (pre-signed) inputs OR add new "preferred" inputs for covenants.
+    // The logic below was moved here from CoinSelector.fund() in case
+    // the old method was used and "preferred" coins are not yet in the view.
     if (this.inputs.length > 0) {
       const inputPrevoutKeys = this.inputs.map(input => input.prevout.toKey());
       for (const coin of coins) {
-        const {hash, index} = coin;
-        const key = Outpoint.toKey(hash, index);
-        if ( inputPrevoutKeys.some(prevout => prevout.equals(key)) ) {
+        const key = coin.toKey();
+        if (inputPrevoutKeys.some(prevout => prevout.equals(key))) {
           this.view.addCoin(coin);
         }
       }
     }
+
     // Select necessary coins.
     const select = await this.selectCoins(coins, options);
 
@@ -1580,9 +1589,9 @@ class CoinSelector {
         this.inputs.set(prevout.toKey(), i);
         const coin = this.parent.view.getCoin(prevout);
         // If the coin is not in the view, it's value cannot be known,
-        // therefore it can't be funded correctly.
-        if(!coin)
-          throw new Error('Could not resolve input coin value');
+        // therefore the TX can't be funded correctly.
+        if (!coin)
+          throw new Error('Could not resolve input coin value.');
         this.tx.view.addCoin(coin);
       }
     }

--- a/lib/primitives/mtx.js
+++ b/lib/primitives/mtx.js
@@ -100,8 +100,7 @@ class MTX extends TX {
   }
 
   /**
-   * Clone the transaction. Note that
-   * this will not carry over the view.
+   * Clone the transaction and it's input coins.
    * @returns {MTX}
    */
 
@@ -109,6 +108,13 @@ class MTX extends TX {
     assert(mtx instanceof this.constructor);
     super.inject(mtx);
     this.changeIndex = mtx.changeIndex;
+
+    // CoinView has other properties like UndoCoins and BitView
+    // that an MTX doesn't care about. We just want a copy of the
+    // coins spent by the MTX.
+    for (const [key, value] of mtx.view.map.entries())
+      this.view.map.set(key, value);
+
     return this;
   }
 
@@ -1449,7 +1455,6 @@ class CoinSelector {
    */
 
   constructor(tx, options) {
-    this.parent = tx;
     this.tx = tx.clone();
     this.coins = [];
     this.outputValue = 0;
@@ -1595,12 +1600,6 @@ class CoinSelector {
       for (let i = 0; i < this.tx.inputs.length; i++) {
         const {prevout} = this.tx.inputs[i];
         this.inputs.set(prevout.toKey(), i);
-        const coin = this.parent.view.getCoin(prevout);
-        // If the coin is not in the view, it's value cannot be known,
-        // therefore the TX can't be funded correctly.
-        if (!coin)
-          throw new Error('Could not resolve input coin value.');
-        this.tx.view.addCoin(coin);
       }
     }
   }

--- a/lib/wallet/wallet.js
+++ b/lib/wallet/wallet.js
@@ -38,7 +38,6 @@ const {types} = rules;
 const {Mnemonic} = HD;
 const {BufferSet} = require('buffer-map');
 const Coin = require('../primitives/coin');
-const Outpoint = require('../primitives/outpoint');
 
 /*
  * Constants
@@ -1839,7 +1838,7 @@ class Wallet extends EventEmitter {
     output.covenant.pushHash(nameHash);
     output.covenant.pushU32(height);
     output.covenant.pushHash(nonce);
-    reveal.addOutpoint(Outpoint.fromTX(bid, bidOuputIndex));
+    reveal.addCoin(bidCoin);
     reveal.outputs.push(output);
 
     await this.fill(reveal, { ...options, coins: coins });
@@ -1926,7 +1925,7 @@ class Wallet extends EventEmitter {
       output.covenant.pushU32(ns.height);
       output.covenant.pushHash(nonce);
 
-      mtx.addOutpoint(prevout);
+      mtx.addCoin(coin);
       mtx.outputs.push(output);
     }
 
@@ -2051,7 +2050,7 @@ class Wallet extends EventEmitter {
       output.covenant.pushU32(ns.height);
       output.covenant.pushHash(nonce);
 
-      mtx.addOutpoint(prevout);
+      mtx.addCoin(coin);
       mtx.outputs.push(output);
     }
 
@@ -2176,7 +2175,7 @@ class Wallet extends EventEmitter {
       if (coin.height < ns.height)
         continue;
 
-      mtx.addOutpoint(prevout);
+      mtx.addCoin(coin);
 
       const output = new Output();
       output.address = coin.address;
@@ -2298,7 +2297,7 @@ class Wallet extends EventEmitter {
       if (coin.height < ns.height)
         continue;
 
-      mtx.addOutpoint(prevout);
+      mtx.addCoin(coin);
 
       const output = new Output();
       output.address = coin.address;
@@ -2444,7 +2443,7 @@ class Wallet extends EventEmitter {
     output.covenant.pushHash(await this.wdb.getRenewalBlock());
 
     const mtx = new MTX();
-    mtx.addOutpoint(ns.owner);
+    mtx.addCoin(coin);
     mtx.outputs.push(output);
 
     return mtx;
@@ -2524,7 +2523,7 @@ class Wallet extends EventEmitter {
     output.covenant.push(raw);
 
     const mtx = new MTX();
-    mtx.addOutpoint(ns.owner);
+    mtx.addCoin(coin);
     mtx.outputs.push(output);
 
     return mtx;
@@ -2663,7 +2662,7 @@ class Wallet extends EventEmitter {
     output.covenant.pushHash(await this.wdb.getRenewalBlock());
 
     const mtx = new MTX();
-    mtx.addOutpoint(ns.owner);
+    mtx.addCoin(coin);
     mtx.outputs.push(output);
 
     return mtx;
@@ -2797,7 +2796,7 @@ class Wallet extends EventEmitter {
     output.covenant.push(address.hash);
 
     const mtx = new MTX();
-    mtx.addOutpoint(ns.owner);
+    mtx.addCoin(coin);
     mtx.outputs.push(output);
 
     return mtx;
@@ -2933,7 +2932,7 @@ class Wallet extends EventEmitter {
     output.covenant.push(EMPTY);
 
     const mtx = new MTX();
-    mtx.addOutpoint(ns.owner);
+    mtx.addCoin(coin);
     mtx.outputs.push(output);
 
     return mtx;
@@ -3077,7 +3076,7 @@ class Wallet extends EventEmitter {
     output.covenant.pushHash(await this.wdb.getRenewalBlock());
 
     const mtx = new MTX();
-    mtx.addOutpoint(ns.owner);
+    mtx.addCoin(coin);
     mtx.outputs.push(output);
 
     return mtx;
@@ -3208,7 +3207,7 @@ class Wallet extends EventEmitter {
     output.covenant.pushU32(ns.height);
 
     const mtx = new MTX();
-    mtx.addOutpoint(ns.owner);
+    mtx.addCoin(coin);
     mtx.outputs.push(output);
 
     return mtx;

--- a/test/interactive-swap-test.js
+++ b/test/interactive-swap-test.js
@@ -208,11 +208,12 @@ describe('Interactive name swap', function() {
 
     // Bob should verify all the data in the MTX to ensure everything is valid,
     // but this is the minimum.
-    const input0 = mtx.input(0).clone(); // copy input with Alice's signature
-    const coinEntry = await node.chain.db.readCoin(input0.prevout);
+    const coinEntry = await node.chain.db.readCoin(mtx.input(0).prevout);
     assert(coinEntry); // ensures that coin exists and is still unspent
 
-    const coin = coinEntry.toCoin(input0.prevout);
+    const coin = coinEntry.toCoin(mtx.input(0).prevout);
+    mtx.view.addCoin(coin);
+
     assert(coin.covenant.type === types.TRANSFER);
     const addr = new Address({
       version: coin.covenant.items[2].readInt8(),
@@ -226,12 +227,8 @@ describe('Interactive name swap', function() {
     const changeAddress = await bob.changeAddress();
     const rate = await wdb.estimateFee();
     const coins = await bob.getSmartCoins();
-    // Add the external coin to the coin selector so we don't fail assertions
-    coins.push(coin);
+
     await mtx.fund(coins, {changeAddress, rate});
-    // The funding mechanism starts by wiping out existing inputs
-    // which for us includes Alice's signature. Replace it from our backup.
-    mtx.inputs[0].inject(input0);
 
     // Rearrange outputs.
     // Since we added a change output, the SINGELREVERSE is now broken:

--- a/test/interactive-swap-test.js
+++ b/test/interactive-swap-test.js
@@ -212,7 +212,7 @@ describe('Interactive name swap', function() {
     assert(coinEntry); // ensures that coin exists and is still unspent
 
     const coin = coinEntry.toCoin(mtx.input(0).prevout);
-    mtx.view.addCoin(coin);
+    mtx.addCoin(coin);
 
     assert(coin.covenant.type === types.TRANSFER);
     const addr = new Address({
@@ -222,13 +222,7 @@ describe('Interactive name swap', function() {
     assert.deepStrictEqual(addr, bobReceive); // transfer is to Bob's address
 
     // Fund the TX.
-    // The hsd wallet is not designed to handle partially-signed TXs
-    // or coins from outside the wallet, so a little hacking is needed.
-    const changeAddress = await bob.changeAddress();
-    const rate = await wdb.estimateFee();
-    const coins = await bob.getSmartCoins();
-
-    await mtx.fund(coins, {changeAddress, rate});
+    await bob.fund(mtx);
 
     // Rearrange outputs.
     // Since we added a change output, the SINGELREVERSE is now broken:

--- a/test/util/memwallet.js
+++ b/test/util/memwallet.js
@@ -1155,7 +1155,7 @@ class MemWallet {
       output.covenant.pushU32(ns.height);
       output.covenant.pushHash(nonce);
 
-      mtx.addOutpoint(prevout);
+      mtx.addCoin(coin);
       mtx.outputs.push(output);
     }
 
@@ -1207,7 +1207,7 @@ class MemWallet {
       if (coin.height < ns.height)
         continue;
 
-      mtx.addOutpoint(prevout);
+      mtx.addCoin(coin);
 
       const output = new Output();
       output.address = coin.address;
@@ -1286,7 +1286,7 @@ class MemWallet {
     output.covenant.pushHash(this.getRenewalBlock());
 
     const mtx = new MTX();
-    mtx.addOutpoint(ns.owner);
+    mtx.addCoin(coin);
     mtx.outputs.push(output);
 
     return this._create(mtx, options);
@@ -1348,7 +1348,7 @@ class MemWallet {
     output.covenant.push(resource);
 
     const mtx = new MTX();
-    mtx.addOutpoint(ns.owner);
+    mtx.addCoin(coin);
     mtx.outputs.push(output);
 
     return this._create(mtx, options);
@@ -1405,7 +1405,7 @@ class MemWallet {
     output.covenant.pushHash(this.getRenewalBlock());
 
     const mtx = new MTX();
-    mtx.addOutpoint(ns.owner);
+    mtx.addCoin(coin);
     mtx.outputs.push(output);
 
     return this._create(mtx, options);
@@ -1461,7 +1461,7 @@ class MemWallet {
     output.covenant.push(address.hash);
 
     const mtx = new MTX();
-    mtx.addOutpoint(ns.owner);
+    mtx.addCoin(coin);
     mtx.outputs.push(output);
 
     return this._create(mtx, options);
@@ -1516,7 +1516,7 @@ class MemWallet {
     output.covenant.push(EMPTY);
 
     const mtx = new MTX();
-    mtx.addOutpoint(ns.owner);
+    mtx.addCoin(coin);
     mtx.outputs.push(output);
 
     return this._create(mtx, options);
@@ -1582,7 +1582,7 @@ class MemWallet {
     output.covenant.pushHash(this.getRenewalBlock());
 
     const mtx = new MTX();
-    mtx.addOutpoint(ns.owner);
+    mtx.addCoin(coin);
     mtx.outputs.push(output);
 
     return this._create(mtx, options);
@@ -1635,7 +1635,7 @@ class MemWallet {
     output.covenant.pushU32(ns.height);
 
     const mtx = new MTX();
-    mtx.addOutpoint(ns.owner);
+    mtx.addCoin(coin);
     mtx.outputs.push(output);
 
     return this._create(mtx, options);


### PR DESCRIPTION
`wallet.fund()` used to mess up existing inputs for reasons mentioned below, this made it incredibly awkward to create transactions with custom inputs, this should fix those issues.

As I understand this, the issue was
1. The CoinSelector works by making a clone of the MTX and trying to add inputs to it till the output's value is met, and then returning those coins.
https://github.com/handshake-org/hsd/blob/484ede0b45c92249a4af81faf6579dcf1611edfc/lib/primitives/mtx.js#L1420-L1427

2. Because of how MTX cloning is done, the CoinView is not cloned, CoinView contained the input values, without which determining if a inputAmount is adequate is not possible.
https://github.com/handshake-org/hsd/blob/484ede0b45c92249a4af81faf6579dcf1611edfc/lib/primitives/mtx.js#L103-L109

3. So there is this "hack" in place which basically works by checking the prevout in the utxo set, and then "adding them back" and returning their list, but this would not always work cause the prevout could possibly be not in the utxo.
https://github.com/handshake-org/hsd/blob/484ede0b45c92249a4af81faf6579dcf1611edfc/lib/primitives/mtx.js#L1692-L1717

4. After which all the inputs of the MTX are wiped and the inputs from above are added "back"
https://github.com/handshake-org/hsd/blob/484ede0b45c92249a4af81faf6579dcf1611edfc/lib/primitives/mtx.js#L1126-L1133

~~This required changes to the current implementation of `interactive-name-swap` test since it used a "hack" which is no longer needed.~~
Backward compatibility with the previous hack is maintained for now.
Compatibility with Bob and Shakedex needs to be checked before merging, but is likely gonna be a non-issue.