### PR TITLE
Add node v16 to ci matrix, and remove v10

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [10.x, 12.x, 14.x]
+        node-version: [12.x, 14.x, 16.x]
 
     steps:
 


### PR DESCRIPTION
Node v10 reached it's EOL on 30-Apr-2021, and therefore i don't
see a need for running ci on that, v16 would soon be the LTS
version (from 26-Oct-2021) therefore needs to be tested on.