### PR TITLE
rpc/pool: use urkel proofs for namestate in spv mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ### Node changes
 
+- RPCs `getnameinfo` `getnameresource` `verifymessagewithname` and `getnamebyhash`
+now accept an additional boolean parameter `safe` which will resolve the name from the Urkel
+tree at the last "safe height" (committed tree root with > 12 confirmations). SPV
+nodes can use this option and retrieve Urkel proofs from the p2p network to respond
+to these calls.
+
 - New RPC methods:
   - `decoderesource` like `decodescript` accepts hex string as input and returns
   JSON formatted DNS records resource.
@@ -13,7 +19,6 @@
 - New RPC methods:
   - `createbatch` and `sendbatch` create batch transactions with any number
   of outputs with any combination of covenants.
-
 ## v4.0.0
 
 **When upgrading to this version of hsd you must pass

--- a/lib/net/pool.js
+++ b/lib/net/pool.js
@@ -4269,15 +4269,26 @@ class Pool extends EventEmitter {
   }
 
   /**
-   * Resolve a name.
+   * Resolve a name at the "safe" Urkel Tree root.
    * @param {Buffer} nameHash
    * @returns {Buffer}
    */
 
-  async resolve(nameHash) {
-    assert(Buffer.isBuffer(nameHash));
-
+   async resolve(nameHash) {
     const root = await this.chain.getSafeRoot();
+    return this.resolveAtRoot(nameHash, root);
+   }
+
+  /**
+   * Resolve a name given any Urkel Tree root.
+   * @param {Buffer} nameHash
+   * @param {Buffer} root
+   * @returns {Buffer}
+   */
+
+  async resolveAtRoot(nameHash, root) {
+    assert(Buffer.isBuffer(nameHash));
+    assert(Buffer.isBuffer(root));
 
     if (!this.chain.synced)
       throw new Error('Chain is not synced.');

--- a/lib/node/rpc.js
+++ b/lib/node/rpc.js
@@ -2196,15 +2196,16 @@ class RPC extends RPCBase {
   }
 
   async verifyMessageWithName(args, help) {
-    if (help || args.length !== 3) {
+    if (help || args.length < 3 || args.length > 4 ) {
       throw new RPCError(errs.MISC_ERROR,
-        'verifymessagewithname "name" "signature" "message"');
+        'verifymessagewithname "name" "signature" "message" (safe)');
     }
 
     const valid = new Validator(args);
     const name = valid.str(0, '');
     const sig = valid.buf(1, null, 'base64');
     const str = valid.str(2);
+    const safe = valid.bool(3, false);
     const network = this.network;
     const height = this.chain.height;
 
@@ -2212,7 +2213,8 @@ class RPC extends RPCBase {
       throw new RPCError(errs.TYPE_ERROR, 'Invalid name.');
 
     const nameHash = rules.hashName(name);
-    const ns = await this.chain.db.getNameState(nameHash);
+
+    const ns = await this.getNameState(nameHash, safe);
 
     if (!ns || !ns.owner)
       throw new RPCError(errs.MISC_ERROR, 'Cannot find the name owner.');
@@ -2415,11 +2417,12 @@ class RPC extends RPCBase {
   }
 
   async getNameInfo(args, help) {
-    if (help || args.length !== 1)
-      throw new RPCError(errs.MISC_ERROR, 'getnameinfo "name"');
+    if (help || args.length < 1 || args.length > 2)
+      throw new RPCError(errs.MISC_ERROR, 'getnameinfo "name" (safe)');
 
     const valid = new Validator(args);
     const name = valid.str(0);
+    const safe = valid.bool(1, false);
 
     if (!name || !rules.verifyName(name))
       throw new RPCError(errs.TYPE_ERROR, 'Invalid name.');
@@ -2429,7 +2432,8 @@ class RPC extends RPCBase {
     const nameHash = rules.hashName(name);
     const reserved = rules.isReserved(nameHash, height + 1, network);
     const [start, week] = rules.getRollout(nameHash, network);
-    const ns = await this.chain.db.getNameState(nameHash);
+
+    const ns = await this.getNameState(nameHash, safe);
 
     let info = null;
 
@@ -2449,17 +2453,19 @@ class RPC extends RPCBase {
   }
 
   async getNameResource(args, help) {
-    if (help || args.length !== 1)
-      throw new RPCError(errs.MISC_ERROR, 'getnameresource "name"');
+    if (help || args.length < 1 || args.length > 2)
+      throw new RPCError(errs.MISC_ERROR, 'getnameresource "name" (safe)');
 
     const valid = new Validator(args);
     const name = valid.str(0);
+    const safe = valid.bool(1, false);
 
     if (!name || !rules.verifyName(name))
       throw new RPCError(errs.TYPE_ERROR, 'Invalid name.');
 
     const nameHash = rules.hashName(name);
-    const ns = await this.chain.db.getNameState(nameHash);
+
+    const ns = await this.getNameState(nameHash, safe);
 
     if (!ns || ns.data.length === 0)
       return null;
@@ -2518,16 +2524,17 @@ class RPC extends RPCBase {
   }
 
   async getNameByHash(args, help) {
-    if (help || args.length !== 1)
-      throw new RPCError(errs.MISC_ERROR, 'getnamebyhash "hash"');
+    if (help || args.length < 1 || args.length > 2)
+      throw new RPCError(errs.MISC_ERROR, 'getnamebyhash "hash" (safe)');
 
     const valid = new Validator(args);
     const hash = valid.bhash(0);
+    const safe = valid.bool(1, false);
 
     if (!hash)
       throw new RPCError(errs.TYPE_ERROR, 'Invalid name hash.');
 
-    const ns = await this.chain.db.getNameState(hash);
+    const ns = await this.getNameState(hash, safe);
 
     if (!ns)
       return null;
@@ -3095,6 +3102,29 @@ class RPC extends RPCBase {
       ancestorfees: 0,
       depends: this.mempool.getDepends(entry.tx)
     };
+  }
+
+  async getNameState(nameHash, safe) {
+    if (!safe) {
+      // Will always return null in SPV mode
+      return this.chain.db.getNameState(nameHash);
+    }
+
+    // Safe roots are the last Urkel tree commitment
+    // with more than 12 confirmations.
+    const root = await this.chain.getSafeRoot();
+    let data;
+    if (this.chain.options.spv)
+      data = await this.pool.resolveAtRoot(nameHash, root);
+    else
+      data = await this.chain.db.lookup(root, nameHash);
+
+    if (!data)
+      return null;
+
+    const ns = NameState.decode(data);
+    ns.nameHash = nameHash;
+    return ns;
   }
 }
 


### PR DESCRIPTION
Closes https://github.com/handshake-org/hsd/issues/646
Also see https://github.com/kyokan/bob-wallet/pull/409

Restores SPV node RPC functionality for `getnameinfo` `getnameresource` `verifymessagewithname` and `getnamebyhash`.

Each of these rpcs now accepts an extra boolean parameter `safe`. When `true`, the node gets historical data from the "safe height" which is **the last tree root commitment with more than 12 confirmations**. This is obviously historical data that any full node will have locally, but is also data that can be retrieved from the p2p network by an SPV node. This is the exact same mechanism used by SPV (and hnsd) for light client name resolution.

Example:
## Full Node
```
# get current info
hsd-rpc getnameinfo chaos

# get info committed at last tree interval
hsd-rpc getnameinfo chaos true
```

## SPV Node
```
# ALWAYS NULL
hsd-rpc getnameinfo chaos

# get info committed at last tree interval (gets proof from p2p network)
hsd-rpc getnameinfo chaos true
```

Here's the tradeoffs for using "safe height":
👍 SPV nodes can getnameinfo and getnameresource without relying on a centralized API
👎 This data may be outdated since it can only be verified with the most recent urkel tree root commitment 
👎 Getting Urkel proofs from the p2p network may be slow and the RPC may time out