### PR TITLE
Gracefully shut down node on critical errors like full disk

### DIFF
--- a/bin/node
+++ b/bin/node
@@ -50,6 +50,26 @@ process.on('SIGINT', async () => {
   await node.close();
 });
 
+node.on('abort', async (err) => {
+  const timeout = setTimeout(() => {
+    console.error('Shutdown is taking a long time. Exitting.');
+    process.exit(3);
+  }, 5000);
+
+  timeout.unref();
+
+  try {
+    console.error('Shutting down...');
+    await node.close();
+    clearTimeout(timeout);
+    console.error(err.stack);
+    process.exit(2);
+  } catch (e) {
+    console.error(`Error occurred during shutdown: ${e.message}`);
+    process.exit(3);
+  }
+});
+
 (async () => {
   await node.ensure();
   await node.open();

--- a/bin/spvnode
+++ b/bin/spvnode
@@ -67,6 +67,26 @@ process.on('SIGINT', async () => {
   await node.close();
 });
 
+node.on('abort', async (err) => {
+  const timeout = setTimeout(() => {
+    console.error('Shutdown is taking a long time. Exitting.');
+    process.exit(3);
+  }, 5000);
+
+  timeout.unref();
+
+  try {
+    console.error('Shutting down...');
+    await node.close();
+    clearTimeout(timeout);
+    console.error(err.stack);
+    process.exit(2);
+  } catch (e) {
+    console.error(`Error occurred during shutdown: ${e.message}`);
+    process.exit(3);
+  }
+});
+
 (async () => {
   await node.ensure();
   await node.open();

--- a/lib/blockchain/chain.js
+++ b/lib/blockchain/chain.js
@@ -2172,6 +2172,10 @@ class Chain extends AsyncEmitter {
       await this.db.compactTree(entry);
       await this.syncTree();
       this.emit('tree compact end', entry.treeRoot, entry);
+    } catch(e) {
+      const error = new CriticalError(e.message);
+      this.emit('abort', error);
+      throw error;
     } finally {
       unlock();
     }

--- a/lib/blockchain/chain.js
+++ b/lib/blockchain/chain.js
@@ -26,6 +26,7 @@ const Script = require('../script/script');
 const {VerifyError} = require('../protocol/errors');
 const {OwnershipProof} = require('../covenants/ownership');
 const AirdropProof = require('../primitives/airdropproof');
+const {CriticalError} = require('../errors');
 const thresholdStates = common.thresholdStates;
 const {states} = NameState;
 
@@ -996,8 +997,10 @@ class Chain extends AsyncEmitter {
       const ns = await view.getNameState(this.db, nameHash);
 
       if (ns.isNull()) {
-        if (!covenant.isClaim() && !covenant.isOpen())
-          throw new Error('Database inconsistency.');
+        if (!covenant.isClaim() && !covenant.isOpen()) {
+          this.emit('abort', 'Unexpected null NameState.');
+          throw new CriticalError('Database inconsistency.');
+        }
 
         const name = covenant.get(2);
         ns.set(name, height);
@@ -1893,7 +1896,12 @@ class Chain extends AsyncEmitter {
     }
 
     // Save block and connect inputs.
-    await this.db.save(entry, block, view);
+    try {
+      await this.db.save(entry, block, view);
+    } catch (e) {
+      this.emit('abort', e.message);
+      throw new CriticalError(e);
+    }
 
     // Expose the new state.
     this.tip = entry;
@@ -1952,7 +1960,12 @@ class Chain extends AsyncEmitter {
         entry.height, util.hex32(entry.version));
     }
 
-    await this.db.save(entry, block);
+    try {
+      await this.db.save(entry, block);
+    } catch (e) {
+      this.emit('abort', e.message);
+      throw new CriticalError(e);
+    }
 
     this.logger.warning('Heads up: Competing chain at height %d:'
       + ' tip-height=%d competitor-height=%d'

--- a/lib/blockchain/chain.js
+++ b/lib/blockchain/chain.js
@@ -998,8 +998,9 @@ class Chain extends AsyncEmitter {
 
       if (ns.isNull()) {
         if (!covenant.isClaim() && !covenant.isOpen()) {
-          this.emit('abort', 'Unexpected null NameState.');
-          throw new CriticalError('Database inconsistency.');
+          const error = new CriticalError('Database inconsistency.');
+          this.emit('abort', error);
+          throw error;
         }
 
         const name = covenant.get(2);
@@ -1899,8 +1900,9 @@ class Chain extends AsyncEmitter {
     try {
       await this.db.save(entry, block, view);
     } catch (e) {
-      this.emit('abort', e.message);
-      throw new CriticalError(e);
+      const error = new CriticalError(e.message);
+      this.emit('abort', error);
+      throw error;
     }
 
     // Expose the new state.
@@ -1963,8 +1965,9 @@ class Chain extends AsyncEmitter {
     try {
       await this.db.save(entry, block);
     } catch (e) {
-      this.emit('abort', e.message);
-      throw new CriticalError(e);
+      const error = new CriticalError(e.message);
+      this.emit('abort', error);
+      throw error;
     }
 
     this.logger.warning('Heads up: Competing chain at height %d:'

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -1,0 +1,60 @@
+/*!
+ * errors.js - internal error objects for hsd
+ * Copyright (c) 2022 The Handshake Developers (MIT License).
+ * https://github.com/handshake-org/hsd
+ */
+
+'use strict';
+
+/**
+ * @module errors
+ */
+
+const assert = require('bsert');
+
+/**
+ * Critical Error
+ * An error severe enough to warrant shutting down the node.
+ * @extends Error
+ * @param {Block|TX} msg
+ * @param {String} code - Reject packet code.
+ * @param {String} reason - Reject packet reason.
+ * @param {Number} score - Ban score increase
+ * (can be -1 for no reject packet).
+ * @param {Boolean} malleated
+ */
+
+class CriticalError extends Error {
+  /**
+   * Create a verify error.
+   * @constructor
+   * @param {Block|TX} msg
+   * @param {String} code - Reject packet code.
+   * @param {String} reason - Reject packet reason.
+   * @param {Number} score - Ban score increase
+   * (can be -1 for no reject packet).
+   * @param {Boolean} malleated
+   */
+
+  constructor(err) {
+    super();
+
+    this.type = 'CriticalError';
+
+    if (err instanceof Error) {
+      this.message = `Critical Error: ${err.message}`;
+    } else {
+      assert(typeof err === 'string');
+      this.message = `Critical Error: ${err}`;
+    }
+
+    if (Error.captureStackTrace)
+      Error.captureStackTrace(this, CriticalError);
+  }
+}
+
+/*
+ * Expose
+ */
+
+exports.CriticalError = CriticalError;

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -10,43 +10,24 @@
  * @module errors
  */
 
-const assert = require('bsert');
-
 /**
  * Critical Error
  * An error severe enough to warrant shutting down the node.
  * @extends Error
- * @param {Block|TX} msg
- * @param {String} code - Reject packet code.
- * @param {String} reason - Reject packet reason.
- * @param {Number} score - Ban score increase
- * (can be -1 for no reject packet).
- * @param {Boolean} malleated
  */
 
 class CriticalError extends Error {
   /**
    * Create a verify error.
    * @constructor
-   * @param {Block|TX} msg
-   * @param {String} code - Reject packet code.
-   * @param {String} reason - Reject packet reason.
-   * @param {Number} score - Ban score increase
-   * (can be -1 for no reject packet).
-   * @param {Boolean} malleated
+   * @param {String} msg
    */
 
-  constructor(err) {
+  constructor(msg) {
     super();
 
     this.type = 'CriticalError';
-
-    if (err instanceof Error) {
-      this.message = `Critical Error: ${err.message}`;
-    } else {
-      assert(typeof err === 'string');
-      this.message = `Critical Error: ${err}`;
-    }
+    this.message = `Critical Error: ${msg}`;
 
     if (Error.captureStackTrace)
       Error.captureStackTrace(this, CriticalError);

--- a/lib/hsd.js
+++ b/lib/hsd.js
@@ -72,6 +72,9 @@ hsd.define('Rules', './covenants/rules');
 hsd.define('dns', './dns/server');
 hsd.define('resource', './dns/resource');
 
+// Errors
+hsd.define('errors', './errors');
+
 // HD
 hsd.define('hd', './hd');
 hsd.define('HDPrivateKey', './hd/private');

--- a/lib/node/fullnode.js
+++ b/lib/node/fullnode.js
@@ -197,7 +197,7 @@ class FullNode extends Node {
   init() {
     // Bind to errors
     this.chain.on('error', err => this.error(err));
-    this.chain.on('abort', msg => this.abort(msg));
+    this.chain.on('abort', err => this.abort(err));
 
     this.mempool.on('error', err => this.error(err));
     this.pool.on('error', err => this.error(err));
@@ -349,23 +349,6 @@ class FullNode extends Node {
     this.logger.info('Node is closed.');
     this.emit('closed');
   }
-
-  /**
-   * Emergency shutdown.
-   * @param {String} msg - error message
-   * @returns {Promise}
-   */
-
-   async abort(msg) {
-      this.logger.error(`Critical error, shutting down: ${msg}`);
-      try {
-        this.emit('abort', msg);
-        await this.close();
-      } catch (e) {
-        this.logger.error(`Error occurred during shutdown: ${e.message}`);
-        process.exit(-2);
-      }
-   }
 
   /**
    * Rescan for any missed transactions.

--- a/lib/node/fullnode.js
+++ b/lib/node/fullnode.js
@@ -197,6 +197,17 @@ class FullNode extends Node {
   init() {
     // Bind to errors
     this.chain.on('error', err => this.error(err));
+    this.chain.on('abort', async (msg) => {
+      this.logger.error(`Critical error, shutting down: ${msg}`);
+      try {
+        this.emit('abort', msg);
+        await this.close();
+      } catch (e) {
+        this.logger.error(`Error occurred during shutdown: ${e.message}`);
+        process.exit(-2);
+      }
+    });
+
     this.mempool.on('error', err => this.error(err));
     this.pool.on('error', err => this.error(err));
     this.miner.on('error', err => this.error(err));
@@ -345,6 +356,7 @@ class FullNode extends Node {
     await this.handleClose();
 
     this.logger.info('Node is closed.');
+    this.emit('closed');
   }
 
   /**

--- a/lib/node/fullnode.js
+++ b/lib/node/fullnode.js
@@ -197,16 +197,7 @@ class FullNode extends Node {
   init() {
     // Bind to errors
     this.chain.on('error', err => this.error(err));
-    this.chain.on('abort', async (msg) => {
-      this.logger.error(`Critical error, shutting down: ${msg}`);
-      try {
-        this.emit('abort', msg);
-        await this.close();
-      } catch (e) {
-        this.logger.error(`Error occurred during shutdown: ${e.message}`);
-        process.exit(-2);
-      }
-    });
+    this.chain.on('abort', msg => this.abort(msg));
 
     this.mempool.on('error', err => this.error(err));
     this.pool.on('error', err => this.error(err));
@@ -358,6 +349,23 @@ class FullNode extends Node {
     this.logger.info('Node is closed.');
     this.emit('closed');
   }
+
+  /**
+   * Emergency shutdown.
+   * @param {String} msg - error message
+   * @returns {Promise}
+   */
+
+   async abort(msg) {
+      this.logger.error(`Critical error, shutting down: ${msg}`);
+      try {
+        this.emit('abort', msg);
+        await this.close();
+      } catch (e) {
+        this.logger.error(`Error occurred during shutdown: ${e.message}`);
+        process.exit(-2);
+      }
+   }
 
   /**
    * Rescan for any missed transactions.

--- a/lib/node/node.js
+++ b/lib/node/node.js
@@ -361,8 +361,10 @@ class Node extends EventEmitter {
 
     this.stack.push(instance);
 
-    if (typeof instance.on === 'function')
+    if (typeof instance.on === 'function') {
       instance.on('error', err => this.error(err));
+      instance.on('abort', msg => this.abort(msg));
+    }
 
     return instance;
   }

--- a/lib/node/node.js
+++ b/lib/node/node.js
@@ -306,6 +306,17 @@ class Node extends EventEmitter {
   }
 
   /**
+   * Emit and log an abort error.
+   * @private
+   * @param {Error} err
+   */
+
+  abort(err) {
+    this.logger.error(err);
+    this.emit('abort', err);
+  }
+
+  /**
    * Get node uptime in seconds.
    * @returns {Number}
    */

--- a/lib/node/spvnode.js
+++ b/lib/node/spvnode.js
@@ -130,6 +130,17 @@ class SPVNode extends Node {
   init() {
     // Bind to errors
     this.chain.on('error', err => this.error(err));
+    this.chain.on('abort', async (msg) => {
+      this.logger.error(`Critical error, shutting down: ${msg}`);
+      try {
+        this.emit('abort', msg);
+        await this.close();
+      } catch (e) {
+        this.logger.error(`Error occurred during shutdown: ${e.message}`);
+        process.exit(-2);
+      }
+    });
+
     this.pool.on('error', err => this.error(err));
 
     if (this.http)
@@ -214,6 +225,9 @@ class SPVNode extends Node {
     await this.pool.close();
     await this.chain.close();
     await this.handleClose();
+
+    this.logger.info('Node is closed.');
+    this.emit('closed');
   }
 
   /**

--- a/lib/node/spvnode.js
+++ b/lib/node/spvnode.js
@@ -130,7 +130,7 @@ class SPVNode extends Node {
   init() {
     // Bind to errors
     this.chain.on('error', err => this.error(err));
-    this.chain.on('abort', msg => this.abort(msg));
+    this.chain.on('abort', err => this.abort(err));
 
     this.pool.on('error', err => this.error(err));
 
@@ -220,23 +220,6 @@ class SPVNode extends Node {
     this.logger.info('Node is closed.');
     this.emit('closed');
   }
-
-  /**
-   * Emergency shutdown.
-   * @param {String} msg - error message
-   * @returns {Promise}
-   */
-
-   async abort(msg) {
-      this.logger.error(`Critical error, shutting down: ${msg}`);
-      try {
-        this.emit('abort', msg);
-        await this.close();
-      } catch (e) {
-        this.logger.error(`Error occurred during shutdown: ${e.message}`);
-        process.exit(-2);
-      }
-   }
 
   /**
    * Scan for any missed transactions.

--- a/lib/node/spvnode.js
+++ b/lib/node/spvnode.js
@@ -130,16 +130,7 @@ class SPVNode extends Node {
   init() {
     // Bind to errors
     this.chain.on('error', err => this.error(err));
-    this.chain.on('abort', async (msg) => {
-      this.logger.error(`Critical error, shutting down: ${msg}`);
-      try {
-        this.emit('abort', msg);
-        await this.close();
-      } catch (e) {
-        this.logger.error(`Error occurred during shutdown: ${e.message}`);
-        process.exit(-2);
-      }
-    });
+    this.chain.on('abort', msg => this.abort(msg));
 
     this.pool.on('error', err => this.error(err));
 
@@ -229,6 +220,23 @@ class SPVNode extends Node {
     this.logger.info('Node is closed.');
     this.emit('closed');
   }
+
+  /**
+   * Emergency shutdown.
+   * @param {String} msg - error message
+   * @returns {Promise}
+   */
+
+   async abort(msg) {
+      this.logger.error(`Critical error, shutting down: ${msg}`);
+      try {
+        this.emit('abort', msg);
+        await this.close();
+      } catch (e) {
+        this.logger.error(`Error occurred during shutdown: ${e.message}`);
+        process.exit(-2);
+      }
+   }
 
   /**
    * Scan for any missed transactions.

--- a/test/node-critical-error-test.js
+++ b/test/node-critical-error-test.js
@@ -88,6 +88,14 @@ describe('Node Critical Error', function() {
       node.once('closed', () => resolve());
     });
 
+    node.on('abort', async () => {
+      try {
+        await node.close();
+      } catch (e) {
+        ;
+      }
+    });
+
     await mineBlocks(node, 99);
     node.chain.db.db.batch = () => {
       return {
@@ -110,6 +118,14 @@ describe('Node Critical Error', function() {
   it('should run out of disk space on tree commit and abort', async () => {
     const waiter = new Promise((resolve) => {
       node.once('closed', () => resolve());
+    });
+
+    node.on('abort', async () => {
+      try {
+        await node.close();
+      } catch (e) {
+        ;
+      }
     });
 
     await mineBlocks(node, 50);

--- a/test/node-critical-error-test.js
+++ b/test/node-critical-error-test.js
@@ -62,7 +62,8 @@ describe('Node Critical Error', function() {
         //   at async Parser.<anonymous> (hsd/lib/net/peer.js:185:9)
         await node.chain.add(block);
       } catch (e) {
-        assert.strictEqual(e.message, 'Disk full!');
+        assert.strictEqual(e.message, 'Critical Error: Disk full!');
+        assert.strictEqual(e.type, 'CriticalError');
         break;
       }
     }

--- a/test/node-critical-error-test.js
+++ b/test/node-critical-error-test.js
@@ -1,0 +1,125 @@
+/* eslint-env mocha */
+
+'use strict';
+
+const assert = require('bsert');
+const FullNode = require('../lib/node/fullnode');
+const {rimraf, testdir} = require('./util/common');
+
+describe('Node Critical Error', function() {
+  this.timeout(30000);
+
+  let prefix, node;
+
+  beforeEach(async () => {
+    prefix = testdir('hsd-critical-error-test');
+    node = new FullNode({
+      memory: false,
+      network: 'regtest',
+      prefix
+    });
+    await node.ensure();
+    await node.open();
+  });
+
+  afterEach(async () => {
+    if (node && node.opened)
+      await node.close();
+    await rimraf(prefix);
+  });
+
+  async function mineBlocks(node, count) {
+    for (let i = 0; i < count; i++) {
+      if (!node || !node.opened)
+        break;
+
+      const block = await node.miner.mineBlock(
+        null,
+        'rs1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqn6kda'
+      );
+
+      try {
+        // We are catching this error in the test but normally
+        // it would bubble up all the way from blockstore to Peer,
+        // where it is caught and logged, then we disconnect the peer
+        // that sent us whatever data caused the error (even if it's our fault!)
+        //
+        // [error] (net) Could not write block.
+        //   at FileBlockStore._write (hsd/lib/blockstore/file.js:424:13)
+        //   at async FileBatch.write (hsd/lib/blockstore/file.js:755:11)
+        //   at async ChainDB.commit (hsd/lib/blockchain/chaindb.js:332:7)
+        //   at async ChainDB.save (hsd/lib/blockchain/chaindb.js:1531:5)
+        //   at async Chain.setBestChain (hsd/lib/blockchain/chain.js:1835:5)
+        //   at async Chain.connect (hsd/lib/blockchain/chain.js:2236:7)
+        //   at async Chain._add (hsd/lib/blockchain/chain.js:2145:19)
+        //   at async Chain.add (hsd/lib/blockchain/chain.js:2073:14)
+        //   at async Pool._addBlock (hsd/lib/net/pool.js:2459:15)
+        //   at async Pool.addBlock (hsd/lib/net/pool.js:2426:14)
+        //   at async Pool.handleBlock (hsd/lib/net/pool.js:2410:5)
+        //   at async Pool.handlePacket (hsd/lib/net/pool.js:1331:9)
+        //   at async Peer.handlePacket (hsd/lib/net/peer.js:1549:7)
+        //   at async Peer.readPacket (hsd/lib/net/peer.js:1486:11)
+        //   at async Parser.<anonymous> (hsd/lib/net/peer.js:185:9)
+        await node.chain.add(block);
+      } catch (e) {
+        assert.strictEqual(e.message, 'Disk full!');
+        break;
+      }
+    }
+  }
+
+  it('should not run out of disk space', async () => {
+    await mineBlocks(node, 100);
+    assert.strictEqual(node.chain.height, 100);
+    assert.strictEqual(node.opened, true);
+    assert.strictEqual(node.chain.opened, true);
+    assert.strictEqual(node.chain.db.db.loaded, true);
+    assert.strictEqual(node.chain.db.blocks.db.loaded, true);
+    await node.close();
+    assert.strictEqual(node.opened, false);
+    assert.strictEqual(node.chain.opened, false);
+    assert.strictEqual(node.chain.db.db.loaded, false);
+    assert.strictEqual(node.chain.db.blocks.db.loaded, false);
+  });
+
+  it('should run out of disk space on block write and abort', async () => {
+    const waiter = new Promise((resolve) => {
+      node.once('closed', () => resolve());
+    });
+
+    await mineBlocks(node, 99);
+    node.chain.db.db.batch = () => {
+      return {
+        clear: () => {},
+        put: () => {},
+        del: () => {},
+        write: () => {
+          throw new Error('Disk full!');
+        }
+      };
+    };
+    await mineBlocks(node, 1);
+    await waiter;
+    assert.strictEqual(node.opened, false);
+    assert.strictEqual(node.chain.opened, false);
+    assert.strictEqual(node.chain.db.db.loaded, false);
+    assert.strictEqual(node.chain.db.blocks.db.loaded, false);
+  });
+
+  it('should run out of disk space on tree commit and abort', async () => {
+    const waiter = new Promise((resolve) => {
+      node.once('closed', () => resolve());
+    });
+
+    await mineBlocks(node, 50);
+    node.chain.db.tree.store.commit = () => {
+      throw new Error('Disk full!');
+    };
+    await mineBlocks(node, 50);
+    await waiter;
+    assert.strictEqual(node.opened, false);
+    assert.strictEqual(node.chain.opened, false);
+    assert.strictEqual(node.chain.db.db.loaded, false);
+    assert.strictEqual(node.chain.db.blocks.db.loaded, false);
+  });
+});


### PR DESCRIPTION
Closes https://github.com/handshake-org/hsd/issues/642
(although there may be more places where this extreme action is warranted)

This PR adds a new test utility: RAMDisk. This is a cute trick where we create a virtual storage device in RAM that is really small (1 MB) then run a full node inside it until we fill up the disk. I tried to ensure that even in test suite failures we don't end up with a bunch of tiny volumes still mounted, but it may take some more work to make sure everything is super clean.

TODO:
- [ ] Apply to MIgrateBlockstore and test
- [x] Either skip test on Windows or implement RAMDisk for Windows (currently CI only runs on Linux)
- [x] Remove logConsole from test nodes (I just wanna see how it runs on CI first)