### PR TITLE
dockerfile: upgrade use node v14

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:10-alpine AS base
+FROM node:14-alpine AS base
 WORKDIR /opt/hsd
 RUN apk add --no-cache bash unbound-dev gmp-dev
 COPY package.json /opt/hsd


### PR DESCRIPTION
This bumps the node version used in the base docker image. The change is intended to bring things in-line with https://github.com/handshake-org/hsd/commit/66f83f72443eaed68b734d1eba89aedc53c938f6.