### PR TITLE
test: sighash_noinput is not implemented correctly

### DIFF
--- a/lib/primitives/tx.js
+++ b/lib/primitives/tx.js
@@ -276,6 +276,17 @@ class TX extends bio.Struct {
     let sequences = consensus.ZERO_HASH;
     let outputs = consensus.ZERO_HASH;
 
+    // SIGHASH_NOINPUT does not commit to "this input's data", meaning the
+    // outpoint and sequence of this input (only this input) is malleable.
+    // However, our implementation neglects to also nullify the `prevouts`
+    // and `sequences` values as specified in the original SIGHASH_NOINPUT BIP
+    // https://blockstream.com/eltoo.pdf (appendix A).
+    // This means that our NOINPUT is not useful by itself, because even though
+    // it removes this input's outpoint from one part of the signed data, it
+    // leaves it in place in a different part, so it is still committed to by
+    // the signature.
+    // Note that eltoo's NOINPUT and it's successor BIP-118 also make committing
+    // to the witness script optional (in our code that value is called `prev`).
     if (type & hashType.NOINPUT)
       input = new Input();
 


### PR DESCRIPTION
Description of this PR is also added as a comment in tx.js:

SIGHASH_NOINPUT does not commit to "this input's data", meaning the
outpoint and sequence of this input (only this input) is malleable.
However, our implementation neglects to also nullify the `prevouts`
and `sequences` values as specified in the original SIGHASH_NOINPUT BIP
https://blockstream.com/eltoo.pdf (appendix A).
This means that our NOINPUT is not useful, because even though it removes
this input's outpoint from one part of the signed data, it leaves it in
place in a different part, so it is still committed to by the signature.
Note that eltoo's NOINPUT and it's successor BIP-118 also make committing
to the witness script optional (in our code that value is called `prev`).

This may end up being not a big deal, adding ANYONECANPAY i think just gets you the equivalent of the original NOINPUT anyway.