### PR TITLE
Add unicode lint - allow only ASCII symbols

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -23,7 +23,7 @@ jobs:
 
     - name: Install
       run: sudo apt-get install -y libunbound-dev |
-           npm install nyc coveralls bslint @hns-dev/bsdoc
+           npm install nyc@15.1.0 coveralls@3.1.1 bslint@5.15.3 @hns-dev/bsdoc@1.0.0
 
     - name: Lint
       run: npm run lint-ci

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -26,7 +26,7 @@ jobs:
            npm install nyc coveralls bslint @hns-dev/bsdoc
 
     - name: Lint
-      run: npm run lint
+      run: npm run lint-ci
 
     - name: Build Docs
       run: npm run build-docs

--- a/package.json
+++ b/package.json
@@ -65,6 +65,8 @@
     "build-docs": "jsdoc -c jsdoc.json",
     "lint": "eslint $(cat .eslintfiles)",
     "lint-file": "eslint",
+    "lint-unicode": "./scripts/unicode-lint.sh",
+    "lint-ci": "npm run lint && npm run lint-unicode",
     "test": "bmocha --reporter spec test/*.js",
     "test-browser": "NODE_BACKEND=js bmocha --reporter spec test/*.js",
     "test-file": "bmocha --reporter spec",

--- a/scripts/unicode-lint.sh
+++ b/scripts/unicode-lint.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+
+filter_ignore() {
+  # Filter Mnemonic keywords
+  filtered=`echo "$1" | grep -v '^\./lib/hd/words/\(french\|italian\|japanese\|spanish\|chinese-traditional\|chinese-simplified\)\.js$'`
+
+  # filter cached files
+  filtered=`echo "$filtered" | grep -v '^./node_modules/.cache'`
+
+  # filter ci dependencies
+  filtered=`echo "$filtered" | grep -v '^./node_modules/\(bslint\|@hns-dev/bsdoc\)'`
+  filtered=`echo "$filtered" | grep -v '^./node_modules/\(qs\|is-windows\|psl\|js-yaml\|argparse\)'`
+  filtered=`echo "$filtered" | grep -v '^./node_modules/\(form-data\|chalk\|jsesc\|json5\|browserslist\)'`
+  filtered=`echo "$filtered" | grep -v '^./node_modules/\(istanbul-lib-source-maps\|archy\|esprima\)'`
+  filtered=`echo "$filtered" | grep -v '^./node_modules/\(foreground-child\|asynckit\|aws4\)'`
+
+
+  echo "$filtered"
+}
+
+get_whitelist() {
+  # Copryright of Jan Schär in faye-websocket.js from node_modules
+  echo "ä"
+}
+
+check_blacklist() {
+  # Source https://blog.rust-lang.org/2021/11/01/cve-2021-42574.html
+  grep $'[\u202A-\u202E\u2066-\u2069]' "$1"
+  exit $?
+}
+
+check_whitelist() {
+  white_list=`get_whitelist`
+  check_symbols=$'[^\u0020-\u007e\r\t'$white_list']'
+
+  grep $check_symbols "$1"
+  exit $?
+}
+
+# Start
+all_files=`find . -iname '*.js' -print`
+
+# Run blacklist against every file
+IFS=$'\n'
+for file in `echo "$all_files"`; do
+  res=`check_blacklist $file`
+  status=$?
+
+  if [[ $status -eq 1 ]]; then
+    continue
+  fi
+
+  echo -e "Found blacklisted symbols in $file !!!\n"
+  echo "More info at https://github.com/handshake-org/hsd/pull/658"
+  exit 1
+done
+unset IFS
+
+# add this script and bin folder
+add_files=`echo -e "$0\n$all_files\n$(find ./bin -type f)"`
+filtered=`filter_ignore "$add_files"`
+
+IFS=$'\n'
+for file in `echo "$filtered"`; do
+  res=`check_whitelist $file`
+  status=$?
+
+  if [[ $status -eq 1 ]]; then
+    continue
+  fi
+
+  echo -e "Found bad symbols in $file.\nPlease either fix or add to the ignore list."
+  echo "More info at https://github.com/handshake-org/hsd/pull/658"
+  exit 1
+done
+unset IFS
+
+exit 0

--- a/scripts/unicode-lint.sh
+++ b/scripts/unicode-lint.sh
@@ -4,32 +4,14 @@ filter_ignore() {
   filtered="$1"
 
   # Filter Mnemonic keywords
-  filtered=`echo "$filtered" | grep -v '^\./lib/hd/words/\(french\|italian\|japanese\|spanish\|chinese-traditional\|chinese-simplified\)\.js$'`
-  filtered=`echo "$filtered" | grep -v '^\./test/data/mnemonic-japanese.json'`
-
-  # filter cached files
-  filtered=`echo "$filtered" | grep -v '^./node_modules/.cache'`
+  filtered=`echo "$filtered" | grep -v '^lib/hd/words/\(french\|italian\|japanese\|spanish\|chinese-traditional\|chinese-simplified\)\.js$'`
+  filtered=`echo "$filtered" | grep -v '^test/data/mnemonic-japanese.json'`
 
   # Generated docs
   filtered=`echo "$filtered" | grep -v '^./docs/reference'`
 
-  # filter ci dependencies
-  filtered=`echo "$filtered" | grep -v '^./node_modules/\(bslint\|@hns-dev/bsdoc\)'`
-  filtered=`echo "$filtered" | grep -v '^./node_modules/\(qs\|is-windows\|psl\|js-yaml\|argparse\)'`
-  filtered=`echo "$filtered" | grep -v '^./node_modules/\(form-data\|chalk\|jsesc\|json5\|browserslist\)'`
-  filtered=`echo "$filtered" | grep -v '^./node_modules/\(istanbul-lib-source-maps\|archy\|esprima\)'`
-  filtered=`echo "$filtered" | grep -v '^./node_modules/\(foreground-child\|asynckit\|aws4\|yargs\)'`
-  filtered=`echo "$filtered" | grep -v '^./node_modules/\(decamelize\|shebang-command\|camelcase\)'`
-  filtered=`echo "$filtered" | grep -v '^./node_modules/\(source-map\|cross-spawn\)'`
-
-
   echo "$filtered"
 }
-
-get_allowedlist() {
-  echo "äöλ⌊⌋≤↔“”⁻¹"
-}
-
 
 # Get file extentions:
 #   find . -iname '*.*' -exec sh -c "echo {} | sed  's|.*\.||g'" \; | sort -u
@@ -59,12 +41,11 @@ if [[ $status -eq 0 ]]; then
 fi
 
 # Check files only have allowed characters
-allowed_list=`get_allowedlist`
-check_symbols=$'[^\u0020-\u007e\r\t\f'$allowed_list']'
-allowed_list_matches=`sh -c "grep \"$check_symbols\" -r . -l $includes"`
+check_symbols=$'[^\u0020-\u007e\r\t\f]'
+allowed_list_matches=`sh -c "grep \"$check_symbols\" -r $(cat .eslintfiles | xargs) -l $includes"`
 
 # See the logs
-# sh -c "grep \"$check_symbols\" -r . $includes"
+# sh -c "grep \"$check_symbols\" -r $(cat .eslintfiles | xargs) $includes"
 
 
 filtered=`filter_ignore "$allowed_list_matches"`

--- a/scripts/unicode-lint.sh
+++ b/scripts/unicode-lint.sh
@@ -5,49 +5,71 @@ filter_ignore() {
 
   # Filter Mnemonic keywords
   filtered=`echo "$filtered" | grep -v '^\./lib/hd/words/\(french\|italian\|japanese\|spanish\|chinese-traditional\|chinese-simplified\)\.js$'`
+  filtered=`echo "$filtered" | grep -v '^\./test/data/mnemonic-japanese.json'`
 
   # filter cached files
   filtered=`echo "$filtered" | grep -v '^./node_modules/.cache'`
+
+  # Generated docs
+  filtered=`echo "$filtered" | grep -v '^./docs/reference'`
 
   # filter ci dependencies
   filtered=`echo "$filtered" | grep -v '^./node_modules/\(bslint\|@hns-dev/bsdoc\)'`
   filtered=`echo "$filtered" | grep -v '^./node_modules/\(qs\|is-windows\|psl\|js-yaml\|argparse\)'`
   filtered=`echo "$filtered" | grep -v '^./node_modules/\(form-data\|chalk\|jsesc\|json5\|browserslist\)'`
   filtered=`echo "$filtered" | grep -v '^./node_modules/\(istanbul-lib-source-maps\|archy\|esprima\)'`
-  filtered=`echo "$filtered" | grep -v '^./node_modules/\(foreground-child\|asynckit\|aws4\)'`
+  filtered=`echo "$filtered" | grep -v '^./node_modules/\(foreground-child\|asynckit\|aws4\|yargs\)'`
+  filtered=`echo "$filtered" | grep -v '^./node_modules/\(decamelize\|shebang-command\|camelcase\)'`
+  filtered=`echo "$filtered" | grep -v '^./node_modules/\(source-map\|cross-spawn\)'`
 
 
   echo "$filtered"
 }
 
-get_whitelist() {
-  # Copryright of Jan Schär in faye-websocket.js from node_modules
-  echo "ä"
+get_allowedlist() {
+  echo "äöλ⌊⌋≤↔“”⁻¹"
 }
 
+
+# Get file extentions:
+#   find . -iname '*.*' -exec sh -c "echo {} | sed  's|.*\.||g'" \; | sort -u
+includes="--include='*.c' \
+  --include='*.cc' \
+  --include='*.cmake' \
+  --include='*.gyp' \
+  --include='*.gypi' \
+  --include='*.h' \
+  --include='*.js'
+  "
+
 # Start
-# Check everything for blacklists.
-blacklist_matches=`grep $'[\u202A-\u202E\u2066-\u2069]' -r . --include='*.js' -l`
+# Check everything for disallowed list.
+disallowed_matches=`sh -c "grep $'[\u202A-\u202E\u2066-\u2069]' -r . -l $includes"`
 status=$?
 
 if [[ $status -eq 0 ]]; then
-  echo "Found blacklisted symbols"
+  echo "Found disallowed symbols"
   echo "More info at https://github.com/handshake-org/hsd/pull/658"
   echo "Files:"
-  for file in $blacklist_matches; do
+  for file in $dissallowed_matches; do
     echo "  $file"
   done
   exit 1
 fi
 
-# Check files only have whitelisted characters
-white_list=`get_whitelist`
-check_symbols=$'[^\u0020-\u007e\r\t'$white_list']'
-whitelist_matches=`grep "$check_symbols" -r . --include='*.js' -l`
-filtered=`filter_ignore "$whitelist_matches"`
+# Check files only have allowed characters
+allowed_list=`get_allowedlist`
+check_symbols=$'[^\u0020-\u007e\r\t\f'$allowed_list']'
+allowed_list_matches=`sh -c "grep \"$check_symbols\" -r . -l $includes"`
+
+# See the logs
+# sh -c "grep \"$check_symbols\" -r . $includes"
+
+
+filtered=`filter_ignore "$allowed_list_matches"`
 
 if [[ `echo "$filtered" | wc -l` -gt 1 ]]; then
-  echo "Found non-whitelisted symbols"
+  echo "Found not allowed symbols"
   echo "More info at https://github.com/handshake-org/hsd/pull/658"
   echo "Files:"
   for file in $filtered; do

--- a/scripts/unicode-lint.sh
+++ b/scripts/unicode-lint.sh
@@ -44,14 +44,15 @@ includes="--include='*.c' \
 
 # Start
 # Check everything for disallowed list.
-disallowed_matches=`sh -c "grep $'[\u202A-\u202E\u2066-\u2069]' -r . -l $includes"`
+check_symbols=$'[\u202A-\u202E\u2066-\u2069]'
+disallowed_matches=`sh -c "grep \"$check_symbols\" -r . -l $includes"`
 status=$?
 
 if [[ $status -eq 0 ]]; then
   echo "Found disallowed symbols"
   echo "More info at https://github.com/handshake-org/hsd/pull/658"
   echo "Files:"
-  for file in $dissallowed_matches; do
+  for file in $disallowed_matches; do
     echo "  $file"
   done
   exit 1


### PR DESCRIPTION
### Motivation
Motivation for this PR is recent attack using unicode:
  - https://www.trojansource.codes/
  - https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-42574

Approach to address the issue varies, recent example:
 - https://blog.rust-lang.org/2021/11/01/cve-2021-42574.html - where they go with deny-by-default for the specific unicode symbols.

Another unicode based issue: https://certitude.consulting/blog/en/invisible-backdoor/

We can be even more strict with our lints and this is example of only allowing ASCII symbols and have separate allowed lists that appear out of necessity. This is in case something similar is discovered with different set of codes.

### Details
Simplest form of the allowed list check:
```sh
grep $'[^\u0020-\u007e\t]' ./**/*.js | grep -v '^\./lib/hd/words/\(french\|italian\|japanese\|spanish\|chinese-traditional\|chinese-simplified\)\.js'
```

Simple form of the disallowed list check
```sh
grep $'[\u202A-\u202E\u2066-\u2069]' ./**/*.js
```

### Future considerations
There are still files that I had to ignore for this:
 - Mnemonic words - any future PRs that affect those files (there should not be any though) or adds new language support needs to go through different checks, maybe we can have `disallowed_list` checks for those.

Even though `script/unicode-lint.sh` is not ignored, if changes are made to this file it needs more careful review what is added to the allowed list or use older unicode-lint to lint new one before executing it.

### Other projects
This currently does not include other projects, only thing it checks is node_modules as of now. But we could potentially have this linter in separate repo and add to all other projects as well.

### Note
This is little bit hacky version that is pretty slow and we can probably do better!
**Any contributions or even different implementation all together are welcome.**