### PR TITLE
Ridvan change txdb zap to use layoutp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ docker_data/
 docs/reference/
 node_modules/
 npm-debug.log
+.vscode/

--- a/lib/wallet/txdb.js
+++ b/lib/wallet/txdb.js
@@ -3178,11 +3178,15 @@ class TXDB {
     assert((age >>> 0) === age);
 
     const now = util.now();
+    const pendingTxs = await this.getPendingHashes(acct);
 
-    const txs = await this.getRange(acct, {
-      start: 0,
-      end: now - age
-    });
+    const txs = [];
+
+    for (const hash of pendingTxs) {
+      const tx = await this.getTX(hash);
+      assert(tx);
+      txs.push(tx);
+    }
 
     const hashes = [];
 

--- a/systemd/hsd.service
+++ b/systemd/hsd.service
@@ -1,8 +1,0 @@
-[Unit]
-Description=hsd mainnet service
-
-[Service]
-Type
-
-[Install]
-WantedBy=multi-user.target

--- a/systemd/hsd.service
+++ b/systemd/hsd.service
@@ -1,0 +1,8 @@
+[Unit]
+Description=hsd mainnet service
+
+[Service]
+Type
+
+[Install]
+WantedBy=multi-user.target

--- a/test/wallet-http-test.js
+++ b/test/wallet-http-test.js
@@ -812,6 +812,30 @@ describe('Wallet HTTP', function() {
     }
   });
 
+  it('should zap eligible transactions', async () => {
+    // clear all pending txes
+    let pendingTxes = await wallet.getPending('default');
+    for (const pendingTx of pendingTxes) {
+      await wallet.abandon(pendingTx.hash);
+    }
+
+    const tx = await wallet.send({
+      outputs: [{ address: cbAddress, value: 1e4 }]
+    });
+
+    pendingTxes = await wallet.getPending('default');
+    assert(pendingTxes.length === 1);
+    assert(pendingTxes[0].hash === tx.hash);
+
+    await sleep(1001);
+
+    const {success} = await wallet.zap('default', 1);
+    assert(success === true);
+
+    pendingTxes = await wallet.getPending('default');
+    assert(pendingTxes.length === 0);
+  });
+
   // this test creates namestate to use duing the
   // next test, hold on to the name being used.
   const state = {


### PR DESCRIPTION
This PR changes the txdb zap method, instead of retrieving records from layout.m (which iterates over all txes i assume), it retrieves from layout.p (pending txes) to prevent unnecessary looping over all txs. 

My understanding might be wrong, I am not quite sure about layout.m if it's used to store **all txes with a timestamp** or not. (if there is some documentation about leveldb layout for hsd that would be awesome)
However if it makes sense, i would like to suggest the zap method to return (instead of just success: true) the list of txes it zapped. Which i can add to this PR if it makes sense ...

 *   p[hash] -> dummy (pending flag)
 *   m[time][hash] -> dummy (tx by time)

If you are on it, would be great to know what should be the relation between the mempool and zapped/abondaned txes

Thanks for the amazing software you are building ...
