### PR TITLE
MTX.fund - Fixes

### DIFF
--- a/lib/primitives/mtx.js
+++ b/lib/primitives/mtx.js
@@ -1415,6 +1415,7 @@ class CoinSelector {
 
   constructor(tx, options) {
     this.tx = tx.clone();
+    this.view = tx.view;
     this.coins = [];
     this.outputValue = 0;
     this.index = 0;
@@ -1682,14 +1683,29 @@ class CoinSelector {
       for (let i = 0; i < this.inputs.size; i++)
         coins.push(null);
 
-      for (const coin of this.coins) {
-        const {hash, index} = coin;
-        const key = Outpoint.toKey(hash, index);
-        const i = this.inputs.get(key);
+      // check coinview first
+      for (const [key, index] of this.inputs.entries()) {
+        const prevout = Outpoint.fromKey(key);
 
-        if (i != null) {
-          coins[i] = coin;
+        if (this.view.hasEntry(prevout)) {
+          const coinEntry = this.view.getEntry(prevout);
+
+          coins[index] = coinEntry.toCoin(prevout);
           this.inputs.delete(key);
+        }
+      }
+
+      // skip this if we resolved all inputs.
+      if (this.inputs.size > 0) {
+        for (const coin of this.coins) {
+          const {hash, index} = coin;
+          const key = Outpoint.toKey(hash, index);
+          const i = this.inputs.get(key);
+
+          if (i != null) {
+            coins[i] = coin;
+            this.inputs.delete(key);
+          }
         }
       }
 

--- a/lib/primitives/mtx.js
+++ b/lib/primitives/mtx.js
@@ -1115,8 +1115,8 @@ class MTX extends TX {
     // Select necessary coins.
     const select = await this.selectCoins(coins, options);
 
-    // Make sure we empty the input array.
-    this.inputs.length = 0;
+    for (const coin of select.viewCoins)
+      this.view.addCoin(coin);
 
     // Add coins to transaction.
     for (const coin of select.chosen)
@@ -1403,6 +1403,27 @@ class MTX extends TX {
 /**
  * Coin Selector
  * @alias module:primitives.CoinSelector
+ * @property {TX} tx - clone of the original mtx.
+ * @property {CoinView} view - reference to the original view.
+ * @property {Coin[]} coins - List of available coins.
+ * @property {Amount} outputValue - Total output value.
+ * @property {Coin[]} chosen - List of chosen coins to add.
+ * @property {Coin[]} viewCoins - List of coins to only apply to coinview.
+ * @property {Address} changeAddress - change address.
+ * @property {Amount} change - change value.
+ * @property {Amount} fee - Value of fee.
+ * @property {String} selection - selection type.
+ * @property {Boolean} subtractFee - whether to subtract fee from the output.
+ * @property {Number} subtractIndex - index of the output to subtract fee from.
+ * @property {Number} height - height of the chain. (to check spendability)
+ * @property {Number} depth - depth or confirmations for the coin.
+ * @property {Number} hardFee - fixed fee.
+ * @property {Number} rate - Rate of dollarydoo per kB.
+ * @property {Number} maxFee - maximum fee we are willing to pay.
+ * @property {Boolean} round - round to the nearest kilobyte.
+ * @property {Number} coinbaseMaturity - when do CBs become spendable.
+ * @property {Function} estimate - Input script size estimator.
+ * @property {Object[]} inputs - preferred inputs.
  */
 
 class CoinSelector {
@@ -1420,6 +1441,7 @@ class CoinSelector {
     this.outputValue = 0;
     this.index = 0;
     this.chosen = [];
+    this.viewCoins = [];
     this.change = 0;
     this.fee = CoinSelector.MIN_FEE;
 
@@ -1435,6 +1457,7 @@ class CoinSelector {
     this.coinbaseMaturity = 400;
     this.changeAddress = null;
     this.inputs = new BufferMap();
+    this.preferredInputs = new BufferMap();
 
     // Needed for size estimation.
     this.estimate = null;
@@ -1543,7 +1566,7 @@ class CoinSelector {
         const prevout = options.inputs[i];
         assert(prevout && typeof prevout === 'object');
         const {hash, index} = prevout;
-        this.inputs.set(Outpoint.toKey(hash, index), i);
+        this.preferredInputs.set(Outpoint.toKey(hash, index), i);
       }
     }
 
@@ -1576,7 +1599,6 @@ class CoinSelector {
     this.chosen = [];
     this.change = 0;
     this.fee = CoinSelector.MIN_FEE;
-    this.tx.inputs.length = 0;
 
     switch (this.selection) {
       case 'all':
@@ -1676,47 +1698,8 @@ class CoinSelector {
    */
 
   fund() {
-    // Ensure all preferred inputs first.
-    if (this.inputs.size > 0) {
-      const coins = [];
-
-      for (let i = 0; i < this.inputs.size; i++)
-        coins.push(null);
-
-      // check coinview first
-      for (const [key, index] of this.inputs.entries()) {
-        const prevout = Outpoint.fromKey(key);
-
-        if (this.view.hasEntry(prevout)) {
-          const coinEntry = this.view.getEntry(prevout);
-
-          coins[index] = coinEntry.toCoin(prevout);
-          this.inputs.delete(key);
-        }
-      }
-
-      // skip this if we resolved all inputs.
-      if (this.inputs.size > 0) {
-        for (const coin of this.coins) {
-          const {hash, index} = coin;
-          const key = Outpoint.toKey(hash, index);
-          const i = this.inputs.get(key);
-
-          if (i != null) {
-            coins[i] = coin;
-            this.inputs.delete(key);
-          }
-        }
-      }
-
-      if (this.inputs.size > 0)
-        throw new Error('Could not resolve preferred inputs.');
-
-      for (const coin of coins) {
-        this.tx.addCoin(coin);
-        this.chosen.push(coin);
-      }
-    }
+    this.resolveInputs();
+    this.resolvePreferred();
 
     if (this.isFull())
       return;
@@ -1735,6 +1718,104 @@ class CoinSelector {
 
       if (this.isFull())
         break;
+    }
+  }
+
+  /**
+   * Resolve coins for existing inputs.
+   */
+
+  resolveInputs() {
+    if (this.inputs.size === 0)
+      return;
+
+    // Ensure we have coins for the existing inputs.
+    const view = this.tx.view;
+    const coins = [];
+
+    for (let i = 0; i < this.inputs.size; i++)
+      coins.push(null);
+
+    // check coinview first
+    for (const [key, index] of this.inputs.entries()) {
+      const prevout = Outpoint.fromKey(key);
+
+      if (this.view.hasEntry(prevout)) {
+        const coinEntry = this.view.getEntry(prevout);
+
+        coins[index] = coinEntry.toCoin(prevout);
+        this.inputs.delete(key);
+      }
+    }
+
+    // skip this if we resolved all inputs.
+    if (this.inputs.size > 0) {
+      for (const coin of this.coins) {
+        const {hash, index} = coin;
+        const key = Outpoint.toKey(hash, index);
+        const i = this.inputs.get(key);
+
+        if (i != null) {
+          coins[i] = coin;
+          this.inputs.delete(key);
+        }
+      }
+    }
+
+    if (this.inputs.size > 0)
+      throw new Error('Could not resolve existing inputs.');
+
+    for (const coin of coins) {
+      view.addCoin(coin);
+      this.viewCoins.push(coin);
+    }
+  }
+
+  /**
+   * Resolve preferred inputs.
+   */
+
+  resolvePreferred() {
+    if (this.preferredInputs.size === 0)
+      return;
+
+    const coins = [];
+
+    for (let i = 0; i < this.preferredInputs.size; i++)
+      coins.push(null);
+
+    // check coinview first
+    for (const [key, index] of this.preferredInputs.entries()) {
+      const prevout = Outpoint.fromKey(key);
+
+      if (this.view.hasEntry(prevout)) {
+        const coinEntry = this.view.getEntry(prevout);
+
+        coins[index] = coinEntry.toCoin(prevout);
+        this.preferredInputs.delete(key);
+      }
+    }
+
+    // skip this if we resolved all inputs.
+    if (this.preferredInputs.size > 0) {
+      for (const coin of this.coins) {
+        const {hash, index} = coin;
+        const key = Outpoint.toKey(hash, index);
+        const i = this.preferredInputs.get(key);
+
+        if (i != null) {
+          coins[i] = coin;
+          this.preferredInputs.delete(key);
+        }
+      }
+    }
+
+    if (this.preferredInputs.size > 0)
+      throw new Error('Could not resolve preferred inputs.');
+
+    for (const coin of coins) {
+      this.tx.addCoin(coin);
+      this.chosen.push(coin);
     }
   }
 

--- a/lib/primitives/mtx.js
+++ b/lib/primitives/mtx.js
@@ -1403,7 +1403,7 @@ class MTX extends TX {
 /**
  * Coin Selector
  * @alias module:primitives.CoinSelector
- * @property {TX} tx - clone of the original mtx.
+ * @property {MTX} tx - clone of the original mtx.
  * @property {CoinView} view - reference to the original view.
  * @property {Coin[]} coins - List of available coins.
  * @property {Amount} outputValue - Total output value.
@@ -1416,21 +1416,22 @@ class MTX extends TX {
  * @property {Boolean} subtractFee - whether to subtract fee from the output.
  * @property {Number} subtractIndex - index of the output to subtract fee from.
  * @property {Number} height - height of the chain. (to check spendability)
- * @property {Number} depth - depth or confirmations for the coin.
+ * @property {Number} depth - minimum confirmation depth of coins to spend.
  * @property {Number} hardFee - fixed fee.
  * @property {Number} rate - Rate of dollarydoo per kB.
  * @property {Number} maxFee - maximum fee we are willing to pay.
  * @property {Boolean} round - round to the nearest kilobyte.
  * @property {Number} coinbaseMaturity - when do CBs become spendable.
- * @property {Function} estimate - Input script size estimator.
- * @property {Object[]} inputs - preferred inputs.
+ * @property {Function?} estimate - Input script size estimator.
+ * @property {BufferMap<Buffer, Number>} existingInputs - inputs from tx.
+ * @property {BufferMap<Buffer, Number>} preferredInputs - preferred inputs.
  */
 
 class CoinSelector {
   /**
    * Create a coin selector.
    * @constructor
-   * @param {TX} tx
+   * @param {MTX} tx - tx to clone.
    * @param {Object?} options
    */
 
@@ -1456,7 +1457,7 @@ class CoinSelector {
     this.round = false;
     this.coinbaseMaturity = 400;
     this.changeAddress = null;
-    this.inputs = new BufferMap();
+    this.existingInputs = new BufferMap();
     this.preferredInputs = new BufferMap();
 
     // Needed for size estimation.
@@ -1560,10 +1561,10 @@ class CoinSelector {
       this.estimate = options.estimate;
     }
 
-    if (options.inputs) {
-      assert(Array.isArray(options.inputs));
-      for (let i = 0; i < options.inputs.length; i++) {
-        const prevout = options.inputs[i];
+    if (options.preferredInputs) {
+      assert(Array.isArray(options.preferredInputs));
+      for (let i = 0; i < options.preferredInputs.length; i++) {
+        const prevout = options.preferredInputs[i];
         assert(prevout && typeof prevout === 'object');
         const {hash, index} = prevout;
         this.preferredInputs.set(Outpoint.toKey(hash, index), i);
@@ -1582,7 +1583,7 @@ class CoinSelector {
     if (this.tx.inputs.length > 0) {
       for (let i = 0; i < this.tx.inputs.length; i++) {
         const {prevout} = this.tx.inputs[i];
-        this.inputs.set(prevout.toKey(), i);
+        this.existingInputs.set(prevout.toKey(), i);
       }
     }
   }
@@ -1698,7 +1699,7 @@ class CoinSelector {
    */
 
   fund() {
-    this.resolveInputs();
+    this.resolveExisting();
     this.resolvePreferred();
 
     if (this.isFull())
@@ -1725,44 +1726,46 @@ class CoinSelector {
    * Resolve coins for existing inputs.
    */
 
-  resolveInputs() {
-    if (this.inputs.size === 0)
+  resolveExisting() {
+    if (this.existingInputs.size === 0)
       return;
 
     // Ensure we have coins for the existing inputs.
     const view = this.tx.view;
     const coins = [];
 
-    for (let i = 0; i < this.inputs.size; i++)
+    for (let i = 0; i < this.existingInputs.size; i++)
       coins.push(null);
 
     // check coinview first
-    for (const [key, index] of this.inputs.entries()) {
+    for (const [key, index] of this.existingInputs.entries()) {
       const prevout = Outpoint.fromKey(key);
 
       if (this.view.hasEntry(prevout)) {
         const coinEntry = this.view.getEntry(prevout);
 
         coins[index] = coinEntry.toCoin(prevout);
-        this.inputs.delete(key);
+        this.existingInputs.delete(key);
       }
     }
 
     // skip this if we resolved all inputs.
-    if (this.inputs.size > 0) {
+    if (this.existingInputs.size > 0) {
+      // Costly operations that tries to fill coinview from passed in
+      // coin list.
       for (const coin of this.coins) {
         const {hash, index} = coin;
         const key = Outpoint.toKey(hash, index);
-        const i = this.inputs.get(key);
+        const i = this.existingInputs.get(key);
 
         if (i != null) {
           coins[i] = coin;
-          this.inputs.delete(key);
+          this.existingInputs.delete(key);
         }
       }
     }
 
-    if (this.inputs.size > 0)
+    if (this.existingInputs.size > 0)
       throw new Error('Could not resolve existing inputs.');
 
     for (const coin of coins) {
@@ -1798,6 +1801,8 @@ class CoinSelector {
 
     // skip this if we resolved all inputs.
     if (this.preferredInputs.size > 0) {
+      // Costly operation that tries to fill coinview from passed in
+      // coin list.
       for (const coin of this.coins) {
         const {hash, index} = coin;
         const key = Outpoint.toKey(hash, index);

--- a/test/interactive-swap-test.js
+++ b/test/interactive-swap-test.js
@@ -206,11 +206,12 @@ describe('Interactive name swap', function() {
 
     // Bob should verify all the data in the MTX to ensure everything is valid,
     // but this is the minimum.
-    const input0 = mtx.input(0).clone(); // copy input with Alice's signature
-    const coinEntry = await node.chain.db.readCoin(input0.prevout);
+    const coinEntry = await node.chain.db.readCoin(mtx.input(0).prevout);
     assert(coinEntry); // ensures that coin exists and is still unspent
 
-    const coin = coinEntry.toCoin(input0.prevout);
+    const coin = coinEntry.toCoin(mtx.input(0).prevout);
+    mtx.view.addCoin(coin);
+
     assert(coin.covenant.type === types.TRANSFER);
     const addr = new Address({
       version: coin.covenant.items[2].readInt8(),
@@ -224,12 +225,8 @@ describe('Interactive name swap', function() {
     const changeAddress = await bob.changeAddress();
     const rate = await wdb.estimateFee();
     const coins = await bob.getSmartCoins();
-    // Add the external coin to the coin selector so we don't fail assertions
-    coins.push(coin);
+
     await mtx.fund(coins, {changeAddress, rate});
-    // The funding mechanism starts by wiping out existing inputs
-    // which for us includes Alice's signature. Replace it from our backup.
-    mtx.inputs[0].inject(input0);
 
     // Rearrange outputs.
     // Since we added a change output, the SINGELREVERSE is now broken:

--- a/test/mtx-test.js
+++ b/test/mtx-test.js
@@ -202,7 +202,7 @@ describe('MTX', function() {
 
       await mtx.fund(coins1, {
         changeAddress: wallet1.getChange(),
-        inputs: [{
+        preferredInputs: [{
           hash: coin.hash,
           index: coin.index
         }]
@@ -229,7 +229,7 @@ describe('MTX', function() {
 
       await mtx.fund(coins1, {
         changeAddress: wallet1.getChange(),
-        inputs: [{
+        preferredInputs: [{
           hash: coin.hash,
           index: coin.index
         }]
@@ -257,7 +257,7 @@ describe('MTX', function() {
 
       await mtx.fund(coins1, {
         changeAddress: wallet1.getChange(),
-        inputs: [{
+        preferredInputs: [{
           hash: viewCoin.hash,
           index: viewCoin.index
         }, {
@@ -296,7 +296,7 @@ describe('MTX', function() {
       try {
         await mtx.fund(coins1, {
           changeAddress: wallet1.getChange(),
-          inputs: [{
+          preferredInputs: [{
             hash: coin.hash,
             index: coin.index
           }]
@@ -458,7 +458,7 @@ describe('MTX', function() {
 
       await mtx.fund(coins1, {
         changeAddress: wallet1.getChange(),
-        inputs: [{
+        preferredInputs: [{
           hash: coin2.hash,
           index: coin2.index
         }]
@@ -501,7 +501,7 @@ describe('MTX', function() {
 
       await mtx.fund(coins1, {
         changeAddress: wallet1.getChange(),
-        inputs: [{
+        preferredInputs: [{
           hash: coin2.hash,
           index: coin2.index
         }]
@@ -555,7 +555,7 @@ describe('MTX', function() {
 
       await mtx.fund(coins1, {
         changeAddress: wallet1.getChange(),
-        inputs: [{
+        preferredInputs: [{
           hash: coin2.hash,
           index: coin2.index
         }, {
@@ -629,7 +629,7 @@ describe('MTX', function() {
       try {
         await mtx.fund(coins1, {
           changeAddress: wallet1.getChange(),
-          inputs: [{
+          preferredInputs: [{
             hash: coin2.hash,
             index: coin2.index
           }, {
@@ -676,7 +676,7 @@ describe('MTX', function() {
       try {
         await mtx.fund(coins1, {
           changeAddress: wallet1.getChange(),
-          inputs: [{
+          preferredInputs: [{
             hash: coin2.hash,
             index: coin2.index
           }, {
@@ -723,7 +723,7 @@ describe('MTX', function() {
       try {
         await mtx.fund(coins1, {
           changeAddress: wallet1.getChange(),
-          inputs: [{
+          preferredInputs: [{
             hash: coin2.hash,
             index: coin2.index
           }, {


### PR DESCRIPTION
This is alternative implementation of #639 that solves issue in the `CoinSelector`.

Separate `existing` and `preferred` inputs:
  - existing are the inputs that are present in the mtx.
  - preferred now refers to inputs passed by `options.inputs`.
  - Use `CoinView` to resolve `coins`.
 
Closes #639
Closes #901