### PR TITLE
[consensus] Enable Urkel Tree compaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,15 +3,16 @@
 ## unreleased
 
 ### Node changes
-  - `FullNode` and `SPVNode` now accept the option `--agent` which adds a string
+ - `FullNode` and `SPVNode` now accept the option `--agent` which adds a string
   to the user-agent of the node (which will already contain hsd version) and is
   sent to peers in the version packet. Strings must not contain slashes and total
-  user-agent string must be 255 characters or less.
+  user-agent string must be 255 charact
 
-- `FullNode` parses new configuration option `--compact-tree` which will compact
-the Urkel Tree only when the node first opens. This is the preferred method
-because it will run before the node connects to the network and the processing
-time will not affect peers.
+  - `FullNode` parses new configuration option `--compact-tree` which will compact
+  the Urkel Tree when the node first opens, by deleting historical data. It will
+  keep up to the last 288 blocks worth of tree data on disk (7-8 tree intervals)
+  exposing the node to a similar deep reorganization vulnerability as a
+  chain-pruning node.
 
 ## v3.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,14 +5,15 @@
 ### Node changes
  - `FullNode` and `SPVNode` now accept the option `--agent` which adds a string
   to the user-agent of the node (which will already contain hsd version) and is
-  sent to peers in the version packet. Strings must not contain slashes and total
-  user-agent string must be 255 charact
+  sent to peers in the version packet. Strings must not contain slashes and
+  total user-agent string must be less than 255 characters.
 
-  - `FullNode` parses new configuration option `--compact-tree` which will compact
-  the Urkel Tree when the node first opens, by deleting historical data. It will
-  keep up to the last 288 blocks worth of tree data on disk (7-8 tree intervals)
-  exposing the node to a similar deep reorganization vulnerability as a
-  chain-pruning node.
+  - `FullNode` parses new configuration option `--compact-tree-on-init` and
+  `--compact-tree-init-interval` which will compact the Urkel Tree when the node
+  first opens, by deleting historical data. It will try to compact it again
+  after `tree-init-interval` has passed. Compaction will keep up to the last 288
+  blocks worth of tree data on disk (7-8 tree intervals) exposing the node to a
+  similar deep reorganization vulnerability as a chain-pruning node.
 
 ## v3.0.0
 
@@ -32,8 +33,10 @@
 ### Wallet API changes
 
 - New RPC methods:
-  - `signmessagewithname`: Like `signmessage` but uses a name instead of an address. The owner's address will be used to sign the message.
-  - `verifymessagewithname`: Like `verifymessage` but uses a name instead of an address. The owner's address will be used to verify the message.
+  - `signmessagewithname`: Like `signmessage` but uses a name instead of an
+    address. The owner's address will be used to sign the message.
+  - `verifymessagewithname`: Like `verifymessage` but uses a name instead of an
+    address. The owner's address will be used to verify the message.
 
 - New wallet creation accepts parameter `language` to generate the mnemonic phrase.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## unreleased
 
+**When upgrading to this version of hsd you must pass
+`--chain-migrate=3` when you run it for the first time.**
+
 ### Node changes
  - `FullNode` and `SPVNode` now accept the option `--agent` which adds a string
   to the user-agent of the node (which will already contain hsd version) and is

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@
   sent to peers in the version packet. Strings must not contain slashes and total
   user-agent string must be 255 characters or less.
 
+- `FullNode` parses new configuration option `--compact-tree` which will compact
+the Urkel Tree only when the node first opens. This is the preferred method
+because it will run before the node connects to the network and the processing
+time will not affect peers.
+
 ## v3.0.0
 
 **When upgrading to this version of hsd you must pass

--- a/lib/blockchain/chain.js
+++ b/lib/blockchain/chain.js
@@ -146,7 +146,7 @@ class Chain extends AsyncEmitter {
 
     const {compactionHeight} = await this.db.getTreeState();
     const {compactTreeInitInterval} = this.options;
-    const compactFrom = compactionHeight + compactTreeInitInterval;
+    const compactFrom = compactionHeight + keepBlocks + compactTreeInitInterval;
 
     if (compactFrom > this.height) {
       this.logger.debug(

--- a/lib/blockchain/chain.js
+++ b/lib/blockchain/chain.js
@@ -101,12 +101,26 @@ class Chain extends AsyncEmitter {
     this.setDeploymentState(state);
 
     if (!this.options.spv) {
-      if (this.options.compactTree)
-        await this.compactTree();
+      const {txStart} = this.network;
+      const startFrom = txStart + this.network.block.keepBlocks;
 
-    // Replay the blockchain from last committed tree root
-    // back up to the tip to rebuild tree and txn.
-      await this.syncTree();
+      if (this.options.compactTreeOnInit && this.height > startFrom) {
+        const {compactionHeight} = await this.db.getTreeState();
+        const {compactTreeInitInterval} = this.options;
+        const compactFrom = compactionHeight + compactTreeInitInterval;
+
+        if (compactFrom <= this.height) {
+          await this.compactTree();
+        } else {
+          this.logger.debug(
+            `Tree will compact at ${compactFrom} height.`);
+          await this.syncTree();
+        }
+      } else {
+        // Replay the blockchain from last committed tree root
+        // back up to the tip to rebuild tree and txn.
+        await this.syncTree();
+      }
     }
 
     this.logger.memory();
@@ -2118,17 +2132,28 @@ class Chain extends AsyncEmitter {
     const oldestBlock = this.height - this.network.block.keepBlocks;
 
     // Distance from that block to the start of the oldest tree interval.
-    const toNextInterval =
-      this.network.names.treeInterval -
-      (oldestBlock % this.network.names.treeInterval);
+    const toNextInterval = (this.network.names.treeInterval -
+      (oldestBlock % this.network.names.treeInterval))
+      % this.network.names.treeInterval;
 
     // Get the oldest Urkel Tree root state a pruning node can recover from.
     const oldestTreeIntervalStart = oldestBlock + toNextInterval + 1;
     const entry = await this.db.getEntryByHeight(oldestTreeIntervalStart);
 
     try {
+      // TODO: For RPC calls, If compaction fails while compacting
+      // and we never hit syncTree, we need to shut down the node
+      // so on restart chain can recover.
+      // Error can also happen in syncTree, but that means the DB
+      // is done for. (because restart would just retry syncTree.)
+      // It's fine on open, open throwing would just stop the node.
+
       // Rewind Urkel Tree and delete all historical state.
+      this.emit('tree compact start', entry.treeRoot, entry);
       await this.db.compactTree(entry);
+      this.emit('tree compact end', entry.treeRoot, entry);
+
+      await this.syncTree();
     } finally {
       unlock();
     }
@@ -3701,7 +3726,8 @@ class ChainOptions {
     this.maxOrphans = 20;
     this.checkpoints = true;
     this.chainMigrate = -1;
-    this.compactTree = false;
+    this.compactTreeOnInit = false;
+    this.compactTreeInitInterval = 10000;
 
     if (options)
       this.fromOptions(options);
@@ -3814,9 +3840,17 @@ class ChainOptions {
       this.chainMigrate = options.chainMigrate;
     }
 
-    if (options.compactTree != null) {
-      assert(typeof options.compactTree === 'boolean');
-      this.compactTree = options.compactTree;
+    if (options.compactTreeOnInit != null) {
+      assert(typeof options.compactTreeOnInit === 'boolean');
+      this.compactTreeOnInit = options.compactTreeOnInit;
+    }
+
+    if (options.compactTreeInitInterval != null) {
+      const {keepBlocks} = this.network.block;
+      assert(typeof options.compactTreeInitInterval === 'number');
+      assert(options.compactTreeInitInterval >= keepBlocks,
+        `compaction interval must not be smaller than ${keepBlocks}.`);
+      this.compactTreeInitInterval = options.compactTreeInitInterval;
     }
 
     if (this.spv || this.memory)

--- a/lib/blockchain/chain.js
+++ b/lib/blockchain/chain.js
@@ -126,11 +126,35 @@ class Chain extends AsyncEmitter {
    */
 
   async syncTree() {
-    const {treeInterval} = this.network.names;
-    const last = this.height - (this.height % treeInterval);
-
     this.logger.info('Synchronizing Tree with block history...');
 
+    const {treeInterval} = this.network.names;
+
+    // Current state of the tree, freshly loaded from disk.
+    // It will be in the most recently-committed state,
+    // which was at the last tree interval. There might have been
+    // new blocks added to the chain since then.
+    const currentRoot = this.db.treeRoot();
+
+    // Get the block that corresponds to beginning of the last tree interval.
+    // The tree root in this block header will be the first block that
+    // commits to the new tree root hash, but the transactions it contains
+    // have not yet been added to the tree.
+    const last = this.height - (this.height % treeInterval);
+    const entry = await this.db.getEntryByHeight(last + 1);
+
+    // Require that tree is less than one tree interval behind the chain.
+    // We can skip this check only if the blockchain is less than
+    // one tree interval old, OR the chain is already at the tree interval,
+    // meaning the tree is already in sync with the chain and there is no delta.
+    if (entry) {
+      assert(entry.treeRoot.equals(currentRoot));
+    } else {
+      assert(last === 0 || last === this.height);
+    }
+
+    // Replay all blocks since the last tree interval to rebuild
+    // the `txn` which is the in-memory delta between tree interval commitments.
     for (let height = last + 1; height <= this.height; height++) {
       const entry = await this.db.getEntryByHeight(height);
       assert(entry);

--- a/lib/blockchain/chain.js
+++ b/lib/blockchain/chain.js
@@ -130,9 +130,11 @@ class Chain extends AsyncEmitter {
 
     const {treeInterval} = this.network.names;
 
-    // Current state of the tree, freshly loaded from disk.
-    // It will be in the most recently-committed state,
-    // which was at the last tree interval. There might have been
+    // Current state of the tree, loaded from chain database and
+    // injected in chainDB.open(). It should be in the most
+    // recently-committed state, which should have been at the last
+    // tree interval. We might also need to recover from a
+    // failed compactTree() operation. Either way, there might have been
     // new blocks added to the chain since then.
     const currentRoot = this.db.treeRoot();
 

--- a/lib/blockchain/chain.js
+++ b/lib/blockchain/chain.js
@@ -2128,7 +2128,7 @@ class Chain extends AsyncEmitter {
 
     try {
       // Rewind Urkel Tree and delete all historical state.
-      await this.db.compactTree(entry.treeRoot);
+      await this.db.compactTree(entry);
     } finally {
       unlock();
     }

--- a/lib/blockchain/chain.js
+++ b/lib/blockchain/chain.js
@@ -148,8 +148,6 @@ class Chain extends AsyncEmitter {
   async syncTree() {
     this.logger.info('Synchronizing Tree with block history...');
 
-    const {treeInterval} = this.network.names;
-
     // Current state of the tree, loaded from chain database and
     // injected in chainDB.open(). It should be in the most
     // recently-committed state, which should have been at the last
@@ -158,38 +156,22 @@ class Chain extends AsyncEmitter {
     // new blocks added to the chain since then.
     const currentRoot = this.db.treeRoot();
 
-    // Get the block that corresponds to beginning of the last tree interval.
-    // The tree root in this block header will be the first block that
-    // commits to the new tree root hash, but the transactions it contains
-    // have not yet been added to the tree.
-    let last = this.height - (this.height % treeInterval);
-    let entry = await this.db.getEntryByHeight(last + 1);
+    // We store commit height for the tree in the tree state.
+    // commitHeight is the height of the block that committed tree root.
+    // Note that the block at commitHeight has different tree root.
+    const treeState = await this.db.getTreeState();
+    const {commitHeight} = treeState;
 
-    // Using the current tree root hash, rewind the blockchain to the beginning
-    // of the corresponding tree interval. If the tree has been compacted,
-    // this may be SEVERAL tree intervals behind the current chain tip
-    // (this is required to support chain reorgs to a limited depth,
-    // similar to pruning nodes keeping the last 288 blocks on disk).
-    // We can skip this only if the blockchain is less than
-    // one tree interval old, OR the chain is already at the tree interval,
-    // meaning the tree is already in sync with the chain and there is no delta.
-    if (!entry) {
-      assert(last === 0 || last === this.height);
-    } else {
-      for (;;) {
-        if (entry.treeRoot.equals(currentRoot))
-          break;
-
-        last -= treeInterval;
-        assert(last > this.height - this.network.block.keepBlocks);
-        entry = await this.db.getEntryByHeight(last + 1);
-        assert(entry);
-      }
+    // sanity check
+    if (commitHeight < this.height) {
+      const entry = await this.db.getEntryByHeight(commitHeight + 1);
+      assert(entry.treeRoot.equals(treeState.treeRoot));
+      assert(entry.treeRoot.equals(currentRoot));
     }
 
     // Replay all blocks since the last tree interval to rebuild
     // the `txn` which is the in-memory delta between tree interval commitments.
-    for (let height = last + 1; height <= this.height; height++) {
+    for (let height = commitHeight + 1; height <= this.height; height++) {
       const entry = await this.db.getEntryByHeight(height);
       assert(entry);
 
@@ -2106,11 +2088,13 @@ class Chain extends AsyncEmitter {
    * Compact the Urkel Tree.
    * Removes all historical state and all data not
    * linked directly to the provided root node hash.
-   * @param {Hash} root
    * @returns {Promise}
    */
 
   async compactTree() {
+    if (this.options.spv)
+      return;
+
     if (this.height < this.network.block.keepBlocks)
       throw new Error('Chain is too short to compact tree.');
 
@@ -2131,10 +2115,11 @@ class Chain extends AsyncEmitter {
     // Oldest block available to a pruning node.
     const oldestBlock = this.height - this.network.block.keepBlocks;
 
+    const {treeInterval} = this.network.names;
+
     // Distance from that block to the start of the oldest tree interval.
-    const toNextInterval = (this.network.names.treeInterval -
-      (oldestBlock % this.network.names.treeInterval))
-      % this.network.names.treeInterval;
+    const toNextInterval = (treeInterval - (oldestBlock % treeInterval))
+      % treeInterval;
 
     // Get the oldest Urkel Tree root state a pruning node can recover from.
     const oldestTreeIntervalStart = oldestBlock + toNextInterval + 1;
@@ -2151,9 +2136,41 @@ class Chain extends AsyncEmitter {
       // Rewind Urkel Tree and delete all historical state.
       this.emit('tree compact start', entry.treeRoot, entry);
       await this.db.compactTree(entry);
-      this.emit('tree compact end', entry.treeRoot, entry);
-
       await this.syncTree();
+      this.emit('tree compact end', entry.treeRoot, entry);
+    } finally {
+      unlock();
+    }
+  }
+
+  /**
+   * Reconstruct the Urkel Tree.
+   * @returns {Promise}
+   */
+
+  async reconstructTree() {
+    if (this.options.spv)
+      return;
+
+    if (this.options.prune)
+      throw new Error('Cannot reconstruct tree in pruned mode.');
+
+    const unlock = await this.locker.lock();
+
+    const treeState = await this.db.getTreeState();
+
+    if (treeState.compactionHeight === 0)
+      throw new Error('Nothing to reconstruct.');
+
+    // Compact all the way to the first block and
+    // let the syncTree do its job.
+    const entry = await this.db.getEntryByHeight(1);
+
+    try {
+      this.emit('tree reconstruct start');
+      await this.db.compactTree(entry);
+      await this.syncTree();
+      this.emit('tree reconstruct end');
     } finally {
       unlock();
     }

--- a/lib/blockchain/chain.js
+++ b/lib/blockchain/chain.js
@@ -167,6 +167,7 @@ class Chain extends AsyncEmitter {
           break;
 
         last -= treeInterval;
+        assert(last > this.height - this.network.block.keepBlocks);
         entry = await this.db.getEntryByHeight(last + 1);
         assert(entry);
       }

--- a/lib/blockchain/chain.js
+++ b/lib/blockchain/chain.js
@@ -100,8 +100,16 @@ class Chain extends AsyncEmitter {
 
     this.setDeploymentState(state);
 
-    if (!this.options.spv)
-      await this.syncTree();
+    if (this.options.compactTree) {
+      if (this.options.spv)
+        throw new Error('Cannot compact tree in SPV mode.');
+
+      // Will call syncTree() after compaction.
+      await this.compactTree();
+    } else {
+      if (!this.options.spv)
+        await this.syncTree();
+    }
 
     this.logger.memory();
 
@@ -3697,6 +3705,7 @@ class ChainOptions {
     this.maxOrphans = 20;
     this.checkpoints = true;
     this.chainMigrate = -1;
+    this.compactTree = false;
 
     if (options)
       this.fromOptions(options);
@@ -3807,6 +3816,11 @@ class ChainOptions {
     if (options.chainMigrate != null) {
       assert(typeof options.chainMigrate === 'number');
       this.chainMigrate = options.chainMigrate;
+    }
+
+    if (options.compactTree != null) {
+      assert(typeof options.compactTree === 'boolean');
+      this.compactTree = options.compactTree;
     }
 
     if (this.spv || this.memory)

--- a/lib/blockchain/chain.js
+++ b/lib/blockchain/chain.js
@@ -150,7 +150,7 @@ class Chain extends AsyncEmitter {
 
     if (compactFrom > this.height) {
       this.logger.debug(
-        `Tree will compact after ${compactFrom} height.`);
+        `Tree will compact when restarted after height ${compactFrom}.`);
       return true;
     }
 

--- a/lib/blockchain/chain.js
+++ b/lib/blockchain/chain.js
@@ -101,26 +101,10 @@ class Chain extends AsyncEmitter {
     this.setDeploymentState(state);
 
     if (!this.options.spv) {
-      const {txStart} = this.network;
-      const startFrom = txStart + this.network.block.keepBlocks;
+      const sync = await this.tryCompact();
 
-      if (this.options.compactTreeOnInit && this.height > startFrom) {
-        const {compactionHeight} = await this.db.getTreeState();
-        const {compactTreeInitInterval} = this.options;
-        const compactFrom = compactionHeight + compactTreeInitInterval;
-
-        if (compactFrom <= this.height) {
-          await this.compactTree();
-        } else {
-          this.logger.debug(
-            `Tree will compact at ${compactFrom} height.`);
-          await this.syncTree();
-        }
-      } else {
-        // Replay the blockchain from last committed tree root
-        // back up to the tip to rebuild tree and txn.
+      if (sync)
         await this.syncTree();
-      }
     }
 
     this.logger.memory();
@@ -139,6 +123,40 @@ class Chain extends AsyncEmitter {
     assert(this.opened, 'Chain is not open.');
     this.opened = false;
     return this.db.close();
+  }
+
+  /**
+   * Check if we need to compact tree data.
+   * @returns {Promise<Boolean>} - Should we sync
+   */
+
+  async tryCompact() {
+    if (this.options.spv)
+      return false;
+
+    if (!this.options.compactTreeOnInit)
+      return true;
+
+    const {txStart} = this.network;
+    const {keepBlocks} = this.network.block;
+    const startFrom = txStart + keepBlocks;
+
+    if (this.height <= startFrom)
+      return true;
+
+    const {compactionHeight} = await this.db.getTreeState();
+    const {compactTreeInitInterval} = this.options;
+    const compactFrom = compactionHeight + compactTreeInitInterval;
+
+    if (compactFrom > this.height) {
+      this.logger.debug(
+        `Tree will compact after ${compactFrom} height.`);
+      return true;
+    }
+
+    // Compact tree calls syncTree so we don't want to rerun it.
+    await this.compactTree();
+    return false;
   }
 
   /**

--- a/lib/blockchain/chain.js
+++ b/lib/blockchain/chain.js
@@ -140,17 +140,28 @@ class Chain extends AsyncEmitter {
     // The tree root in this block header will be the first block that
     // commits to the new tree root hash, but the transactions it contains
     // have not yet been added to the tree.
-    const last = this.height - (this.height % treeInterval);
-    const entry = await this.db.getEntryByHeight(last + 1);
+    let last = this.height - (this.height % treeInterval);
+    let entry = await this.db.getEntryByHeight(last + 1);
 
-    // Require that tree is less than one tree interval behind the chain.
-    // We can skip this check only if the blockchain is less than
+    // Using the current tree root hash, rewind the blockchain to the beginning
+    // of the corresponding tree interval. If the tree has been compacted,
+    // this may be SEVERAL tree intervals behind the current chain tip
+    // (this is required to support chain reorgs to a limited depth,
+    // similar to pruning nodes keeping the last 288 blocks on disk).
+    // We can skip this only if the blockchain is less than
     // one tree interval old, OR the chain is already at the tree interval,
     // meaning the tree is already in sync with the chain and there is no delta.
-    if (entry) {
-      assert(entry.treeRoot.equals(currentRoot));
-    } else {
+    if (!entry) {
       assert(last === 0 || last === this.height);
+    } else {
+      for (;;) {
+        if (entry.treeRoot.equals(currentRoot))
+          break;
+
+        last -= treeInterval;
+        entry = await this.db.getEntryByHeight(last + 1);
+        assert(entry);
+      }
     }
 
     // Replay all blocks since the last tree interval to rebuild
@@ -171,8 +182,8 @@ class Chain extends AsyncEmitter {
       for (const tx of block.txs)
         await this.verifyCovenants(tx, view, height, hardened);
 
-      assert((height % this.network.names.treeInterval) !== 0);
-
+      // If the chain replay crosses a tree interval, it will commit
+      // and write to disk in saveNames(), resetting the `txn` like usual.
       await this.db.saveNames(view, entry, false);
     }
 

--- a/lib/blockchain/chain.js
+++ b/lib/blockchain/chain.js
@@ -2080,6 +2080,52 @@ class Chain extends AsyncEmitter {
   }
 
   /**
+   * Compact the Urkel Tree.
+   * Removes all historical state and all data not
+   * linked directly to the provided root node hash.
+   * @param {Hash} root
+   * @returns {Promise}
+   */
+
+  async compactTree() {
+    const unlock = await this.locker.lock();
+    this.logger.info('Compacting Urkel Tree...');
+
+    // To support chain reorgs of limited depth we compact the tree
+    // to some commitment point in recent history, then rebuild it from there
+    // back up to the current chain tip. In order to support pruning nodes,
+    // all blocks above this depth must be available on disk.
+    // This actually further reduces the ability for a pruning node to recover
+    // from a deep reorg. On mainnet, `keepBlocks` is 288. A normal pruning
+    // node can recover from a reorg up to that depth. Compacting the tree
+    // potentially reduces that depth to 288 - 36 = 252. A reorg deeper than
+    // that will result in a `MissingNodeError` thrown by Urkel inside
+    // chain.saveNames() as it tries to restore a deleted state.
+
+    // Oldest block available to a pruning node.
+    const oldestBlock = this.height - this.network.block.keepBlocks;
+
+    // Distance from that block to the start of the oldest tree interval.
+    const toNextInterval =
+      this.network.names.treeInterval -
+      (oldestBlock % this.network.names.treeInterval);
+
+    // Get the oldest Urkel Tree root state a pruning node can recover from.
+    const oldestTreeIntervalStart = oldestBlock + toNextInterval + 1;
+    const entry = await this.db.getEntryByHeight(oldestTreeIntervalStart);
+
+    try {
+      // Rewind Urkel Tree and delete all historical state.
+      await this.db.compactTree(entry.treeRoot);
+
+      // Replay the blockchain back up to the tip to rebuild tree.
+      return await this.syncTree();
+    } finally {
+      unlock();
+    }
+  }
+
+  /**
    * Scan the blockchain for transactions containing specified address hashes.
    * @param {Hash} start - Block hash to start at.
    * @param {Bloom} filter - Bloom filter containing tx and address hashes.

--- a/lib/blockchain/chain.js
+++ b/lib/blockchain/chain.js
@@ -100,15 +100,13 @@ class Chain extends AsyncEmitter {
 
     this.setDeploymentState(state);
 
-    if (this.options.compactTree) {
-      if (this.options.spv)
-        throw new Error('Cannot compact tree in SPV mode.');
+    if (!this.options.spv) {
+      if (this.options.compactTree)
+        await this.compactTree();
 
-      // Will call syncTree() after compaction.
-      await this.compactTree();
-    } else {
-      if (!this.options.spv)
-        await this.syncTree();
+    // Replay the blockchain from last committed tree root
+    // back up to the tip to rebuild tree and txn.
+      await this.syncTree();
     }
 
     this.logger.memory();
@@ -2130,9 +2128,6 @@ class Chain extends AsyncEmitter {
     try {
       // Rewind Urkel Tree and delete all historical state.
       await this.db.compactTree(entry.treeRoot);
-
-      // Replay the blockchain back up to the tip to rebuild tree.
-      return await this.syncTree();
     } finally {
       unlock();
     }

--- a/lib/blockchain/chain.js
+++ b/lib/blockchain/chain.js
@@ -2090,6 +2090,9 @@ class Chain extends AsyncEmitter {
    */
 
   async compactTree() {
+    if (this.height < this.network.block.keepBlocks)
+      throw new Error('Chain is too short to compact tree.');
+
     const unlock = await this.locker.lock();
     this.logger.info('Compacting Urkel Tree...');
 

--- a/lib/blockchain/chaindb.js
+++ b/lib/blockchain/chaindb.js
@@ -1930,6 +1930,25 @@ class ChainDB {
    */
 
   async saveNames(view, entry, revert) {
+    this.start();
+    try {
+      await this._saveNames(view, entry, revert);
+    } catch (e) {
+      this.drop();
+      throw e;
+    }
+    await this.commit();
+  }
+
+  /**
+   * Commit names to tree, assuming batch is started.
+   * @private
+   * @param {CoinView} view
+   * @param {ChainEntry} entry
+   * @param {Boolean} revert
+   */
+
+  async _saveNames(view, entry, revert) {
     for (const ns of view.names.values()) {
       const {nameHash} = ns;
 
@@ -1980,7 +1999,7 @@ class ChainDB {
     else
       this.put(layout.w.encode(entry.height), undo.encode());
 
-    return this.saveNames(view, entry, false);
+    return this._saveNames(view, entry, false);
   }
 
   /**
@@ -2005,7 +2024,7 @@ class ChainDB {
       this.del(layout.w.encode(entry.height));
     }
 
-    return this.saveNames(view, entry, true);
+    return this._saveNames(view, entry, true);
   }
 
   /**

--- a/lib/blockchain/chaindb.js
+++ b/lib/blockchain/chaindb.js
@@ -956,6 +956,14 @@ class ChainDB {
    */
 
   async compactTree(root) {
+    // Before doing anything to the tree,
+    // save the target tree root hash to chain database.
+    // If the tree data gets out of sync or corrupted
+    // the chain database knows where to resync the tree from.
+    this.start();
+    this.put(layout.s.encode(), root);
+    await this.commit();
+
     // Rewind tree to historical commitment
     await this.tree.inject(root);
 

--- a/lib/blockchain/chaindb.js
+++ b/lib/blockchain/chaindb.js
@@ -948,6 +948,25 @@ class ChainDB {
   }
 
   /**
+   * Compact the Urkel Tree.
+   * Removes all historical state and all data not
+   * linked directly to the provided root node hash.
+   * @param {Hash} root
+   * @returns {Promise}
+   */
+
+  async compactTree(root) {
+    // Rewind tree to historical commitment
+    await this.tree.inject(root);
+
+    // Delete historical data
+    await this.tree.compact();
+
+    // Reset in-memory tree delta
+    this.txn = this.tree.txn();
+  }
+
+  /**
    * Get the _next_ block hash (does not work by height).
    * @param {Hash} hash
    * @returns {Promise} - Returns {@link Hash}.

--- a/lib/blockchain/chaindb.js
+++ b/lib/blockchain/chaindb.js
@@ -997,8 +997,8 @@ class ChainDB {
     this.start();
     this.pendingTreeState.compact(entry.treeRoot, entry.height);
 
-    // Note: the tree root commit height is always,
-    // first it's appearence - 1.
+    // Note: the tree root commit height is always one block before its
+    // appearence in a header.
     this.put(layout.s.encode(), this.pendingTreeState.commit(
       entry.treeRoot,
       entry.height - 1

--- a/lib/blockchain/chaindb.js
+++ b/lib/blockchain/chaindb.js
@@ -1005,11 +1005,29 @@ class ChainDB {
     ));
     await this.commit();
 
+    const tmpDir = this.options.treePrefix + '~';
+
+    const tmpTree = new Tree({
+      hash: blake2b,
+      bits: 256,
+      prefix: tmpDir
+    });
+
+    // Make sure to remove the tmp directory first.
+    // There should not be directory, unless it was
+    // stopped in the middle of compaction.
+    // Otherwise compacted tree would add on top
+    // of the previsouly compacted db.
+    await tmpTree.open();
+    const tmpStore = tmpTree.store;
+    await tmpTree.close();
+    await tmpStore.destroy();
+
     // Rewind tree to historical commitment
     await this.tree.inject(entry.treeRoot);
 
     // Delete historical data
-    await this.tree.compact();
+    await this.tree.compact(tmpDir);
 
     // Reset in-memory tree delta
     this.txn = this.tree.txn();

--- a/lib/blockchain/chaindb.js
+++ b/lib/blockchain/chaindb.js
@@ -52,7 +52,7 @@ class ChainDB {
 
     this.db = bdb.create(this.options);
     this.name = 'chain';
-    this.version = 2;
+    this.version = 3;
     this.tree = new Tree({
       hash: blake2b,
       bits: 256,
@@ -61,6 +61,7 @@ class ChainDB {
       initCacheSize: -1
     });
     this.txn = this.tree.txn();
+    this.treeState = new TreeState();
     this.stateCache = new StateCache(this.network);
     this.state = new ChainState();
     this.field = new BitField();
@@ -117,10 +118,16 @@ class ChainDB {
 
       // Grab the current tree state.
       if (!this.options.spv) {
-        const root = await this.db.get(layout.s.encode());
-        assert(root && root.length === 32);
+        const treeState = await this.getTreeState();
+        assert(treeState);
+        this.treeState = treeState;
 
-        await this.tree.inject(root);
+        if (treeState.compactionHeight !== 0) {
+          this.logger.warning(
+            `Tree is compacted at ${treeState.compactionHeight}`);
+        }
+
+        await this.tree.inject(treeState.treeRoot);
       }
 
       // Read bitfield.
@@ -662,6 +669,20 @@ class ChainDB {
   }
 
   /**
+   * Retrieve tree state from the tree record.
+   * @returns {Promise<TreeState>}
+   */
+
+  async getTreeState() {
+    const data = await this.db.get(layout.s.encode());
+
+    if (!data)
+      return null;
+
+    return TreeState.decode(data);
+  }
+
+  /**
    * Write genesis block to database.
    * @returns {Promise}
    */
@@ -951,21 +972,24 @@ class ChainDB {
    * Compact the Urkel Tree.
    * Removes all historical state and all data not
    * linked directly to the provided root node hash.
-   * @param {Hash} root
+   * @param {ChainEntry} entry
    * @returns {Promise}
    */
 
-  async compactTree(root) {
+  async compactTree(entry) {
     // Before doing anything to the tree,
     // save the target tree root hash to chain database.
     // If the tree data gets out of sync or corrupted
     // the chain database knows where to resync the tree from.
     this.start();
-    this.put(layout.s.encode(), root);
+    this.treeState.treeRoot = entry.treeRoot;
+    this.treeState.compactionRoot = entry.treeRoot;
+    this.treeState.compactionHeight = entry.height;
+    this.put(layout.s.encode(), this.treeState.encode());
     await this.commit();
 
     // Rewind tree to historical commitment
-    await this.tree.inject(root);
+    await this.tree.inject(entry.treeRoot);
 
     // Delete historical data
     await this.tree.compact();
@@ -2007,7 +2031,8 @@ class ChainDB {
       else
         await this.txn.commit();
 
-      this.put(layout.s.encode(), this.tree.rootHash());
+      this.treeState.treeRoot = this.tree.rootHash();
+      this.put(layout.s.encode(), this.treeState.encode());
     }
   }
 
@@ -2643,6 +2668,53 @@ class CacheUpdate {
     const data = Buffer.allocUnsafe(1);
     data[0] = this.state;
     return data;
+  }
+}
+
+/**
+ * Tree related state.
+ */
+
+class TreeState extends bio.Struct {
+  /**
+   * Create tree state.
+   * @constructor
+   * @ignore
+   */
+
+  constructor() {
+    super();
+    this.treeRoot = consensus.ZERO_HASH;
+    this.compactionRoot = consensus.ZERO_HASH;
+    this.compactionHeight = 0;
+  }
+
+  inject(state) {
+    this.treeRoot = state.treeRoot;
+    this.compactionHeight = state.compactionHeight;
+    this.compactionRoot = state.compactionRoot;
+
+    return this;
+  }
+
+  getSize() {
+    return 68;
+  }
+
+  write(bw) {
+    bw.writeHash(this.treeRoot);
+    bw.writeHash(this.compactionRoot);
+    bw.writeU32(this.compactionHeight);
+
+    return bw;
+  }
+
+  read(br) {
+    this.treeRoot = br.readHash();
+    this.compactionRoot = br.readHash();
+    this.compactionHeight = br.readU32();
+
+    return this;
   }
 }
 

--- a/lib/blockchain/chaindb.js
+++ b/lib/blockchain/chaindb.js
@@ -66,6 +66,7 @@ class ChainDB {
     this.state = new ChainState();
     this.field = new BitField();
     this.pending = null;
+    this.pendingTreeState = null;
     this.current = null;
     this.blocksBatch = null;
 
@@ -239,6 +240,7 @@ class ChainDB {
 
     this.current = this.db.batch();
     this.pending = this.state.clone();
+    this.pendingTreeState = this.treeState.clone();
 
     if (this.blocks)
       this.blocksBatch = this.blocks.batch();
@@ -291,10 +293,12 @@ class ChainDB {
 
     assert(this.current);
     assert(this.pending);
+    assert(this.pendingTreeState);
     assert(!this.blocks || this.blocksBatch);
 
     this.current = null;
     this.pending = null;
+    this.pendingTreeState = null;
     this.blocksBatch = null;
 
     this.cacheHash.drop();
@@ -315,6 +319,7 @@ class ChainDB {
   async commit() {
     assert(this.current);
     assert(this.pending);
+    assert(this.pendingTreeState);
 
     try {
       if (this.blocks)
@@ -324,6 +329,7 @@ class ChainDB {
     } catch (e) {
       this.current = null;
       this.pending = null;
+      this.pendingTreeState = null;
       this.cacheHash.drop();
       this.cacheHeight.drop();
       this.blocksBatch = null;
@@ -338,8 +344,15 @@ class ChainDB {
     if (this.pending.committed)
       this.state = this.pending;
 
+    // Overwrite the entire TreeState
+    // if it's committed. Only happens
+    // on tree.commits. @see _saveNames
+    if (this.pendingTreeState.committed)
+      this.treeState = this.pendingTreeState;
+
     this.current = null;
     this.pending = null;
+    this.pendingTreeState = null;
 
     this.cacheHash.commit();
     this.cacheHeight.commit();
@@ -982,10 +995,14 @@ class ChainDB {
     // If the tree data gets out of sync or corrupted
     // the chain database knows where to resync the tree from.
     this.start();
-    this.treeState.treeRoot = entry.treeRoot;
-    this.treeState.compactionRoot = entry.treeRoot;
-    this.treeState.compactionHeight = entry.height;
-    this.put(layout.s.encode(), this.treeState.encode());
+    this.pendingTreeState.compact(entry.treeRoot, entry.height);
+
+    // Note: the tree root commit height is always,
+    // first it's appearence - 1.
+    this.put(layout.s.encode(), this.pendingTreeState.commit(
+      entry.treeRoot,
+      entry.height - 1
+    ));
     await this.commit();
 
     // Rewind tree to historical commitment
@@ -1246,7 +1263,7 @@ class ChainDB {
   /**
    * Get name state.
    * @param {Buffer} nameHash
-   * @returns {NameState}
+   * @returns {Promise<NameState>}
    */
 
   async getNameState(nameHash) {
@@ -1263,7 +1280,7 @@ class ChainDB {
   /**
    * Get name state by name.
    * @param {Buffer} name
-   * @returns {NameState}
+   * @returns {Promise<NameState>}
    */
 
   async getNameStateByName(name) {
@@ -1273,7 +1290,7 @@ class ChainDB {
   /**
    * Get name status.
    * @param {Buffer} nameHash
-   * @returns {NameState}
+   * @returns {Promise<NameState>}
    */
 
   async getNameStatus(nameHash, height, hardened) {
@@ -1783,6 +1800,9 @@ class ChainDB {
     if (this.options.prune)
       throw new Error('Cannot reset when pruned.');
 
+    if (this.treeState.compactionHeight !== 0)
+      throw new Error('Cannot reset when tree is compacted.');
+
     // We need to remove all alternate
     // chains first. This is ugly, but
     // it's the only safe way to reset
@@ -2031,8 +2051,13 @@ class ChainDB {
       else
         await this.txn.commit();
 
-      this.treeState.treeRoot = this.tree.rootHash();
-      this.put(layout.s.encode(), this.treeState.encode());
+      // Commit new tree state.
+      // Chain will need to recover current txn
+      // from treeState.commitHeight + 1 (including).
+      this.put(layout.s.encode(), this.pendingTreeState.commit(
+        this.tree.rootHash(),
+        entry.height
+      ));
     }
   }
 
@@ -2685,24 +2710,47 @@ class TreeState extends bio.Struct {
   constructor() {
     super();
     this.treeRoot = consensus.ZERO_HASH;
+    this.commitHeight = 0;
     this.compactionRoot = consensus.ZERO_HASH;
     this.compactionHeight = 0;
+
+    this.committed = false;
   }
 
   inject(state) {
     this.treeRoot = state.treeRoot;
+    this.commitHeight = state.treeHeight;
     this.compactionHeight = state.compactionHeight;
     this.compactionRoot = state.compactionRoot;
 
     return this;
   }
 
+  compact(hash, height) {
+    assert(Buffer.isBuffer(hash));
+    assert((height >>> 0) === height);
+
+    this.compactionRoot = hash;
+    this.compactionHeight = height;
+  };
+
+  commit(hash, height) {
+    assert(Buffer.isBuffer(hash));
+    assert((height >>> 0) === height);
+
+    this.treeRoot = hash;
+    this.commitHeight = height;
+    this.committed = true;
+    return this.encode();
+  }
+
   getSize() {
-    return 68;
+    return 72;
   }
 
   write(bw) {
     bw.writeHash(this.treeRoot);
+    bw.writeU32(this.commitHeight);
     bw.writeHash(this.compactionRoot);
     bw.writeU32(this.compactionHeight);
 
@@ -2711,6 +2759,7 @@ class TreeState extends bio.Struct {
 
   read(br) {
     this.treeRoot = br.readHash();
+    this.commitHeight = br.readU32();
     this.compactionRoot = br.readHash();
     this.compactionHeight = br.readU32();
 

--- a/lib/blockchain/migrations.js
+++ b/lib/blockchain/migrations.js
@@ -412,13 +412,15 @@ class MigrateTreeState extends AbstractMigration {
   }
 
   async check() {
-    if (this.options.spv)
-      return types.FAKE_MIGRATE;
-
     return types.MIGRATE;
   }
 
   async migrate(b) {
+    if (this.options.spv) {
+      this.db.writeVersion(b, 3);
+      return;
+    }
+
     const {treeInterval} = this.network.names;
     const state = await this.db.getState();
     const tipHeight = await this.db.getHeight(state.tip);

--- a/lib/blockchain/migrations.js
+++ b/lib/blockchain/migrations.js
@@ -8,6 +8,7 @@
 
 const assert = require('bsert');
 const Logger = require('blgr');
+const {encoding} = require('bufio');
 const Network = require('../protocol/network');
 const rules = require('../covenants/rules');
 const Block = require('../primitives/block');
@@ -407,6 +408,7 @@ class MigrateTreeState extends AbstractMigration {
     this.logger = options.logger.context('chain-migration-tree-state');
     this.db = options.db;
     this.ldb = options.ldb;
+    this.network = options.network;
   }
 
   async check() {
@@ -417,13 +419,18 @@ class MigrateTreeState extends AbstractMigration {
   }
 
   async migrate(b) {
+    const {treeInterval} = this.network.names;
+    const state = await this.db.getState();
+    const tipHeight = await this.db.getHeight(state.tip);
+    const lastCommitHeight = tipHeight - (tipHeight % treeInterval);
     const hash = await this.ldb.get(layout.s.encode());
     assert(hash && hash.length === 32);
 
     // new tree root
     // see chaindb.js TreeState
-    const buff = Buffer.alloc(68);
-    hash.copy(buff);
+    const buff = Buffer.alloc(72);
+    encoding.writeBytes(buff, hash, 0);
+    encoding.writeU32(buff, lastCommitHeight, 32);
 
     this.db.writeVersion(b, 3);
     b.put(layout.s.encode(), buff);

--- a/lib/blockchain/migrations.js
+++ b/lib/blockchain/migrations.js
@@ -390,6 +390,54 @@ class MigrateBlockStore extends AbstractMigration {
 };
 
 /**
+ * Migrate Tree State
+ */
+
+class MigrateTreeState extends AbstractMigration {
+  /**
+   * Create tree state migrator
+   * @constructor
+   * @param {ChainMigrator} options
+   */
+
+  constructor(options) {
+    super(options);
+
+    this.options = options;
+    this.logger = options.logger.context('chain-migration-tree-state');
+    this.db = options.db;
+    this.ldb = options.ldb;
+  }
+
+  async check() {
+    if (this.options.spv)
+      return types.FAKE_MIGRATE;
+
+    return types.MIGRATE;
+  }
+
+  async migrate(b) {
+    const hash = await this.ldb.get(layout.s.encode());
+    assert(hash && hash.length === 32);
+
+    // new tree root
+    // see chaindb.js TreeState
+    const buff = Buffer.alloc(68);
+    hash.copy(buff);
+
+    this.db.writeVersion(b, 3);
+    b.put(layout.s.encode(), buff);
+  }
+
+  static info() {
+    return {
+      name: 'Migrate Tree State',
+      description: 'Add compaction information to the tree state.'
+    };
+  }
+}
+
+/**
  * Chain Migrator
  * @alias module:blockchain.ChainMigrator
  */
@@ -528,12 +576,14 @@ exports = ChainMigrator;
 exports.migrations = {
   0: MigrateMigrations,
   1: MigrateChainState,
-  2: MigrateBlockStore
+  2: MigrateBlockStore,
+  3: MigrateTreeState
 };
 
 // Expose migrations
 exports.MigrateChainState = MigrateChainState;
 exports.MigrateMigrations = MigrateMigrations;
 exports.MigrateBlockStore = MigrateBlockStore;
+exports.MigrateTreeState = MigrateTreeState;
 
 module.exports = exports;

--- a/lib/node/fullnode.js
+++ b/lib/node/fullnode.js
@@ -260,7 +260,7 @@ class FullNode extends Node {
       this.emit('tree compact start', treeRoot, entry);
     });
 
-    this.chain.on('tree compact start', (treeRoot, entry) => {
+    this.chain.on('tree compact end', (treeRoot, entry) => {
       this.emit('tree compact end', treeRoot, entry);
     });
 

--- a/lib/node/fullnode.js
+++ b/lib/node/fullnode.js
@@ -67,7 +67,8 @@ class FullNode extends Node {
       chainMigrate: this.config.uint('chain-migrate'),
       indexTX: this.config.bool('index-tx'),
       indexAddress: this.config.bool('index-address'),
-      compactTree: this.config.bool('compact-tree')
+      compactTreeOnInit: this.config.bool('compact-tree-on-init'),
+      compactTreeInitInterval: this.config.uint('compact-tree-init-interval')
     });
 
     // Fee estimation.
@@ -253,6 +254,14 @@ class FullNode extends Node {
         this.error(e);
       }
       this.emit('reset', tip);
+    });
+
+    this.chain.on('tree compact start', (treeRoot, entry) => {
+      this.emit('tree compact start', treeRoot, entry);
+    });
+
+    this.chain.on('tree compact start', (treeRoot, entry) => {
+      this.emit('tree compact end', treeRoot, entry);
     });
 
     this.loadPlugins();

--- a/lib/node/fullnode.js
+++ b/lib/node/fullnode.js
@@ -264,6 +264,14 @@ class FullNode extends Node {
       this.emit('tree compact end', treeRoot, entry);
     });
 
+    this.chain.on('tree reconstruct start', () => {
+      this.emit('tree reconstruct start');
+    });
+
+    this.chain.on('tree reconstruct end', () => {
+      this.emit('tree reconstruct end');
+    });
+
     this.loadPlugins();
   }
 

--- a/lib/node/fullnode.js
+++ b/lib/node/fullnode.js
@@ -66,7 +66,8 @@ class FullNode extends Node {
       entryCache: this.config.uint('entry-cache'),
       chainMigrate: this.config.uint('chain-migrate'),
       indexTX: this.config.bool('index-tx'),
-      indexAddress: this.config.bool('index-address')
+      indexAddress: this.config.bool('index-address'),
+      compactTree: this.config.bool('compact-tree')
     });
 
     // Fee estimation.

--- a/lib/node/rpc.js
+++ b/lib/node/rpc.js
@@ -178,6 +178,7 @@ class RPC extends RPCBase {
     this.add('gettxoutsetinfo', this.getTXOutSetInfo);
     this.add('pruneblockchain', this.pruneBlockchain);
     this.add('compacttree', this.compactTree);
+    this.add('reconstructtree', this.reconstructTree);
     this.add('verifychain', this.verifyChain);
 
     this.add('invalidateblock', this.invalidateBlock);
@@ -1114,6 +1115,27 @@ class RPC extends RPCBase {
 
     try {
       await this.chain.compactTree();
+    } catch (e) {
+      throw new RPCError(errs.DATABASE_ERROR, e.message);
+    }
+  }
+
+  async reconstructTree(args, help) {
+    if (help || args.length !== 0)
+      throw new RPCError(errs.MISC_ERROR, 'reconstructtree');
+
+    if (this.chain.options.spv) {
+      throw new RPCError(errs.MISC_ERROR,
+        'Cannot reconstruct tree in SPV mode.');
+    }
+
+    if (this.chain.options.prune) {
+      throw new RPCError(errs.MISC_ERROR,
+        'Cannot reconstruct tree in pruned node.');
+    }
+
+    try {
+      await this.chain.reconstructTree();
     } catch (e) {
       throw new RPCError(errs.DATABASE_ERROR, e.message);
     }

--- a/lib/node/rpc.js
+++ b/lib/node/rpc.js
@@ -177,6 +177,7 @@ class RPC extends RPCBase {
     this.add('gettxout', this.getTXOut);
     this.add('gettxoutsetinfo', this.getTXOutSetInfo);
     this.add('pruneblockchain', this.pruneBlockchain);
+    this.add('compacttree', this.compactTree);
     this.add('verifychain', this.verifyChain);
 
     this.add('invalidateblock', this.invalidateBlock);
@@ -1099,6 +1100,20 @@ class RPC extends RPCBase {
 
     try {
       await this.chain.prune();
+    } catch (e) {
+      throw new RPCError(errs.DATABASE_ERROR, e.message);
+    }
+  }
+
+    async compactTree(args, help) {
+    if (help || args.length !== 0)
+      throw new RPCError(errs.MISC_ERROR, 'compacttree');
+
+    if (this.chain.options.spv)
+      throw new RPCError(errs.MISC_ERROR, 'Cannot compact tree in SPV mode.');
+
+    try {
+      await this.chain.compactTree();
     } catch (e) {
       throw new RPCError(errs.DATABASE_ERROR, e.message);
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
         "goosig": "~0.10.0",
         "hs-client": "~0.0.11",
         "n64": "~0.2.10",
-        "urkel": "~1.0.0"
+        "urkel": "~1.0.1"
       },
       "bin": {
         "hs-seeder": "bin/hs-seeder",
@@ -461,9 +461,9 @@
       }
     },
     "node_modules/urkel": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/urkel/-/urkel-1.0.0.tgz",
-      "integrity": "sha512-N1dvng7KMCr9XXKPI8yIaCwlggNvXOpY6OxYb42cuLHPiabe7QCknsU6BWklcBLUHpouyHZ/KHCceyKRrI5e7A==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/urkel/-/urkel-1.0.1.tgz",
+      "integrity": "sha512-/ul3w/hvvGzppHqdpDAcEFe8kS1hi6ty5h7oQalIlVLwPNUJ/tz/h7KtIyNRC0+u7ANryq2Aw96N8snq+VYEOg==",
       "dependencies": {
         "bfile": "~0.2.1",
         "bmutex": "~0.1.6",
@@ -748,9 +748,9 @@
       }
     },
     "urkel": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/urkel/-/urkel-1.0.0.tgz",
-      "integrity": "sha512-N1dvng7KMCr9XXKPI8yIaCwlggNvXOpY6OxYb42cuLHPiabe7QCknsU6BWklcBLUHpouyHZ/KHCceyKRrI5e7A==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/urkel/-/urkel-1.0.1.tgz",
+      "integrity": "sha512-/ul3w/hvvGzppHqdpDAcEFe8kS1hi6ty5h7oQalIlVLwPNUJ/tz/h7KtIyNRC0+u7ANryq2Aw96N8snq+VYEOg==",
       "requires": {
         "bfile": "~0.2.1",
         "bmutex": "~0.1.6",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "goosig": "~0.10.0",
     "hs-client": "~0.0.11",
     "n64": "~0.2.10",
-    "urkel": "~1.0.0"
+    "urkel": "~1.0.1"
   },
   "devDependencies": {
     "bmocha": "^2.1.5"

--- a/test/chain-migration-test.js
+++ b/test/chain-migration-test.js
@@ -2,6 +2,8 @@
 
 const assert = require('bsert');
 const fs = require('bfile');
+const {encoding} = require('bufio');
+const {ZERO_HASH} = require('../lib/protocol/consensus');
 const Network = require('../lib/protocol/network');
 const WorkerPool = require('../lib/workers/workerpool');
 const Miner = require('../lib/mining/miner');
@@ -935,7 +937,10 @@ describe('Chain Migrations', function() {
 
       await chain.open();
       const state = chaindb.treeState;
-      assert.bufferEqual(state.encode(), Buffer.alloc(68, 0));
+      const encoded = Buffer.alloc(72, 0);
+
+      encoding.writeU32(encoded, chain.height, 32);
+      assert.bufferEqual(state.encode(), encoded);
     });
 
     it('should migrate tree state (2)', async () => {
@@ -971,7 +976,7 @@ describe('Chain Migrations', function() {
       const version = getVersion(await ldb.get(layout.V.encode()), 'chain');
       assert.strictEqual(version, 3);
       assert.bufferEqual(chaindb.treeState.treeRoot, root);
-      assert.bufferEqual(chaindb.treeState.compactionRoot, Buffer.alloc(32, 0));
+      assert.bufferEqual(chaindb.treeState.compactionRoot, ZERO_HASH);
       assert.strictEqual(chaindb.treeState.compactionHeight, 0);
     });
   });

--- a/test/chain-tree-compaction-test.js
+++ b/test/chain-tree-compaction-test.js
@@ -364,7 +364,7 @@ describe('Tree Compacting', function() {
 
         // Rewind the tree 6 intervals and compact, but do not sync to tip yet.
         const entry = await chain.getEntry(chain.height - 6 * treeInterval);
-        await chain.db.compactTree(entry.treeRoot);
+        await chain.db.compactTree(entry);
 
         // Confirm tree state has been rewound
         assert.notBufferEqual(chain.db.tree.rootHash(), chain.tip.treeRoot);

--- a/test/chain-tree-compaction-test.js
+++ b/test/chain-tree-compaction-test.js
@@ -384,7 +384,7 @@ describe('Tree Compacting', function() {
   }
 
   describe('SPV', function() {
-    it('should refuse to compact tree via RPC', async () => {
+    it('should ignore compact tree option', async () => {
       const prefix = path.join(
         os.tmpdir(),
         `hsd-tree-compacting-test-${Date.now()}`
@@ -393,17 +393,13 @@ describe('Tree Compacting', function() {
       const node = new SPVNode({
         prefix,
         network: 'regtest',
-        memory: false
+        memory: false,
+        compactTree: true,
+        prune: true // also ignored
       });
 
       await node.ensure();
       await node.open();
-
-      await assert.rejects(
-        node.rpc.compactTree([]),
-        {message: 'Cannot compact tree in SPV mode.'}
-      );
-
       await node.close();
     });
   });
@@ -428,29 +424,6 @@ describe('Tree Compacting', function() {
         node.open(),
         {message: 'Chain is too short to compact tree.'}
       );
-    });
-
-    it('should throw if chain is too short to compact via RPC', async () => {
-      const prefix = path.join(
-        os.tmpdir(),
-        `hsd-tree-compacting-test-${Date.now()}`
-      );
-
-      const node = new FullNode({
-        prefix,
-        network: 'regtest',
-        memory: false
-      });
-
-      await node.ensure();
-      await node.open();
-
-      await assert.rejects(
-        node.rpc.compactTree([]),
-        {message: 'Chain is too short to compact tree.'}
-      );
-
-      await node.close();
     });
 
     it('should compact tree on launch', async () => {

--- a/test/chain-tree-compaction-test.js
+++ b/test/chain-tree-compaction-test.js
@@ -201,6 +201,7 @@ describe('Tree Compacting', function() {
       it('should compact tree', async () => {
         const before = await fs.stat(treePath);
         await chain.compactTree();
+        await chain.syncTree();
         const after = await fs.stat(treePath);
 
         // Urkel Tree should be smaller now.
@@ -271,6 +272,7 @@ describe('Tree Compacting', function() {
         // it shouldn't break anything.
         const before = await fs.stat(treePath);
         await chain.compactTree();
+        await chain.syncTree();
         const after = await fs.stat(treePath);
 
         // Should be no change
@@ -330,6 +332,7 @@ describe('Tree Compacting', function() {
         // Compact
         const before = await fs.stat(treePath);
         await chain.compactTree();
+        await chain.syncTree();
         const after = await fs.stat(treePath);
         assert(before.size > after.size);
 
@@ -371,11 +374,8 @@ describe('Tree Compacting', function() {
         await chain.close();
         await blocks.close();
 
-        // Restart -- chainDB used to open tree with what it thought
-        // was the latest tree state (saved in levelDB). If the actual
-        // tree on disk was still 6 intervals behind, chain.open() would
-        // fail with `Missing node` error. The updated logic relies on the
-        // tree itself to find its own state (saved in Meta nodes) then
+        // Restart -- chainDB will open tree with what it thinks
+        // is the latest tree state (saved in levelDB). Then
         // chain.syncTree() will catch it up from there to tip.
         await blocks.open();
         await chain.open();

--- a/test/chain-tree-compaction-test.js
+++ b/test/chain-tree-compaction-test.js
@@ -1,0 +1,325 @@
+'use strict';
+
+const os = require('os');
+const path = require('path');
+const fs = require('bfile');
+const assert = require('bsert');
+const Network = require('../lib/protocol/network');
+const Miner = require('../lib/mining/miner');
+const Chain = require('../lib/blockchain/chain');
+const blockstore = require('../lib/blockstore');
+const MemWallet = require('./util/memwallet');
+const rules = require('../lib/covenants/rules');
+const NameState = require('../lib/covenants/namestate');
+
+const network = Network.get('regtest');
+const {
+  treeInterval,
+  biddingPeriod,
+  revealPeriod
+} = network.names;
+
+describe('Tree Compacting', function() {
+  for (const prune of [true, false]) {
+    describe(`Chain: ${prune ? 'Pruning' : 'Archival'}`, function() {
+      const prefix = path.join(
+        os.tmpdir(),
+        `hsd-tree-compacting-test-${Date.now()}`
+      );
+      const treePath = path.join(prefix, 'tree', '0000000001');
+
+      const blocks = blockstore.create({
+        prefix,
+        network
+      });
+
+      const chain = new Chain({
+        memory: false,
+        prefix,
+        blocks,
+        network,
+        prune
+      });
+
+      const miner = new Miner({chain});
+      const cpu = miner.cpu;
+
+      const wallet = new MemWallet({network});
+      wallet.getNameStatus = async (nameHash) => {
+        assert(Buffer.isBuffer(nameHash));
+        const height = chain.height + 1;
+        return chain.db.getNameStatus(nameHash, height);
+      };
+
+      const mempool = [];
+
+      function send(mtx, mempool) {
+        mempool.push(mtx.toTX());
+      }
+
+      async function mineBlocks(num, mempool = []) {
+        const job = await cpu.createJob();
+        while (mempool.length) {
+          job.pushTX(mempool.pop());
+        }
+        job.refresh();
+        const block = await job.mineAsync();
+        const entry = await chain.add(block);
+        wallet.addBlock(entry, block.txs);
+
+        for (num--; num > 0; num--) {
+          const job = await cpu.createJob();
+          const block = await job.mineAsync();
+          const entry = await chain.add(block);
+          wallet.addBlock(entry, block.txs);
+        }
+      }
+
+      const oldKeepBlocks = network.block.keepBlocks;
+      const oldpruneAfterHeight = network.block.pruneAfterHeight;
+
+      let name, nameHash;
+      const treeRoots = [];
+
+      before(async () => {
+        // Copy the 1:8 ratio from mainnet
+        network.block.keepBlocks = treeInterval * 8;
+
+        // Ensure old blocks are pruned right away
+        network.block.pruneAfterHeight = 1;
+
+        await blocks.ensure();
+        await blocks.open();
+        await chain.open();
+        await miner.open();
+      });
+
+      after(async () => {
+        await miner.close();
+        await chain.close();
+        await blocks.close();
+        await fs.rimraf(prefix);
+
+        network.block.keepBlocks = oldKeepBlocks;
+        network.block.pruneAfterHeight = oldpruneAfterHeight;
+      });
+
+      it('should fund wallet', async () => {
+        miner.addresses.length = 0;
+        miner.addAddress(wallet.getReceive());
+        await mineBlocks(100);
+      });
+
+      it('should win an auction and register', async () => {
+        name = rules.grindName(3, chain.height, network);
+        nameHash = rules.hashName(name);
+        send(await wallet.sendOpen(name), mempool);
+        await mineBlocks(treeInterval + 1, mempool);
+        send(await wallet.sendBid(name, 10000, 10000), mempool);
+        await mineBlocks(biddingPeriod, mempool);
+        send(await wallet.sendReveal(name), mempool);
+        await mineBlocks(revealPeriod, mempool);
+
+        // Instead of using a version 0 serialized `Resource` with DNS data,
+        // just register a single byte as a counter.
+        send(await wallet.sendRegister(name, Buffer.from([0x00])), mempool);
+        await mineBlocks(treeInterval, mempool);
+      });
+
+      it('should update Urkel Tree 20 times', async () => {
+        let count = 0;
+        chain.on('tree commit', (rootHash, entry, block) => {
+          count++;
+          // Keep track of all new tree root hashes.
+          treeRoots.push(rootHash);
+        });
+
+        for (let i = 1; i <= 20; i++) {
+          // Every namestate update, increment the name's 1-byte data resource.
+          send(await wallet.sendUpdate(name, Buffer.from([i])), mempool);
+          await mineBlocks(treeInterval, mempool);
+        }
+
+        assert.strictEqual(count, 20);
+
+        const ns = await chain.db.getNameStateByName(name);
+        assert.bufferEqual(ns.data, Buffer.from([20]));
+      });
+
+      it('should restore tree state from any historical root', async () => {
+        for (let i = 0; i < treeRoots.length; i++) {
+          // Restore old tree state using historical root hash.
+          await chain.db.tree.inject(treeRoots[i]);
+
+          // Get old namestate from old tree state.
+          const raw = await chain.db.tree.get(nameHash);
+          const ns = NameState.decode(raw);
+
+          // Counter in the name's data resource should match.
+          assert.bufferEqual(ns.data, Buffer.from([i + 1]));
+        }
+      });
+
+      it('should compact tree', async () => {
+        const before = await fs.stat(treePath);
+        await chain.compactTree();
+        const after = await fs.stat(treePath);
+
+        // Urkel Tree should be smaller now.
+        // Urkel Tree files are padded to ensure that Meta nodes are written
+        // at predictable offsets so they can be quickly discovered
+        // without indexing (Meta nodes point to the current tree root
+        // node as well as the PREVIOUS Meta node). This makes it
+        // really complicated to estimate exactly what the size of the file
+        // should be before and after compacting.
+        // The compacting process definitely should have deleted 12 of
+        // the 20 recent tree namestate updates so we can make
+        // sure that the data savings is at least that size. It should
+        // also have deleted the OPEN, REVEAL and original REGISTER,
+        // as well as tree updates written during the initial wallet funding.
+        // One advantage we have is there is only one name in the tree,
+        // so there are no internal nodes. In fact, the tree root node
+        // is just our name's leaf node!
+        const META_NODE_SIZE = 38;      // See urkel/radix/store.js
+        const LEAF_NODE_SIZE = 40;      // See urkel/radix/nodes.js
+        const NAMESTATE_DATA_SIZE = 53; // NameState.getSize();
+
+        // First 100 blocks wrote a Meta node every tree interval
+        const fundingWallet = (100 / treeInterval) * META_NODE_SIZE;
+
+        const eachUpdate = (
+          META_NODE_SIZE +
+          LEAF_NODE_SIZE +
+          NAMESTATE_DATA_SIZE
+        );
+
+        // Auction wrote a Meta node and namestate update every tree interval
+        const auction = (
+          (treeInterval + 1 + biddingPeriod + revealPeriod + treeInterval) /
+          treeInterval
+        ) * eachUpdate;
+
+        const minReduction = fundingWallet + auction + (eachUpdate * 12);
+
+        // The margin of error here is the padding.
+        assert(before.size - after.size >= minReduction);
+
+        // We also expect the compacted tree to be at least big enough
+        // for the last 8 namestate updates. Padding makes precision difficult.
+        assert(after.size >= (eachUpdate * 8));
+      });
+
+      it('should ONLY restore tree state from most recent roots', async () => {
+        for (let i = 0; i < treeRoots.length; i++) {
+          if (i < (treeRoots.length - 8)) {
+            // Old root node has been deleted, tree state can not be restored.
+            await assert.rejects(
+              chain.db.tree.inject(treeRoots[i]),
+              {message: `Missing node: ${treeRoots[i].toString('hex')}.`}
+            );
+            continue;
+          }
+
+          // Last 8 tree roots are recovered successfully like before compaction.
+          await chain.db.tree.inject(treeRoots[i]);
+          const raw = await chain.db.tree.get(nameHash);
+          const ns = NameState.decode(raw);
+          assert.bufferEqual(ns.data, Buffer.from([i + 1]));
+        }
+      });
+
+      it('should compact tree a second time with no new data', async () => {
+        // If user executes rpc compacttree repeatedly,
+        // it shouldn't break anything.
+        const before = await fs.stat(treePath);
+        await chain.compactTree();
+        const after = await fs.stat(treePath);
+
+        // Should be no change
+        assert.strictEqual(before.size, after.size);
+      });
+
+      it('should ONLY restore tree state from most recent roots', async () => {
+        // Data recovery conditions are the same after second compacttree.
+        for (let i = 0; i < treeRoots.length; i++) {
+          if (i < (treeRoots.length - 8)) {
+            // Old root node has been deleted, tree state can not be restored.
+            await assert.rejects(
+              chain.db.tree.inject(treeRoots[i]),
+              {message: `Missing node: ${treeRoots[i].toString('hex')}.`}
+            );
+            continue;
+          }
+
+          // Last 8 tree roots are recovered successfully like before compaction.
+          await chain.db.tree.inject(treeRoots[i]);
+          const raw = await chain.db.tree.get(nameHash);
+          const ns = NameState.decode(raw);
+          assert.bufferEqual(ns.data, Buffer.from([i + 1]));
+        }
+      });
+
+      it('should recover txn between tree intervals', async () => {
+        // Get current counter value.
+        let raw = await chain.db.tree.get(nameHash);
+        let ns = NameState.decode(raw);
+        let counter = ns.data[0];
+
+        // Increment counter and commit one tree interval.
+        send(await wallet.sendUpdate(name, Buffer.from([++counter])), mempool);
+        await mineBlocks(treeInterval, mempool);
+
+        // Tree and txn are synced due to tree commitment.
+        assert.bufferEqual(chain.db.tree.rootHash(), chain.db.txn.rootHash());
+
+        // Increment counter and confirm, but do not advance to tree interval.
+        send(await wallet.sendUpdate(name, Buffer.from([++counter])), mempool);
+        await mineBlocks(1, mempool);
+
+        // The txn is updated, but the tree is still in last-committed state
+        assert.notBufferEqual(chain.db.tree.rootHash(), chain.db.txn.rootHash());
+        raw = await chain.db.txn.get(nameHash);
+        ns = NameState.decode(raw);
+        assert.bufferEqual(ns.data, Buffer.from([counter]));
+        raw = await chain.db.tree.get(nameHash);
+        ns = NameState.decode(raw);
+        assert.bufferEqual(ns.data, Buffer.from([counter - 1]));
+
+        // Save
+        const txnRootBefore = chain.db.txn.rootHash();
+        const treeRootBefore = chain.db.tree.rootHash();
+
+        // Compact
+        const before = await fs.stat(treePath);
+        await chain.compactTree();
+        const after = await fs.stat(treePath);
+        assert(before.size > after.size);
+
+        // Check
+        assert.bufferEqual(txnRootBefore, chain.db.txn.rootHash());
+        assert.bufferEqual(treeRootBefore, chain.db.tree.rootHash());
+        assert.notBufferEqual(chain.db.tree.rootHash(), chain.db.txn.rootHash());
+        raw = await chain.db.txn.get(nameHash);
+        ns = NameState.decode(raw);
+        assert.bufferEqual(ns.data, Buffer.from([counter]));
+        raw = await chain.db.tree.get(nameHash);
+        ns = NameState.decode(raw);
+        assert.bufferEqual(ns.data, Buffer.from([counter - 1]));
+      });
+
+      it(`should ${prune ? '' : 'not '}have pruned chain`, async () => {
+        // Sanity check. Everything worked on a chain that is indeed pruning.
+        // Start at height 2 because pruneAfterHeight == 1
+        for (let i = 2; i <= chain.height; i++) {
+          const entry = await chain.getEntry(i);
+          const block = await chain.getBlock(entry.hash);
+
+          if (prune && i <= chain.height - network.block.keepBlocks)
+            assert.strictEqual(block, null);
+          else
+            assert(block);
+        }
+      });
+    });
+  }
+});

--- a/test/chain-tree-compaction-test.js
+++ b/test/chain-tree-compaction-test.js
@@ -104,6 +104,13 @@ describe('Tree Compacting', function() {
         network.block.pruneAfterHeight = oldpruneAfterHeight;
       });
 
+      it('should throw if chain is too short to compact', async () => {
+        await assert.rejects(
+          chain.compactTree(),
+          {message: 'Chain is too short to compact tree.'}
+        );
+      });
+
       it('should fund wallet', async () => {
         miner.addresses.length = 0;
         miner.addAddress(wallet.getReceive());

--- a/test/chain-tree-compaction-test.js
+++ b/test/chain-tree-compaction-test.js
@@ -478,12 +478,20 @@ describe('Tree Compacting', function() {
   }
 
   describe('SPV', function() {
-    it('should ignore compact tree option', async () => {
-      const prefix = path.join(
+    let prefix;
+
+    beforeEach(async () => {
+      prefix = path.join(
         os.tmpdir(),
         `hsd-tree-compacting-test-${Date.now()}`
       );
+    });
 
+    afterEach(async () => {
+      await fs.rimraf(prefix);
+    });
+
+    it('should ignore compact tree option', async () => {
       const node = new SPVNode({
         prefix,
         network: 'regtest',
@@ -499,12 +507,20 @@ describe('Tree Compacting', function() {
   });
 
   describe('Full Node', function() {
-    it('should throw if chain is too short to compact on launch', async () => {
-      const prefix = path.join(
+    let prefix;
+
+    beforeEach(async () => {
+      prefix = path.join(
         os.tmpdir(),
         `hsd-tree-compacting-test-${Date.now()}`
       );
+    });
 
+    afterEach(async () => {
+      await fs.rimraf(prefix);
+    });
+
+    it('should throw if chain is too short to compact on launch', async () => {
       const node = new FullNode({
         prefix,
         network: 'regtest',
@@ -523,10 +539,6 @@ describe('Tree Compacting', function() {
     it('should compact tree on launch', async () => {
       this.timeout(10000);
 
-      const prefix = path.join(
-        os.tmpdir(),
-        `hsd-tree-compacting-test-${Date.now()}`
-      );
       const treePath = path.join(prefix, 'regtest', 'tree', '0000000001');
 
       // Fresh start


### PR DESCRIPTION
Closes #660

Adds new rpc method `compacttree` which deletes from disk an enormous amount of historical data in the Urkel Tree that is only necessary in the case that a chain reorganization occurs deeper than ~288 blocks. Note that this condition also applies to blockchain-pruning nodes and in the event of such a deep reorg, a pruned node will fail into an unrecoverable state. Pruning is available as a configuration setting or can be executed while running with rpc `pruneblockchain`.

### What does compacting the Urkel Tree mean?

Since the tree is append-only, when an existing name is updated (anything from a REVEAL to a REGISTER to an UPDATE) the old data still remains on disk. A new tree node is written and some file pointers are shuffled around to determine the new root hash of the tree (which is committed to in a block header).

If a chain reorg crosses back over a tree interval (36 blocks on mainnet) then an old tree root is pulled from the unzipped chain and used to revert the entire Urkel Tree to its old state, which is possible since all the historical data and pointers are still there on disk.

To compact the Urkel Tree means to take a given tree root and write a fresh Urkel Tree (in flat-file format on disk) containing ONLY the data connected directly to the root, then rename that directory to `~/.hsd/tree`, wiping out all the historical data that is no longer part of the current state.

### Strategy in this PR

Since compacting means the tree can no longer be reverted, it means that a chain reorg only one block deep that crosses a tree interval will permanently annihilate the full node. Therefore, what we must do is:

1. Use the historical data we still have on disk to rewind the Urkel Tree to an old state (~288 blocks ago / about 7-8 tree intervals ago)
2. Run the compacting process on that historical tree root, creating an unrecoverable reorg boundary two days in the past
3. Replay the blockchain back in to the Urkel Tree, all ~288 blocks, including all namestate updates crossing back over those 7-8 tree commitments until the Urkel Tree is back in sync with the chain

### End result

Whether or not a full node is pruning the blockchain, executing this RPC will apply the same restriction at the moment it is completed: a 288-block reorg is the end of the game. Of course UNLIKE a pruning node, this compacting process is NOT on-going, so over time the Urkel Tree will bloat back up again (for better or for worse) until the RPC is called again.

### Mainnet testing

I created a second branch of this PR with [WIP rpc dumpzone](https://github.com/handshake-org/hsd/pull/534) applied. I have hsd synced to height 97555 already and started it in an isolated mode:

`hsd --no-dns --no-wallet --only=127.0.0.1`

Then executed `hsd-rpc dumpzone hns-97555-full.zone` to get a snapshot of the Urkel Tree state.

Then executed `hsd-rpc compacttree` to run the pruning process.

The size of the directory `~/.hsd/tree` dropped from 6.8 GB down to ~500 MB 🥳  and the process took about 2.5 minutes total 🎉 

```
[I:2021-12-09T00:46:06Z] (net) Removed loader peer (127.0.0.1:12038).
[D:2021-12-09T00:46:06Z] (node-rpc) Handling RPC call: compacttree.
[D:2021-12-09T00:46:06Z] (node-rpc) []
[I:2021-12-09T00:46:06Z] (chain) Compacting Urkel Tree...
...
[I:2021-12-09T00:48:13Z] (chain) Synchronizing Tree with block history...
...
[I:2021-12-09T00:48:32Z] (chain) Synchronized Tree Root: 9d8eefb2af6c7ab640826f245040c693738ad7cd629b86f32ba040b3ad7a5f8c.
```

Finally, I ran `hsd-rpc dumpzone hns-97555-compacted.zone` and compared the two output zone files which matched exactly 🚀 




TODO:
- [x] add tests
- [x] consider edge cases like executing too frequently (?)
- [x] determine best deployment (should it be automatic?)