### PR TITLE
dns: fix negative answers & add non-existence proofs for _synth

### DIFF
--- a/lib/dns/common.js
+++ b/lib/dns/common.js
@@ -29,6 +29,12 @@ exports.TYPE_MAP_NS = Buffer.from('0006200000000003', 'hex');
 // TXT RRSIG NSEC
 exports.TYPE_MAP_TXT = Buffer.from('0006000080000003', 'hex');
 
+// A RRSIG NSEC
+exports.TYPE_MAP_A = Buffer.from('0006400000000003', 'hex');
+
+// AAAA RRSIG NSEC
+exports.TYPE_MAP_AAAA = Buffer.from('0006000000080003', 'hex');
+
 exports.hsTypes = {
   DS: 0,
   NS: 1,

--- a/lib/dns/server.js
+++ b/lib/dns/server.js
@@ -26,7 +26,9 @@ const {
   DEFAULT_TTL,
   TYPE_MAP_ROOT,
   TYPE_MAP_EMPTY,
-  TYPE_MAP_NS
+  TYPE_MAP_NS,
+  TYPE_MAP_A,
+  TYPE_MAP_AAAA
 } = require('./common');
 
 const {
@@ -321,15 +323,40 @@ class RootServer extends DNSServer {
       // TLD '._synth' is being queried on its own, send SOA
       // so recursive asks again with complete synth record.
       if (labels.length === 1) {
+        // Empty non-terminal proof:
+        res.authority.push(
+          nsec.create(
+            '_synth.',
+            '\\000._synth.',
+            TYPE_MAP_EMPTY
+          )
+        );
+        key.signZSK(res.authority, types.NSEC);
+
         res.authority.push(this.toSOA());
         key.signZSK(res.authority, types.SOA);
+
         return res;
       }
 
       const hash = util.label(name, labels, -2);
       const ip = IP.map(base32.decodeHex(hash.substring(1)));
+      const synthType = IP.isIPv4(ip) ? types.A : types.AAAA;
 
-      if (IP.isIPv4(ip)) {
+      // Query must be for the correct synth version
+      if (type !== synthType) {
+        // SYNTH4/6 proof:
+        const typeMap = synthType === types.A ? TYPE_MAP_A : TYPE_MAP_AAAA;
+        res.authority.push(nsec.create(name, '\\000.' + name, typeMap));
+        key.signZSK(res.authority, types.NSEC);
+
+        res.authority.push(this.toSOA());
+        key.signZSK(res.authority, types.SOA);
+
+        return res;
+      }
+
+      if (synthType === types.A) {
         rr.type = types.A;
         rr.data = new ARecord();
       } else {

--- a/test/ns-test.js
+++ b/test/ns-test.js
@@ -63,8 +63,9 @@ describe('RootServer', function() {
 
   it('should resolve a SYNTH4', async () => {
     const name = '_fs0000g._synth.';
+    const type = wire.types.A;
     const req = {
-      question: [{name}]
+      question: [{name, type}]
     };
 
     const res = await ns.resolve(req);
@@ -78,8 +79,9 @@ describe('RootServer', function() {
 
   it('should resolve a SYNTH6', async () => {
     const name = '_00000000000000000000000008._synth.';
+    const type = wire.types.AAAA;
     const req = {
-      question: [{name}]
+      question: [{name, type}]
     };
 
     const res = await ns.resolve(req);
@@ -99,27 +101,22 @@ describe('RootServer', function() {
 
     // Query a record the RootResolver knows even without a database
     let name = '.';
+    let type = wire.types.NS;
     let req = {
-      question: [
-        {
-          name,
-          type: wire.types.NS
-        }
-      ]
+      question: [{name, type}]
     };
-    let res = await ns.resolve(req);
+    await ns.resolve(req);
 
     // Added to cache
     assert.strictEqual(cache.size, 1);
 
     // Query a SYNTH6 record
     name = '_00000000000000000000000008._synth.';
+    type = wire.types.AAAA;
     req = {
-      question: [
-        {name}
-      ]
+      question: [{name, type}]
     };
-    res = await ns.resolve(req);
+    let res = await ns.resolve(req);
     let answer = res.answer;
     let rec = answer[0];
 
@@ -136,8 +133,9 @@ describe('RootServer', function() {
     // This SYNTH4 request would return the result of the SYNTH6
     // record from the last request.
     name = '_fs0000g._synth.';
-     req = {
-      question: [{name}]
+    type = wire.types.A;
+    req = {
+      question: [{name, type}]
     };
 
     res = await ns.resolve(req);


### PR DESCRIPTION
The root server doesn't give proper negative answers for synth records. Asking a synth name for a TXT record it answers with an AAAA record:
```
dig @hsd-root _4o34e027000000000000000h24._synth. TXT +dnssec
_4o34e027000000000000000h24._synth. 21600 IN AAAA 2606:4700:4700::1111
```

Also querying `dig @hsd-root _synth. DS/NS` doesn't give proper NSECs which may be problematic for some recursive resolvers and ends up being SERVFAIL if queried from recursive. This PR fixes negative answers and also adds proper NSECs for _synth to make them more standards compliant/suitable for production use.