### PR TITLE
node-rpc: clean up hex32 method.

### DIFF
--- a/lib/node/rpc.js
+++ b/lib/node/rpc.js
@@ -331,7 +331,7 @@ class RPC extends RPCBase {
       subversion: this.pool.options.agent,
       protocolversion: this.pool.options.version,
       identitykey: this.pool.hosts.brontide.getKey('base32'),
-      localservices: hex32(this.pool.options.services),
+      localservices: util.hex32(this.pool.options.services),
       localservicenames: this.pool.getServiceNames(),
       localrelay: !this.pool.options.noRelay,
       timeoffset: this.network.time.offset,
@@ -505,7 +505,7 @@ class RPC extends RPCBase {
           ? peer.local.hostname
           : undefined,
         name: peer.name || undefined,
-        services: hex32(peer.services),
+        services: util.hex32(peer.services),
         servicenames: peer.getServiceNames(),
         relaytxes: !peer.noRelay,
         lastsend: peer.lastSend / 1000 | 0,
@@ -1487,7 +1487,7 @@ class RPC extends RPCBase {
       reservedroot: attempt.reservedRoot.toString('hex'),
       mask: consensus.ZERO_HASH.toString('hex'), // Compat.
       target: attempt.target.toString('hex'),
-      bits: hex32(attempt.bits),
+      bits: util.hex32(attempt.bits),
       noncerange:
         Array(consensus.NONCE_SIZE + 1).join('00')
         + Array(consensus.NONCE_SIZE + 1).join('ff'),
@@ -1499,7 +1499,8 @@ class RPC extends RPCBase {
       // sizelimit: consensus.MAX_RAW_BLOCK_SIZE,
       sizelimit: consensus.MAX_BLOCK_SIZE,
       weightlimit: consensus.MAX_BLOCK_WEIGHT,
-      longpollid: this.chain.tip.hash.toString('hex') + hex32(this.totalTX()),
+      longpollid: this.chain.tip.hash.toString('hex')
+                  + util.hex32(this.totalTX()),
       submitold: false,
       coinbaseaux: {
         flags: attempt.coinbaseFlags.toString('hex')
@@ -2951,7 +2952,7 @@ class RPC extends RPCBase {
       confirmations: confirmations,
       height: entry.height,
       version: entry.version,
-      versionHex: hex32(entry.version),
+      versionHex: util.hex32(entry.version),
       merkleroot: entry.merkleRoot.toString('hex'),
       witnessroot: entry.witnessRoot.toString('hex'),
       treeroot: entry.treeRoot.toString('hex'),
@@ -2961,7 +2962,7 @@ class RPC extends RPCBase {
       mediantime: mtp,
       nonce: entry.nonce,
       extranonce: entry.extraNonce.toString('hex'),
-      bits: hex32(entry.bits),
+      bits: util.hex32(entry.bits),
       difficulty: toDifficulty(entry.bits),
       chainwork: entry.chainwork.toString('hex', 64),
       previousblockhash: !entry.prevBlock.equals(consensus.ZERO_HASH)
@@ -2998,7 +2999,7 @@ class RPC extends RPCBase {
       weight: block.getWeight(),
       height: entry.height,
       version: entry.version,
-      versionHex: hex32(entry.version),
+      versionHex: util.hex32(entry.version),
       merkleroot: entry.merkleRoot.toString('hex'),
       witnessroot: entry.witnessRoot.toString('hex'),
       treeroot: entry.treeRoot.toString('hex'),
@@ -3012,7 +3013,7 @@ class RPC extends RPCBase {
       mediantime: mtp,
       nonce: entry.nonce,
       extranonce: entry.extraNonce.toString('hex'),
-      bits: hex32(entry.bits),
+      bits: util.hex32(entry.bits),
       difficulty: toDifficulty(entry.bits),
       chainwork: entry.chainwork.toString('hex', 64),
       nTx: txs.length,
@@ -3103,19 +3104,6 @@ function toDifficulty(bits) {
   }
 
   return diff;
-}
-
-function hex32(num) {
-  assert(num >= 0);
-
-  num = num.toString(16);
-
-  assert(num.length <= 8);
-
-  while (num.length < 8)
-    num = '0' + num;
-
-  return num;
 }
 
 /*


### PR DESCRIPTION
Just use `util.hex32` instead.

continues: #146