### PR TITLE
Wallet: create batch transactions with any combination of covenants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@
   - `decoderesource` like `decodescript` accepts hex string as input and returns
   JSON formatted DNS records resource.
 
+### Wallet changes
+
+- New RPC methods:
+  - `createbatch` and `sendbatch` create batch transactions with any number
+  of outputs with any combination of covenants.
+
 ## v4.0.0
 
 **When upgrading to this version of hsd you must pass

--- a/lib/wallet/rpc.js
+++ b/lib/wallet/rpc.js
@@ -198,6 +198,7 @@ class RPC extends RPCBase {
     this.add('sendcancel', this.sendCancel);
     this.add('sendfinalize', this.sendFinalize);
     this.add('sendrevoke', this.sendRevoke);
+    this.add('sendbatch', this.sendBatch);
     this.add('importnonce', this.importNonce);
     this.add('createopen', this.createOpen);
     this.add('createbid', this.createBid);
@@ -209,6 +210,7 @@ class RPC extends RPCBase {
     this.add('createcancel', this.createCancel);
     this.add('createfinalize', this.createFinalize);
     this.add('createrevoke', this.createRevoke);
+    this.add('createbatch', this.createBatch);
 
     // Compat
     this.add('getauctions', this.getNames);
@@ -2464,7 +2466,6 @@ class RPC extends RPCBase {
 
     return mtx.getJSON(this.network);
   }
-
   _validateRevoke(args, help, method) {
     if (help || args.length < 1 || args.length > 2)
       throw new RPCError(errs.MISC_ERROR, `${method} "name" ( "account" )`);
@@ -2477,6 +2478,150 @@ class RPC extends RPCBase {
       throw new RPCError(errs.TYPE_ERROR, 'Invalid name.');
 
     return {name, account};
+  }
+
+  async sendBatch(args, help) {
+    const [actions, options] = this._validateBatch(args, help, 'sendbatch');
+    const wallet = this.wallet;
+    const tx = await wallet.sendBatch(actions, options);
+
+    return tx.getJSON(this.network);
+  }
+
+  async createBatch(args, help) {
+    const [actions, options] = this._validateBatch(args, help, 'sendbatch');
+    const wallet = this.wallet;
+    const mtx = await wallet.createBatch(actions, options);
+
+    return mtx.getJSON(this.network);
+  }
+
+ _validateBatch(args, help, method) {
+  if (help || args.length < 1 || args.length > 2) {
+      throw new RPCError(errs.MISC_ERROR,
+        `${method} ["type", ...args] ( options )`);
+    }
+
+    const valid = new Validator(args);
+    const check = valid.array(0);
+    const options = valid.obj(1);
+    const actions = [];
+
+    for (const action of check) {
+      assert(
+        Array.isArray(action),
+        'Actions must be arrays'
+      );
+
+      const type = action.shift();
+      assert(
+        typeof type === 'string',
+        'Actions must start with type (string)'
+      );
+
+      switch (type) {
+        case 'NONE': {
+          assert(
+            action.length === 2,
+            'NONE action requires 2 arguments: address, value'
+          );
+          const {addr, value} = this._validateSendToAddress(action);
+          actions.push([type, addr, value]);
+          break;
+        }
+        case 'OPEN': {
+          assert(
+            action.length === 1,
+            'OPEN action requires 1 argument: name'
+          );
+          const {name} = this._validateOpen(action);
+          actions.push([type, name]);
+          break;
+        }
+        case 'BID': {
+          assert(
+            action.length === 3,
+            'BID action requires 3 arguments: name, bid, value'
+          );
+          const {name, bid, value} = this._validateBid(action);
+          actions.push([type, name, bid, value]);
+          break;
+        }
+        case 'REVEAL': {
+          assert(
+            action.length === 0 || action.length === 1,
+            'REVEAL action can only have 1 argument: name'
+          );
+          const {name} = this._validateReveal(action);
+          if (name)
+            actions.push([type, name]);
+          else
+            actions.push([type]);
+          break;
+        }
+        case 'REDEEM': {
+          assert(
+            action.length === 0 || action.length === 1,
+            'REDEEM action can only have 1 argument: name'
+          );
+          const {name} = this._validateRedeem(action);
+          if (name)
+            actions.push([type, name]);
+          else
+            actions.push([type]);
+          break;
+        }
+        case 'UPDATE': {
+          assert(
+            action.length === 2,
+            'UPDATE action requires 2 arguments: name, data'
+          );
+          const {name, resource} = this._validateUpdate(action);
+          actions.push([type, name, resource]);
+          break;
+        }
+        case 'TRANSFER': {
+          assert(
+            action.length === 2,
+            'TRANSFER action requires 2 arguments: name, address'
+          );
+          const {name, address} = this._validateTransfer(action);
+          actions.push([type, name, address]);
+          break;
+        }
+        case 'FINALIZE': {
+          assert(
+            action.length === 1,
+            'FINALIZE action requires 1 argument: name'
+          );
+          const {name} = this._validateFinalize(action);
+          actions.push([type, name]);
+          break;
+        }
+        case 'CANCEL': {
+          assert(
+            action.length === 1,
+            'CANCEL action requires 1 argument: name'
+          );
+          const {name} = this._validateCancel(action);
+          actions.push([type, name]);
+          break;
+        }
+        case 'REVOKE': {
+          assert(
+            action.length === 1,
+            'REVOKE action requires 1 argument: name'
+          );
+          const {name} = this._validateRevoke(action);
+          actions.push([type, name]);
+          break;
+        }
+        default:
+          throw new Error(`Unknown action type: ${type}`);
+      }
+    }
+
+    return [actions, options];
   }
 
   async importNonce(args, help) {

--- a/lib/wallet/wallet.js
+++ b/lib/wallet/wallet.js
@@ -1457,7 +1457,7 @@ class Wallet extends EventEmitter {
     assert(typeof name === 'string');
 
     if (!rules.verifyName(name))
-      throw new Error('Invalid name.');
+      throw new Error(`Invalid name: ${name}.`);
 
     const rawName = Buffer.from(name, 'ascii');
     const nameHash = rules.hashName(rawName);
@@ -1466,16 +1466,16 @@ class Wallet extends EventEmitter {
 
     // TODO: Handle expired behavior.
     if (!rules.isReserved(nameHash, height, network))
-      throw new Error('Name is not reserved.');
+      throw new Error(`Name is not reserved: ${name}.`);
 
     const ns = await this.getNameState(nameHash);
 
     if (ns) {
       if (!ns.isExpired(height, network))
-        throw new Error('Name already claimed.');
+        throw new Error(`Name already claimed: ${name}.`);
     } else {
       if (!await this.wdb.isAvailable(nameHash))
-        throw new Error('Name is not available.');
+        throw new Error(`Name is not available: ${name}.`);
     }
 
     const item = reserved.get(nameHash);
@@ -1532,7 +1532,7 @@ class Wallet extends EventEmitter {
     assert((acct >>> 0) === acct || typeof acct === 'string');
 
     if (!rules.verifyName(name))
-      throw new Error('Invalid name.');
+      throw new Error(`Invalid name: ${name}.`);
 
     const rawName = Buffer.from(name, 'ascii');
     const nameHash = rules.hashName(rawName);
@@ -1541,10 +1541,10 @@ class Wallet extends EventEmitter {
 
     // TODO: Handle expired behavior.
     if (rules.isReserved(nameHash, height, network))
-      throw new Error('Name is reserved.');
+      throw new Error(`Name is reserved: ${name}.`);
 
     if (!rules.hasRollout(nameHash, height, network))
-      throw new Error('Name not yet available.');
+      throw new Error(`Name not yet available: ${name}.`);
 
     let ns = await this.getNameState(nameHash);
 
@@ -1556,10 +1556,10 @@ class Wallet extends EventEmitter {
     const start = ns.height;
 
     if (!ns.isOpening(height, network))
-      throw new Error('Name is not available.');
+      throw new Error(`Name is not available: ${name}.`);
 
     if (start !== 0 && start !== height)
-      throw new Error('Name is already opening.');
+      throw new Error(`Name is already opening: ${name}.`);
 
     const addr = await this.receiveAddress(acct);
 
@@ -1663,7 +1663,7 @@ class Wallet extends EventEmitter {
     assert((acct >>> 0) === acct || typeof acct === 'string');
 
     if (!rules.verifyName(name))
-      throw new Error('Invalid name.');
+      throw new Error(`Invalid name: ${name}.`);
 
     const rawName = Buffer.from(name, 'ascii');
     const nameHash = rules.hashName(rawName);
@@ -1671,10 +1671,10 @@ class Wallet extends EventEmitter {
     const network = this.network;
 
     if (rules.isReserved(nameHash, height, network))
-      throw new Error('Name is reserved.');
+      throw new Error(`Name is reserved: ${name}.`);
 
     if (!rules.hasRollout(nameHash, height, network))
-      throw new Error('Name not yet available.');
+      throw new Error(`Name not yet available: ${name}.`);
 
     let ns = await this.getNameState(nameHash);
 
@@ -1686,13 +1686,15 @@ class Wallet extends EventEmitter {
     const start = ns.height;
 
     if (ns.isOpening(height, network))
-      throw new Error('Name has not reached the bidding phase yet.');
+      throw new Error(`Name has not reached the bidding phase yet: ${name}.`);
 
     if (!ns.isBidding(height, network))
-      throw new Error('Name is not available.');
+      throw new Error(`Name is not available: ${name}.`);
 
     if (value > lockup)
-      throw new Error('Bid exceeds lockup value.');
+      throw new Error(
+        `Bid (${value}) exceeds lockup value (${lockup}): ${name}.`
+      );
 
     const addr = await this.receiveAddress(acct);
     const blind = await this.generateBlind(nameHash, addr, value);
@@ -1830,7 +1832,7 @@ class Wallet extends EventEmitter {
     const blind = bidOutput.covenant.getHash(3);
     const bv = await this.getBlind(blind);
     if (!bv)
-      throw new Error('Blind value not found.');
+      throw new Error(`Blind value not found for name: ${name}.`);
     const { nonce } = bv;
 
     const reveal = new MTX();
@@ -1871,7 +1873,7 @@ class Wallet extends EventEmitter {
     }
 
     if (!rules.verifyName(name))
-      throw new Error('Invalid name.');
+      throw new Error(`Invalid name: ${name}.`);
 
     const rawName = Buffer.from(name, 'ascii');
     const nameHash = rules.hashName(rawName);
@@ -1880,17 +1882,17 @@ class Wallet extends EventEmitter {
     const network = this.network;
 
     if (!ns)
-      throw new Error('Auction not found.');
+      throw new Error(`Auction not found: ${name}.`);
 
     ns.maybeExpire(height, network);
 
     const state = ns.state(height, network);
 
     if (state < states.REVEAL)
-      throw new Error('Cannot reveal yet.');
+      throw new Error(`Cannot reveal yet: ${name}.`);
 
     if (state > states.REVEAL)
-      throw new Error('Reveal period has passed.');
+      throw new Error(`Reveal period has passed: ${name}.`);
 
     const bids = await this.getBids(nameHash);
 
@@ -1919,7 +1921,7 @@ class Wallet extends EventEmitter {
       const bv = await this.getBlind(blind);
 
       if (!bv)
-        throw new Error('Blind value not found.');
+        throw new Error(`Blind value not found: ${name}.`);
 
       const {value, nonce} = bv;
 
@@ -1937,7 +1939,7 @@ class Wallet extends EventEmitter {
     }
 
     if (pushed === 0)
-      throw new Error('No bids to reveal.');
+      throw new Error(`No bids to reveal for name: ${name}.`);
 
     return mtx;
   }
@@ -2020,6 +2022,7 @@ class Wallet extends EventEmitter {
         continue;
 
       const ns = await this.getNameState(nameHash);
+      const name = ns.name;
 
       if (!ns)
         continue;
@@ -2043,7 +2046,7 @@ class Wallet extends EventEmitter {
       const bv = await this.getBlind(blind);
 
       if (!bv)
-        throw new Error('Blind value not found.');
+        throw new Error(`Blind value not found for name: ${name}.`);
 
       const {value, nonce} = bv;
 
@@ -2132,7 +2135,7 @@ class Wallet extends EventEmitter {
     assert(typeof name === 'string');
 
     if (!rules.verifyName(name))
-      throw new Error('Invalid name.');
+      throw new Error(`Invalid name: ${name}.`);
 
     if (acct != null) {
       assert((acct >>> 0) === acct || typeof acct === 'string');
@@ -2146,13 +2149,13 @@ class Wallet extends EventEmitter {
     const network = this.network;
 
     if (!ns)
-      throw new Error('Auction not found.');
+      throw new Error(`Auction not found: ${name}.`);
 
     if (ns.isExpired(height, network))
-      throw new Error('Name has expired!');
+      throw new Error(`Name has expired: ${name}.`);
 
     if (!ns.isRedeemable(height, network))
-      throw new Error('Auction is not yet closed.');
+      throw new Error(`Auction is not yet closed: ${name}.`);
 
     const reveals = await this.txdb.getReveals(nameHash);
 
@@ -2196,7 +2199,7 @@ class Wallet extends EventEmitter {
     }
 
     if (pushed === 0)
-      throw new Error('No reveals to redeem.');
+      throw new Error(`No reveals to redeem for name: ${name}.`);
 
     return mtx;
   }
@@ -2395,7 +2398,7 @@ class Wallet extends EventEmitter {
     assert(!resource || (resource instanceof Resource));
 
     if (!rules.verifyName(name))
-      throw new Error('Invalid name.');
+      throw new Error(`Invalid name: ${name}.`);
 
     const rawName = Buffer.from(name, 'ascii');
     const nameHash = rules.hashName(rawName);
@@ -2404,31 +2407,31 @@ class Wallet extends EventEmitter {
     const network = this.network;
 
     if (!ns)
-      throw new Error('Auction not found.');
+      throw new Error(`Auction not found: ${name}.`);
 
     const {hash, index} = ns.owner;
     const coin = await this.getCoin(hash, index);
 
     if (!coin)
-      throw new Error('Wallet did not win the auction.');
+      throw new Error(`Wallet did not win the auction: ${name}.`);
 
     if (ns.isExpired(height, network))
-      throw new Error('Name has expired!');
+      throw new Error(`Name has expired: ${name}.`);
 
     // Is local?
     if (coin.height < ns.height)
-      throw new Error('Wallet did not win the auction.');
+      throw new Error(`Wallet did not win the auction: ${name}.`);
 
     if (!coin.covenant.isReveal() && !coin.covenant.isClaim())
-      throw new Error('Name must be in REVEAL or CLAIM state.');
+      throw new Error(`Name is not in REVEAL or CLAIM state: ${name}.`);
 
     if (coin.covenant.isClaim()) {
       if (height < coin.height + network.coinbaseMaturity)
-        throw new Error('Claim is not yet mature.');
+        throw new Error(`Claim is not yet mature: ${name}.`);
     }
 
     if (!ns.isClosed(height, network))
-      throw new Error('Auction is not yet closed.');
+      throw new Error(`Auction is not yet closed: ${name}.`);
 
     const output = new Output();
     output.address = coin.address;
@@ -2442,7 +2445,10 @@ class Wallet extends EventEmitter {
       const raw = resource.encode();
 
       if (raw.length > rules.MAX_RESOURCE_SIZE)
-        throw new Error('Resource exceeds maximum size.');
+        throw new Error(
+          `Resource size (${raw.length}) exceeds maximum `+
+          `(${rules.MAX_RESOURCE_SIZE}) for name: ${name}.`
+        );
 
       output.covenant.push(raw);
     } else {
@@ -2487,41 +2493,41 @@ class Wallet extends EventEmitter {
     const network = this.network;
 
     if (!ns)
-      throw new Error('Auction not found.');
+      throw new Error(`Auction not found: ${name}.`);
 
     const {hash, index} = ns.owner;
     const coin = await this.getCoin(hash, index);
 
     if (!coin)
-      throw new Error(`Wallet does not own: "${name}".`);
+      throw new Error(`Wallet does not own name: ${name}.`);
 
     if (acct != null && !await this.txdb.hasCoinByAccount(acct, hash, index))
-      throw new Error(`Account does not own: "${name}".`);
+      throw new Error(`Account does not own name: ${name}.`);
 
     if (coin.covenant.isReveal() || coin.covenant.isClaim())
       return this._makeRegister(name, resource, mtx);
 
     if (ns.isExpired(height, network))
-      throw new Error('Name has expired!');
+      throw new Error(`Name has expired: ${name}.`);
 
     // Is local?
     if (coin.height < ns.height)
-      throw new Error(`Wallet does not own: "${name}".`);
+      throw new Error(`Wallet does not own name: ${name}.`);
 
     if (!ns.isClosed(height, network))
-      throw new Error('Auction is not yet closed.');
+      throw new Error(`Auction is not yet closed: ${name}.`);
 
     if (!coin.covenant.isRegister()
         && !coin.covenant.isUpdate()
         && !coin.covenant.isRenew()
         && !coin.covenant.isFinalize()) {
-      throw new Error('Name must be registered.');
+      throw new Error(`Name is not registered: ${name}.`);
     }
 
     const raw = resource.encode();
 
     if (raw.length > rules.MAX_RESOURCE_SIZE)
-      throw new Error('Resource exceeds maximum size.');
+      throw new Error(`Resource exceeds maximum size: ${name}.`);
 
     const output = new Output();
     output.address = coin.address;
@@ -2617,7 +2623,7 @@ class Wallet extends EventEmitter {
     assert(typeof name === 'string');
 
     if (!rules.verifyName(name))
-      throw new Error('Invalid name.');
+      throw new Error(`Invalid name: ${name}.`);
 
     if (acct != null) {
       assert((acct >>> 0) === acct || typeof acct === 'string');
@@ -2631,36 +2637,36 @@ class Wallet extends EventEmitter {
     const network = this.network;
 
     if (!ns)
-      throw new Error('Auction not found.');
+      throw new Error(`Auction not found: ${name}.`);
 
     const {hash, index} = ns.owner;
     const coin = await this.getCoin(hash, index);
 
     if (!coin)
-      throw new Error(`Wallet does not own: "${name}".`);
+      throw new Error(`Wallet does not own name: ${name}.`);
 
     if (ns.isExpired(height, network))
-      throw new Error('Name has expired!');
+      throw new Error(`Name has expired: ${name}.`);
 
     // Is local?
     if (coin.height < ns.height)
-      throw new Error(`Wallet does not own: "${name}".`);
+      throw new Error(`Wallet does not own name: ${name}.`);
 
     if (acct != null && !await this.txdb.hasCoinByAccount(acct, hash, index))
-      throw new Error(`Account does not own: "${name}".`);
+      throw new Error(`Account does not own name: ${name}.`);
 
     if (!ns.isClosed(height, network))
-      throw new Error('Auction is not yet closed.');
+      throw new Error(`Auction is not yet closed: ${name}.`);
 
     if (!coin.covenant.isRegister()
         && !coin.covenant.isUpdate()
         && !coin.covenant.isRenew()
         && !coin.covenant.isFinalize()) {
-      throw new Error('Name must be registered.');
+      throw new Error(`Name is not registered: ${name}.`);
     }
 
     if (height < ns.renewal + network.names.treeInterval)
-      throw new Error('Must wait to renew.');
+      throw new Error(`Can not renew yet: ${name}.`);
 
     const output = new Output();
     output.address = coin.address;
@@ -2753,7 +2759,7 @@ class Wallet extends EventEmitter {
     assert(address instanceof Address);
 
     if (!rules.verifyName(name))
-      throw new Error('Invalid name.');
+      throw new Error(`Invalid name: ${name}.`);
 
     if (acct != null) {
       assert((acct >>> 0) === acct || typeof acct === 'string');
@@ -2767,32 +2773,32 @@ class Wallet extends EventEmitter {
     const network = this.network;
 
     if (!ns)
-      throw new Error('Auction not found.');
+      throw new Error(`Auction not found: ${name}.`);
 
     const {hash, index} = ns.owner;
     const coin = await this.getCoin(hash, index);
 
     if (!coin)
-      throw new Error(`Wallet does not own: "${name}".`);
+      throw new Error(`Wallet does not own name: ${name}.`);
 
     if (ns.isExpired(height, network))
-      throw new Error('Name has expired!');
+      throw new Error(`Name has expired: ${name}.`);
 
     // Is local?
     if (coin.height < ns.height)
-      throw new Error(`Wallet does not own: "${name}".`);
+      throw new Error(`Wallet does not own name: ${name}.`);
 
     if (acct != null && !await this.txdb.hasCoinByAccount(acct, hash, index))
-      throw new Error(`Account does not own: "${name}".`);
+      throw new Error(`Account does not own name: ${name}.`);
 
     if (!ns.isClosed(height, network))
-      throw new Error('Auction is not yet closed.');
+      throw new Error(`Auction is not yet closed: ${name}.`);
 
     if (!coin.covenant.isRegister()
         && !coin.covenant.isUpdate()
         && !coin.covenant.isRenew()
         && !coin.covenant.isFinalize()) {
-      throw new Error('Name must be registered.');
+      throw new Error(`Name is not registered: ${name}.`);
     }
 
     const output = new Output();
@@ -2894,7 +2900,7 @@ class Wallet extends EventEmitter {
     assert(typeof name === 'string');
 
     if (!rules.verifyName(name))
-      throw new Error('Invalid name.');
+      throw new Error(`Invalid name: ${name}.`);
 
     if (acct != null) {
       assert((acct >>> 0) === acct || typeof acct === 'string');
@@ -2908,29 +2914,29 @@ class Wallet extends EventEmitter {
     const network = this.network;
 
     if (!ns)
-      throw new Error('Auction not found.');
+      throw new Error(`Auction not found: ${name}.`);
 
     const {hash, index} = ns.owner;
     const coin = await this.getCoin(hash, index);
 
     if (!coin)
-      throw new Error(`Wallet does not own: "${name}".`);
+      throw new Error(`Wallet does not own name: ${name}.`);
 
     if (ns.isExpired(height, network))
-      throw new Error('Name has expired!');
+      throw new Error(`Name has expired: ${name}.`);
 
     // Is local?
     if (coin.height < ns.height)
-      throw new Error(`Wallet does not own: "${name}".`);
+      throw new Error(`Wallet does not own name: ${name}.`);
 
     if (acct != null && !await this.txdb.hasCoinByAccount(acct, hash, index))
-      throw new Error(`Account does not own: "${name}".`);
+      throw new Error(`Account does not own name: ${name}.`);
 
     if (!ns.isClosed(height, network))
-      throw new Error('Auction is not yet closed.');
+      throw new Error(`Auction is not yet closed: ${name}.`);
 
     if (!coin.covenant.isTransfer())
-      throw new Error('Name is not being transfered.');
+      throw new Error(`Name is not being transferred: ${name}.`);
 
     const output = new Output();
     output.address = coin.address;
@@ -3022,7 +3028,7 @@ class Wallet extends EventEmitter {
     assert(typeof name === 'string');
 
     if (!rules.verifyName(name))
-      throw new Error('Invalid name.');
+      throw new Error(`Invalid name: ${name}.`);
 
     if (acct != null) {
       assert((acct >>> 0) === acct || typeof acct === 'string');
@@ -3036,32 +3042,32 @@ class Wallet extends EventEmitter {
     const network = this.network;
 
     if (!ns)
-      throw new Error('Auction not found.');
+      throw new Error(`Auction not found: ${name}.`);
 
     const {hash, index} = ns.owner;
     const coin = await this.getCoin(hash, index);
 
     if (!coin)
-      throw new Error(`Wallet does not own: "${name}".`);
+      throw new Error(`Wallet does not own name: ${name}.`);
 
     if (ns.isExpired(height, network))
-      throw new Error('Name has expired!');
+      throw new Error(`Name has expired: ${name}.`);
 
     // Is local?
     if (coin.height < ns.height)
-      throw new Error(`Wallet does not own: "${name}".`);
+      throw new Error(`Wallet does not own name: ${name}.`);
 
     if (acct != null && !await this.txdb.hasCoinByAccount(acct, hash, index))
-      throw new Error(`Account does not own: "${name}".`);
+      throw new Error(`Account does not own name: ${name}.`);
 
     if (!ns.isClosed(height, network))
-      throw new Error('Auction is not yet closed.');
+      throw new Error(`Auction is not yet closed: ${name}.`);
 
     if (!coin.covenant.isTransfer())
-      throw new Error('Name is not being transfered.');
+      throw new Error(`Name is not being transferred: ${name}.`);
 
     if (height < coin.height + network.names.transferLockup)
-      throw new Error('Transfer is still locked up.');
+      throw new Error(`Transfer is still locked up: ${name}.`);
 
     const version = coin.covenant.getU8(2);
     const addr = coin.covenant.get(3);
@@ -3165,7 +3171,7 @@ class Wallet extends EventEmitter {
     assert(typeof name === 'string');
 
     if (!rules.verifyName(name))
-      throw new Error('Invalid name.');
+      throw new Error(`Invalid name: ${name}.`);
 
     if (acct != null) {
       assert((acct >>> 0) === acct || typeof acct === 'string');
@@ -3179,33 +3185,33 @@ class Wallet extends EventEmitter {
     const network = this.network;
 
     if (!ns)
-      throw new Error('Auction not found.');
+      throw new Error(`Auction not found: ${name}.`);
 
     const {hash, index} = ns.owner;
     const coin = await this.getCoin(hash, index);
 
     if (!coin)
-      throw new Error(`Wallet does not own: "${name}".`);
+      throw new Error(`Wallet does not own name: ${name}.`);
 
     if (acct != null && !await this.txdb.hasCoinByAccount(acct, hash, index))
-      throw new Error(`Account does not own: "${name}".`);
+      throw new Error(`Account does not own name: ${name}.`);
 
     // Is local?
     if (coin.height < ns.height)
-      throw new Error(`Wallet does not own: "${name}".`);
+      throw new Error(`Wallet does not own name: ${name}.`);
 
     if (ns.isExpired(height, network))
-      throw new Error('Name has expired!');
+      throw new Error(`Name has expired: ${name}.`);
 
     if (!ns.isClosed(height, network))
-      throw new Error('Auction is not yet closed.');
+      throw new Error(`Auction is not yet closed: ${name}.`);
 
     if (!coin.covenant.isRegister()
         && !coin.covenant.isUpdate()
         && !coin.covenant.isRenew()
         && !coin.covenant.isTransfer()
         && !coin.covenant.isFinalize()) {
-      throw new Error('Name must be registered.');
+      throw new Error(`Name is not registered: ${name}.`);
     }
 
     const output = new Output();

--- a/lib/wallet/wallet.js
+++ b/lib/wallet/wallet.js
@@ -3422,11 +3422,34 @@ class Wallet extends EventEmitter {
     const acct = options ? options.account || 0 : 0;
     const mtx = new MTX();
 
+    // Sort actions so covenants that require linked inputs
+    // are pushed first into the mtx input/output arrays.
+    // This is a required step otherwise an unlinked
+    // covenant like NONE, OPEN, or BID could shift the
+    // output array out of sync with their corresponding inputs.
+    actions.sort((a, b) => {
+      assert(Array.isArray(a));
+      assert(Array.isArray(b));
+      assert(a.length);
+      assert(b.length);
+
+      switch (b[0]) {
+        case 'REVEAL':
+        case 'REDEEM':
+        case 'UPDATE':
+        case 'TRANSFER':
+        case 'FINALIZE':
+        case 'CANCEL':
+        case 'REVOKE':
+          return 1;
+        default:
+          return -1;
+      }
+    });
+
     // "actions" are arrays that start with a covenant type (or meta-type)
     // followed by the arguments expected by the corresponding "make" function.
     for (const action of actions) {
-      assert(Array.isArray(action));
-
       const type = action.shift();
       assert(typeof type === 'string');
 

--- a/lib/wallet/wallet.js
+++ b/lib/wallet/wallet.js
@@ -3514,6 +3514,37 @@ class Wallet extends EventEmitter {
       }
     }
 
+    // Some actions MUST be the ONLY action for a name.
+    // (i.e. no duplicate OPENs or REVOKE/FINALIZE for same name in one tx)
+    const set = new BufferSet();
+    for (const {covenant} of mtx.outputs) {
+      if (!covenant.isName())
+        continue;
+
+      const nameHash = covenant.getHash(0);
+
+      switch (covenant.type) {
+        case types.CLAIM:
+        case types.OPEN:
+          assert(!set.has(nameHash), 'Duplicate name with exclusive action.');
+          set.add(nameHash);
+          break;
+        case types.BID:
+        case types.REVEAL:
+        case types.REDEEM:
+          break;
+        case types.REGISTER:
+        case types.UPDATE:
+        case types.RENEW:
+        case types.TRANSFER:
+        case types.FINALIZE:
+        case types.REVOKE:
+          assert(!set.has(nameHash), 'Duplicate name with exclusive action.');
+          set.add(nameHash);
+          break;
+      }
+    }
+
     return mtx;
   }
 

--- a/lib/wallet/wallet.js
+++ b/lib/wallet/wallet.js
@@ -1522,10 +1522,11 @@ class Wallet extends EventEmitter {
    * @param {String} name
    * @param {Number|String} acct
    * @param {Boolean} force
+   * @param {MTX?} mtx
    * @returns {MTX}
    */
 
-  async makeOpen(name, force, acct) {
+  async makeOpen(name, force, acct, mtx) {
     assert(typeof name === 'string');
     assert(typeof force === 'boolean');
     assert((acct >>> 0) === acct || typeof acct === 'string');
@@ -1570,7 +1571,8 @@ class Wallet extends EventEmitter {
     output.covenant.pushU32(0);
     output.covenant.push(rawName);
 
-    const mtx = new MTX();
+    if (!mtx)
+      mtx = new MTX();
     mtx.outputs.push(output);
 
     if (await this.txdb.isDoubleOpen(mtx))
@@ -1650,10 +1652,11 @@ class Wallet extends EventEmitter {
    * @param {Number} value
    * @param {Number} lockup
    * @param {Number|String} acct
+   * @param {MTX?} mtx
    * @returns {MTX}
    */
 
-  async makeBid(name, value, lockup, acct) {
+  async makeBid(name, value, lockup, acct, mtx) {
     assert(typeof name === 'string');
     assert(Number.isSafeInteger(value) && value >= 0);
     assert(Number.isSafeInteger(lockup) && lockup >= 0);
@@ -1703,7 +1706,8 @@ class Wallet extends EventEmitter {
     output.covenant.push(rawName);
     output.covenant.pushHash(blind);
 
-    const mtx = new MTX();
+    if (!mtx)
+      mtx = new MTX();
     mtx.outputs.push(output);
 
     return mtx;
@@ -1854,10 +1858,11 @@ class Wallet extends EventEmitter {
    * Make a reveal MTX.
    * @param {String} name
    * @param {(Number|String)?} acct
+   * @param {MTX?} mtx
    * @returns {MTX}
    */
 
-  async makeReveal(name, acct) {
+  async makeReveal(name, acct, mtx) {
     assert(typeof name === 'string');
 
     if (acct != null) {
@@ -1889,8 +1894,10 @@ class Wallet extends EventEmitter {
 
     const bids = await this.getBids(nameHash);
 
-    const mtx = new MTX();
+    if (!mtx)
+      mtx = new MTX();
 
+    let pushed = 0;
     for (const {prevout, own} of bids) {
       if (!own)
         continue;
@@ -1926,9 +1933,10 @@ class Wallet extends EventEmitter {
 
       mtx.addOutpoint(prevout);
       mtx.outputs.push(output);
+      pushed++;
     }
 
-    if (mtx.outputs.length === 0)
+    if (pushed === 0)
       throw new Error('No bids to reveal.');
 
     return mtx;
@@ -1995,15 +2003,18 @@ class Wallet extends EventEmitter {
 
   /**
    * Make a reveal MTX.
+   * @param {MTX?} mtx
    * @returns {MTX}
    */
 
-  async makeRevealAll() {
+  async makeRevealAll(mtx) {
     const height = this.wdb.height + 1;
     const network = this.network;
     const bids = await this.getBids();
-    const mtx = new MTX();
+    if (!mtx)
+      mtx = new MTX();
 
+    let pushed = 0;
     for (const {nameHash, prevout, own} of bids) {
       if (!own)
         continue;
@@ -2046,9 +2057,10 @@ class Wallet extends EventEmitter {
 
       mtx.addOutpoint(prevout);
       mtx.outputs.push(output);
+      pushed++;
     }
 
-    if (mtx.outputs.length === 0)
+    if (pushed === 0)
       throw new Error('No bids to reveal.');
 
     return mtx;
@@ -2112,10 +2124,11 @@ class Wallet extends EventEmitter {
    * Make a redeem MTX.
    * @param {String} name
    * @param {(Number|String)?} acct
+   * @param {MTX?} mtx
    * @returns {MTX}
    */
 
-  async makeRedeem(name, acct) {
+  async makeRedeem(name, acct, mtx) {
     assert(typeof name === 'string');
 
     if (!rules.verifyName(name))
@@ -2143,8 +2156,10 @@ class Wallet extends EventEmitter {
 
     const reveals = await this.txdb.getReveals(nameHash);
 
-    const mtx = new MTX();
+    if (!mtx)
+      mtx = new MTX();
 
+    let pushed = 0;
     for (const {prevout, own} of reveals) {
       const {hash, index} = prevout;
 
@@ -2177,9 +2192,10 @@ class Wallet extends EventEmitter {
       output.covenant.pushU32(ns.height);
 
       mtx.outputs.push(output);
+      pushed++;
     }
 
-    if (mtx.outputs.length === 0)
+    if (pushed === 0)
       throw new Error('No reveals to redeem.');
 
     return mtx;
@@ -2249,15 +2265,18 @@ class Wallet extends EventEmitter {
   /**
    * Make a redeem MTX.
    * @param {String} name
+   * @param {MTX?} mtx
    * @returns {MTX}
    */
 
-  async makeRedeemAll() {
+  async makeRedeemAll(mtx) {
     const height = this.wdb.height + 1;
     const network = this.network;
     const reveals = await this.txdb.getReveals();
-    const mtx = new MTX();
+    if (!mtx)
+      mtx = new MTX();
 
+    let pushed = 0;
     for (const {nameHash, prevout, own} of reveals) {
       const {hash, index} = prevout;
 
@@ -2297,9 +2316,10 @@ class Wallet extends EventEmitter {
       output.covenant.pushU32(ns.height);
 
       mtx.outputs.push(output);
+      pushed++;
     }
 
-    if (mtx.outputs.length === 0)
+    if (pushed === 0)
       throw new Error('No reveals to redeem.');
 
     return mtx;
@@ -2366,10 +2386,11 @@ class Wallet extends EventEmitter {
    * @private
    * @param {String} name
    * @param {Resource?} resource
+   * @param {MTX?} mtx
    * @returns {MTX}
    */
 
-  async _makeRegister(name, resource) {
+  async _makeRegister(name, resource, mtx) {
     assert(typeof name === 'string');
     assert(!resource || (resource instanceof Resource));
 
@@ -2430,7 +2451,8 @@ class Wallet extends EventEmitter {
 
     output.covenant.pushHash(await this.wdb.getRenewalBlock());
 
-    const mtx = new MTX();
+    if (!mtx)
+      mtx = new MTX();
     mtx.addOutpoint(ns.owner);
     mtx.outputs.push(output);
 
@@ -2442,10 +2464,11 @@ class Wallet extends EventEmitter {
    * @param {String} name
    * @param {Resource} resource
    * @param {(Number|String)?} acct
+   * @param {MTX?} mtx
    * @returns {MTX}
    */
 
-  async makeUpdate(name, resource, acct) {
+  async makeUpdate(name, resource, acct, mtx) {
     assert(typeof name === 'string');
     assert(resource instanceof Resource);
 
@@ -2476,7 +2499,7 @@ class Wallet extends EventEmitter {
       throw new Error(`Account does not own: "${name}".`);
 
     if (coin.covenant.isReveal() || coin.covenant.isClaim())
-      return this._makeRegister(name, resource);
+      return this._makeRegister(name, resource, mtx);
 
     if (ns.isExpired(height, network))
       throw new Error('Name has expired!');
@@ -2508,7 +2531,8 @@ class Wallet extends EventEmitter {
     output.covenant.pushU32(ns.height);
     output.covenant.push(raw);
 
-    const mtx = new MTX();
+    if (!mtx)
+      mtx = new MTX();
     mtx.addOutpoint(ns.owner);
     mtx.outputs.push(output);
 
@@ -2585,10 +2609,11 @@ class Wallet extends EventEmitter {
    * @private
    * @param {String} name
    * @param {(Number|String)?} acct
+   * @param {MTX?} mtx
    * @returns {MTX}
    */
 
-  async makeRenewal(name, acct) {
+  async makeRenewal(name, acct, mtx) {
     assert(typeof name === 'string');
 
     if (!rules.verifyName(name))
@@ -2645,7 +2670,8 @@ class Wallet extends EventEmitter {
     output.covenant.pushU32(ns.height);
     output.covenant.pushHash(await this.wdb.getRenewalBlock());
 
-    const mtx = new MTX();
+    if (!mtx)
+      mtx = new MTX();
     mtx.addOutpoint(ns.owner);
     mtx.outputs.push(output);
 
@@ -2718,10 +2744,11 @@ class Wallet extends EventEmitter {
    * @param {String} name
    * @param {Address} address
    * @param {(Number|String)?} acct
+   * @param {MTX?} mtx
    * @returns {MTX}
    */
 
-  async makeTransfer(name, address, acct) {
+  async makeTransfer(name, address, acct, mtx) {
     assert(typeof name === 'string');
     assert(address instanceof Address);
 
@@ -2777,7 +2804,8 @@ class Wallet extends EventEmitter {
     output.covenant.pushU8(address.version);
     output.covenant.push(address.hash);
 
-    const mtx = new MTX();
+    if (!mtx)
+      mtx = new MTX();
     mtx.addOutpoint(ns.owner);
     mtx.outputs.push(output);
 
@@ -2858,10 +2886,11 @@ class Wallet extends EventEmitter {
    * @private
    * @param {String} name
    * @param {(Number|String)?} acct
+   * @param {MTX?} mtx
    * @returns {MTX}
    */
 
-  async makeCancel(name, acct) {
+  async makeCancel(name, acct, mtx) {
     assert(typeof name === 'string');
 
     if (!rules.verifyName(name))
@@ -2911,7 +2940,8 @@ class Wallet extends EventEmitter {
     output.covenant.pushU32(ns.height);
     output.covenant.push(EMPTY);
 
-    const mtx = new MTX();
+    if (!mtx)
+      mtx = new MTX();
     mtx.addOutpoint(ns.owner);
     mtx.outputs.push(output);
 
@@ -2984,10 +3014,11 @@ class Wallet extends EventEmitter {
    * @private
    * @param {String} name
    * @param {(Number|String)?} acct
+   * @param {MTX?} mtx
    * @returns {MTX}
    */
 
-  async makeFinalize(name, acct) {
+  async makeFinalize(name, acct, mtx) {
     assert(typeof name === 'string');
 
     if (!rules.verifyName(name))
@@ -3053,7 +3084,8 @@ class Wallet extends EventEmitter {
     output.covenant.pushU32(ns.renewals);
     output.covenant.pushHash(await this.wdb.getRenewalBlock());
 
-    const mtx = new MTX();
+    if (!mtx)
+      mtx = new MTX();
     mtx.addOutpoint(ns.owner);
     mtx.outputs.push(output);
 
@@ -3125,10 +3157,11 @@ class Wallet extends EventEmitter {
    * Make a revoke MTX.
    * @param {String} name
    * @param {(Number|String)?} acct
+   * @param {MTX?} mtx
    * @returns {MTX}
    */
 
-  async makeRevoke(name, acct) {
+  async makeRevoke(name, acct, mtx) {
     assert(typeof name === 'string');
 
     if (!rules.verifyName(name))
@@ -3182,7 +3215,8 @@ class Wallet extends EventEmitter {
     output.covenant.pushHash(nameHash);
     output.covenant.pushU32(ns.height);
 
-    const mtx = new MTX();
+    if (!mtx)
+      mtx = new MTX();
     mtx.addOutpoint(ns.owner);
     mtx.outputs.push(output);
 
@@ -3319,12 +3353,18 @@ class Wallet extends EventEmitter {
    * to avoid sorting), set locktime, and template it.
    * @param {Object} options - See {@link Wallet#fund options}.
    * @param {Object[]} options.outputs - See {@link MTX#addOutput}.
+   * @param {Object[]} options.outputs - See {@link MTX#addOutput}.
+   * @param {MTX?} mtx
    * @returns {Promise} - Returns {@link MTX}.
    */
 
-  async createTX(options, force) {
+  async createTX(options, force, mtx) {
     const outputs = options.outputs;
-    const mtx = new MTX();
+    let finish = false;
+    if (!mtx) {
+      finish = true;
+      mtx = new MTX();
+    }
 
     assert(Array.isArray(outputs), 'Outputs must be an array.');
     assert(outputs.length > 0, 'At least one output required.');
@@ -3347,6 +3387,14 @@ class Wallet extends EventEmitter {
 
       mtx.outputs.push(output);
     }
+
+    // If a MTX was passed in to this function as an argument,
+    // we assume the caller is constructing a bigger TX and
+    // may still have more ins/out to add to it.
+    // That caller will have to call fund() and finalize()
+    // on their own when they are ready.
+    if (!finish)
+      return mtx;
 
     // Fill the inputs with unspents
     await this.fund(mtx, options, force);

--- a/lib/wallet/wallet.js
+++ b/lib/wallet/wallet.js
@@ -3514,10 +3514,16 @@ class Wallet extends EventEmitter {
       }
     }
 
-    // Some actions MUST be the ONLY action for a name.
-    // (i.e. no duplicate OPENs or REVOKE/FINALIZE for same name in one tx)
+    // Clean up.
+    // 1. Some actions MUST be the ONLY action for a name.
+    //    i.e. no duplicate OPENs or REVOKE/FINALIZE for same name in one tx.
+    // 2. Some outputs may reuse same address from this.receieveAddress(acct)
+    //    We can bump those to the next receive address,
+    const account = await this.getAccount(acct);
+    let receiveIndex = account.receiveDepth - 1;
     const set = new BufferSet();
-    for (const {covenant} of mtx.outputs) {
+    for (const output of mtx.outputs) {
+      const {covenant} = output;
       if (!covenant.isName())
         continue;
 
@@ -3526,10 +3532,13 @@ class Wallet extends EventEmitter {
       switch (covenant.type) {
         case types.CLAIM:
         case types.OPEN:
+          output.address = account.deriveReceive(receiveIndex++).getAddress();
+
           assert(!set.has(nameHash), 'Duplicate name with exclusive action.');
           set.add(nameHash);
           break;
         case types.BID:
+          output.address = account.deriveReceive(receiveIndex++).getAddress();
         case types.REVEAL:
         case types.REDEEM:
           break;

--- a/lib/wallet/wallet.js
+++ b/lib/wallet/wallet.js
@@ -3403,6 +3403,150 @@ class Wallet extends EventEmitter {
   }
 
   /**
+   * Make a batch transaction with multiple actions.
+   * @param {Array} actions
+   * @param {Object} options
+   * @returns {MTX}
+   */
+
+  async makeBatch(actions, options) {
+    assert(Array.isArray(actions));
+
+    const force = false;
+    const acct = options ? options.account || 0 : 0;
+    const mtx = new MTX();
+
+    // "actions" are arrays that start with a covenant type (or meta-type)
+    // followed by the arguments expected by the corresponding "make" function.
+    for (const action of actions) {
+      assert(Array.isArray(action));
+
+      const type = action.shift();
+      assert(typeof type === 'string');
+
+      switch (type) {
+        case 'NONE':
+          assert(action.length === 2);
+          await this.createTX(
+            {outputs: [{
+              address: action[0],
+              value: action[1]
+            }]},
+            force,
+            mtx
+          );
+          break;
+        case 'OPEN':
+          assert(action.length === 1, 'Bad arguments for OPEN.');
+          await this.makeOpen(...action, force, acct, mtx);
+          break;
+        case 'BID':
+          assert(action.length === 3, 'Bad arguments for BID.');
+          await this.makeBid(...action, acct, mtx);
+          break;
+        case 'REVEAL':
+          if (action.length === 1) {
+            await this.makeReveal(...action, acct, mtx);
+          } else {
+            assert(action.length === 0, 'Bad arguments for REVEAL.');
+            await this.makeRevealAll(mtx);
+          }
+          break;
+        case 'REDEEM':
+          if (action.length === 1) {
+            await this.makeRedeem(...action, acct, mtx);
+          } else {
+            assert(action.length === 0, 'Bad arguments for REDEEM.');
+            await this.makeRedeemAll(mtx);
+          }
+          break;
+        case 'UPDATE':
+          assert(action.length === 2, 'Bad arguments for UPDATE.');
+          await this.makeUpdate(...action, acct, mtx);
+          break;
+        case 'TRANSFER':
+          assert(action.length === 2, 'Bad arguments for TRANSFER.');
+          await this.makeTransfer(...action, acct, mtx);
+          break;
+        case 'FINALIZE':
+          assert(action.length === 1, 'Bad arguments for FINALIZE.');
+          await this.makeFinalize(...action, acct, mtx);
+          break;
+        case 'CANCEL':
+          assert(action.length === 1, 'Bad arguments for CANCEL.');
+          await this.makeCancel(...action, acct, mtx);
+          break;
+        case 'REVOKE':
+          assert(action.length === 1, 'Bad arguments for REVOKE.');
+          await this.makeRevoke(...action, acct, mtx);
+          break;
+        default:
+          throw new Error(`Unknown action type: ${type}`);
+      }
+    }
+
+    return mtx;
+  }
+
+  /**
+   * Make a batch transaction with multiple actions.
+   * @param {Array} actions
+   * @param {Object} options
+   * @returns {MTX}
+   */
+
+  async _createBatch(actions, options) {
+    const mtx = await this.makeBatch(actions, options);
+    await this.fill(mtx, options);
+    return this.finalize(mtx, options);
+  }
+
+  /**
+   * Make a batch transaction with multiple actions.
+   * @param {Array} actions
+   * @param {Object} options
+   * @returns {MTX}
+   */
+
+  async createBatch(actions, options) {
+    const unlock = await this.fundLock.lock();
+    try {
+      return await this._createBatch(actions, options);
+    } finally {
+      unlock();
+    }
+  }
+
+  /**
+   * Create and send a batch transaction with multiple actions.
+   * @param {Array} actions
+   * @param {Object} options
+   * @returns {TX}
+   */
+
+  async _sendBatch(actions, options) {
+    const passphrase = options ? options.passphrase : null;
+    const mtx = await this._createBatch(actions, options);
+    return this.sendMTX(mtx, passphrase);
+  }
+
+  /**
+   * Create and send a batch transaction with multiple actions.
+   * @param {Array} actions
+   * @param {Object} options
+   * @returns {TX}
+   */
+
+  async sendBatch(actions, options) {
+    const unlock = await this.fundLock.lock();
+    try {
+      return await this._sendBatch(actions, options);
+    } finally {
+      unlock();
+    }
+  }
+
+  /**
    * Finalize and template an MTX.
    * @param {MTX} mtx
    * @param {Object} options

--- a/test/anyone-can-renew-test.js
+++ b/test/anyone-can-renew-test.js
@@ -163,12 +163,12 @@ describe('Anyone-can-renew address', function() {
   it('should not be owned by either wallet', async  () => {
     assert.rejects(
       alice.sendTransfer(name, aliceReceive),
-      {message: `Wallet does not own: "${name}".`}
+      {message: `Wallet does not own name: ${name}.`}
     );
 
     assert.rejects(
       bob.sendTransfer(name, bobReceive),
-      {message: 'Auction not found.'}
+      {message: `Auction not found: ${name}.`}
     );
   });
 

--- a/test/interactive-swap-test.js
+++ b/test/interactive-swap-test.js
@@ -105,7 +105,7 @@ describe('Interactive name swap', function() {
     assert.rejects(async () => {
       await alice.sendTransfer(name, bobReceive);
     }, {
-      message: 'Name must be registered.'
+      message: `Name is not registered: ${name}.`
     });
   });
 

--- a/test/wallet-accounts-auction-test.js
+++ b/test/wallet-accounts-auction-test.js
@@ -164,7 +164,7 @@ describe('Multiple accounts participating in same auction', function() {
         await wallet.sendUpdate(name, bobResource, {account: 'bob'});
       }, {
         name: 'Error',
-        message: `Account does not own: "${name}".`
+        message: `Account does not own name: ${name}.`
       });
     });
 
@@ -193,7 +193,7 @@ describe('Multiple accounts participating in same auction', function() {
         await wallet.sendRedeem(name, {account: 0});
       }, {
         name: 'Error',
-        message: 'No reveals to redeem.'
+        message: `No reveals to redeem for name: ${name}.`
       });
     });
 
@@ -227,7 +227,7 @@ describe('Multiple accounts participating in same auction', function() {
         await wallet.sendRenewal(name, {account: 'bob'});
       }, {
         name: 'Error',
-        message: `Account does not own: "${name}".`
+        message: `Account does not own name: ${name}.`
       });
     });
 
@@ -267,7 +267,7 @@ describe('Multiple accounts participating in same auction', function() {
         await wallet.sendTransfer(name, toAddr, {account: 'bob'});
       }, {
         name: 'Error',
-        message: `Account does not own: "${name}".`
+        message: `Account does not own name: ${name}.`
       });
     });
 
@@ -304,7 +304,7 @@ describe('Multiple accounts participating in same auction', function() {
         await wallet.sendFinalize(name, {account: 'bob'});
       }, {
         name: 'Error',
-        message: `Account does not own: "${name}".`
+        message: `Account does not own name: ${name}.`
       });
     });
 
@@ -337,7 +337,7 @@ describe('Multiple accounts participating in same auction', function() {
         await wallet.sendCancel(name, {account: 'bob'});
       }, {
         name: 'Error',
-        message: `Account does not own: "${name}".`
+        message: `Account does not own name: ${name}.`
       });
     });
 
@@ -370,7 +370,7 @@ describe('Multiple accounts participating in same auction', function() {
         await wallet.sendRevoke(name, {account: 'bob'});
       }, {
         name: 'Error',
-        message: `Account does not own: "${name}".`
+        message: `Account does not own name: ${name}.`
       });
     });
 

--- a/test/wallet-auction-test.js
+++ b/test/wallet-auction-test.js
@@ -10,13 +10,17 @@ const WalletDB = require('../lib/wallet/walletdb');
 const Network = require('../lib/protocol/network');
 const rules = require('../lib/covenants/rules');
 const Address = require('../lib/primitives/address');
+const {Resource} = require('../lib/dns/resource');
 
 const network = Network.get('regtest');
 const NAME1 = rules.grindName(10, 2, network);
 const {
   treeInterval,
   biddingPeriod,
-  revealPeriod
+  revealPeriod,
+  transferLockup,
+  auctionMaturity,
+  renewalWindow
 } = network.names;
 
 const workers = new WorkerPool({
@@ -201,6 +205,283 @@ describe('Wallet Auction', function() {
       ns = await chain.db.getNameStateByName(NAME1);
       state = ns.state(chain.height, network);
       assert.strictEqual(state, states.BIDDING);
+    });
+  });
+
+  describe('Batch TXs', function() {
+    let wallet, receive;
+    const hardFee = 12345;
+
+    const name1 = rules.grindName(3, 0, network);
+    const name2 = rules.grindName(4, 0, network);
+    const name3 = rules.grindName(5, 0, network);
+    const name4 = rules.grindName(6, 0, network);
+
+    const res1 = Resource.fromJSON({records: [{type: 'TXT', txt: ['one']}]});
+    const res2 = Resource.fromJSON({records: [{type: 'TXT', txt: ['two']}]});
+    const res3 = Resource.fromJSON({records: [{type: 'TXT', txt: ['three']}]});
+    const res4 = Resource.fromJSON({records: [{type: 'TXT', txt: ['four']}]});
+
+    const mempool = [];
+    wdb.send = (tx) => {
+      mempool.push(tx);
+    };
+    wdb.getNameStatus = async (nameHash) => {
+      return chain.db.getNameStatus(nameHash, chain.height + 1);
+    };
+
+    async function mineBlocks(n) {
+      for (let i = 0; i < n; i++) {
+        const job = await cpu.createJob(chain.tip, receive);
+        while (mempool.length)
+          job.pushTX(mempool.pop());
+        job.refresh();
+
+        const block = await job.mineAsync();
+        const entry = await chain.add(block);
+        await wdb.addBlock(entry, block.txs);
+      }
+    }
+
+    before(async () => {
+      // Create wallet
+      wallet = await wdb.create();
+      receive = await wallet.receiveAddress();
+
+      // Fund wallet
+      await mineBlocks(20);
+
+      // Verify funds
+      const bal = await wallet.getBalance();
+      assert.strictEqual(bal.confirmed, 20 * 2000e6);
+    });
+
+    it('should create multiple OPENs with options', async () => {
+      const mtx = await wallet.createBatch(
+        [
+          ['OPEN', name1],
+          ['OPEN', name2],
+          ['OPEN', name3]
+        ],
+        {
+          hardFee
+        }
+      );
+
+      assert.strictEqual(mtx.outputs.length, 4);
+      let opens = 0;
+      for (const output of mtx.outputs) {
+        if (output.covenant.type === rules.types.OPEN)
+          opens++;
+      }
+      assert.strictEqual(opens, 3);
+      assert.strictEqual(mtx.getFee(mtx.view), hardFee);
+    });
+
+    it('should fail if one action is invalid: OPEN reserved', async () => {
+      await assert.rejects(
+        wallet.sendBatch(
+          [
+            ['OPEN', 'google'],
+            ['OPEN', name2],
+            ['OPEN', name3]
+          ]
+        ),
+        {message: 'Name is reserved: google.'}
+      );
+    });
+
+    it('should fail if one action is invalid: OPEN duplicated', async () => {
+      await assert.rejects(
+        wallet.sendBatch(
+          [
+            ['OPEN', name1],
+            ['OPEN', name1],
+            ['OPEN', name3]
+          ]
+        ),
+         {message: 'Duplicate name with exclusive action.'}
+       );
+    });
+
+    it('should fail if one action is invalid: BID early', async () => {
+      await assert.rejects(
+        wallet.sendBatch(
+          [
+            ['BID', name1, 1, 1],
+            ['OPEN', name2],
+            ['OPEN', name3]
+          ]
+        ),
+        {message: `Name has not reached the bidding phase yet: ${name1}.`}
+      );
+    });
+
+    it('should fail if one action is invalid: wrong arguments', async () => {
+      await assert.rejects(
+        wallet.sendBatch(
+          [
+            ['BID', name1, 21000000],
+            ['OPEN', name2],
+            ['OPEN', name3]
+          ]
+        ),
+        {message: 'Bad arguments for BID.'}
+      );
+    });
+
+    it('should fail if one action is invalid: REVEAL before bid', async () => {
+      await assert.rejects(
+        wallet.sendBatch(
+          [
+            ['REVEAL', name1],
+            ['OPEN', name2],
+            ['OPEN', name3]
+          ]
+        ),
+        {message: `Auction not found: ${name1}.`}
+      );
+    });
+
+    describe('Complete auction and diverse-action batches', function() {
+      it('3 OPENs', async () => {
+        await wallet.sendBatch(
+          [
+            ['OPEN', name1],
+            ['OPEN', name2],
+            ['OPEN', name3]
+          ]
+        );
+        await mineBlocks(treeInterval + 1);
+      });
+
+      it('4 BIDs', async () => {
+        await wallet.sendBatch(
+          [
+            ['BID', name1, 10000, 20000],
+            ['BID', name1, 10001, 20000], // self-snipe!
+            ['BID', name2, 30000, 40000],
+            ['BID', name3, 50000, 60000]
+          ]
+        );
+        await mineBlocks(biddingPeriod);
+      });
+
+      it('2 REVEALs then 1 REVEAL', async () => {
+        await wallet.sendBatch(
+          [
+            ['REVEAL', name1],
+            ['REVEAL', name2]
+          ]
+        );
+        // No "could not resolve preferred inputs" error
+        // because names are being revealed individually.
+        await wallet.sendBatch(
+          [
+            ['REVEAL', name3]
+          ]
+        );
+        await mineBlocks(revealPeriod);
+      });
+
+      it('3 REGISTERs, 1 REDEEM and 1 OPEN', async () => {
+        // Complete all 4 bids win and/or lose in one TX
+        const batch1 = await wallet.sendBatch(
+          [
+            ['OPEN', name4],
+            ['REDEEM', name1],
+            ['UPDATE', name1, res1],
+            ['UPDATE', name2, res2],
+            ['UPDATE', name3, res3]
+          ]
+        );
+
+        // Unlinked covenant (OPEN) was listed first but
+        // should be sorted last with the change output (NONE).
+        assert(!batch1.outputs[4].covenant.isLinked());
+        assert(!batch1.outputs[5].covenant.isLinked());
+        await mineBlocks(treeInterval + 1);
+      });
+
+      it('3 TRANSFERs and 1 BID', async () => {
+        // Transfer out of wallet
+        const nullAddr = new Address({
+          version: 31,
+          hash: Buffer.from([1, 2, 3])
+        });
+        await wallet.sendBatch(
+          [
+            ['TRANSFER', name1, nullAddr],
+            ['TRANSFER', name2, nullAddr],
+            ['TRANSFER', name3, nullAddr],
+            ['BID', name4, 70000, 80000]
+          ]
+        );
+
+        // True for regtest but not mainnet,
+        // should allow both REVEAL and FINALIZE
+        assert(transferLockup > biddingPeriod);
+        assert(transferLockup < (biddingPeriod + revealPeriod));
+        await mineBlocks(transferLockup);
+      });
+
+      it('1 FINALIZE, 1 CANCEL, 1 REVOKE and 1 REVEAL', async () => {
+        await wallet.sendBatch(
+          [
+            ['FINALIZE', name1],
+            ['CANCEL', name2],
+            ['REVOKE', name3],
+            ['REVEAL', name4]
+          ]
+        );
+
+        // Should allow for both REGISTER and re-open revoked name
+        assert(auctionMaturity > revealPeriod);
+        assert(auctionMaturity < renewalWindow);
+        await mineBlocks(auctionMaturity);
+      });
+
+      it('1 revoked name re-OPEN and 1 REGISTER', async () => {
+        const batch2 = await wallet.sendBatch(
+          [
+            ['OPEN', name3], // and the cycle begins again...
+            ['UPDATE', name4, res4]
+          ]
+        );
+
+        // Linked covenant (UPDATE) was listed last but should be sorted first.
+        assert.strictEqual(batch2.outputs[0].covenant.type, rules.types.REGISTER);
+        await mineBlocks(treeInterval);
+      });
+
+      it('should verify expected name properties', async () => {
+        const ns1 = await chain.db.getNameStateByName(name1);
+        const ns2 = await chain.db.getNameStateByName(name2);
+        const ns3 = await chain.db.getNameStateByName(name3);
+        const ns4 = await chain.db.getNameStateByName(name4);
+
+        assert.bufferEqual(ns1.data, res1.encode());
+        assert.bufferEqual(ns2.data, res2.encode());
+        assert.bufferEqual(ns3.data, Buffer.from([])); // revoked name data is cleared
+        assert.bufferEqual(ns4.data, res4.encode());
+
+        const coin1 = await wallet.getCoin(ns1.owner.hash, ns1.owner.index);
+        assert(!coin1); // name was transferred out of wallet
+
+        const coin2 = await wallet.getCoin(ns2.owner.hash, ns2.owner.index);
+        assert(coin2); // cancelled transfer is still in wallet
+
+        const coin3 = await wallet.getCoin(ns3.owner.hash, ns3.owner.index);
+        assert(!coin3); // revoked name no longer in wallet
+
+        const coin4 = await wallet.getCoin(ns4.owner.hash, ns4.owner.index);
+        assert(coin4); // name was won and registered
+
+        assert(ns1.isClosed(chain.height, network));
+        assert(ns2.isClosed(chain.height, network));
+        assert(ns3.isOpening(chain.height, network));
+        assert(ns4.isClosed(chain.height, network));
+      });
     });
   });
 });

--- a/test/wallet-http-test.js
+++ b/test/wallet-http-test.js
@@ -1014,7 +1014,10 @@ describe('Wallet HTTP', function() {
       name: name
     }));
 
-    await assert.rejects(fn, {message: 'No reveals to redeem.'});
+    await assert.rejects(
+      fn,
+      {message: `No reveals to redeem for name: ${name}.`}
+    );
 
     const json = await wallet.createRedeem({
       name: name

--- a/test/wallet-importname-test.js
+++ b/test/wallet-importname-test.js
@@ -110,7 +110,7 @@ describe('Wallet Import Name', function() {
     // Sanity check: bids are allowed starting in the NEXT block
     await assert.rejects(
       alice.sendBid(name, 100001, 200001),
-      {message: 'Name has not reached the bidding phase yet.'}
+      {message: `Name has not reached the bidding phase yet: ${name}.`}
     );
     await mineBlocks(1);
     await wdb.rescan(0);

--- a/test/wallet-rpc-test.js
+++ b/test/wallet-rpc-test.js
@@ -799,6 +799,55 @@ describe('Wallet RPC Methods', function() {
       await nclient.execute('generatetoaddress', [100, addr]);
     });
 
+    it('should not send invalid batch: OPEN arguments', async () => {
+      await assert.rejects(
+        wclient.execute(
+          'sendbatch',
+          [
+            [['OPEN', 'abc123'], ['OPEN', 'def456'], ['OPEN']]
+          ]
+        ),
+        {message: 'OPEN action requires 1 argument: name'}
+      );
+    });
+
+    it('should not send invalid batch: BID arguments', async () => {
+      await assert.rejects(
+        wclient.execute(
+          'sendbatch',
+          [
+            [['OPEN', 'abc123'], ['OPEN', 'def456'], ['BID', 'ghi789', 1000]]
+          ]
+        ),
+        {message: 'BID action requires 3 arguments: name, bid, value'}
+      );
+    });
+
+    it('should not send invalid batch: BID values', async () => {
+      // Bid value is higher than lockup
+      await assert.rejects(
+        wclient.execute(
+          'sendbatch',
+          [
+            [['OPEN', 'abc123'], ['OPEN', 'def456'], ['BID', 'ghi789', 2, 1]]
+          ]
+        ),
+        {message: 'Invalid bid.'}
+      );
+    });
+
+    it('should not send invalid batch: REVEAL arguments', async () => {
+      await assert.rejects(
+        wclient.execute(
+          'sendbatch',
+          [
+            [['OPEN', 'abc123'], ['OPEN', 'def456'], ['REVEAL', 'invalid.name']]
+          ]
+        ),
+        {message: 'Invalid name: invalid.name.'}
+      );
+    });
+
     it('should send multiple OPENs', async () => {
       const tx = await wclient.execute(
         'sendbatch',

--- a/test/wallet-rpc-test.js
+++ b/test/wallet-rpc-test.js
@@ -787,4 +787,98 @@ describe('Wallet RPC Methods', function() {
       assert.strictEqual(wallet2OwnedNames[0].name, name2);
     });
   });
+
+  describe('Batches', function() {
+    let addr;
+
+    before(async () => {
+      await wclient.createWallet('batchWallet');
+      wclient.wallet('batchWallet');
+      await wclient.execute('selectwallet', ['batchWallet']);
+      addr = await wclient.execute('getnewaddress', []);
+      await nclient.execute('generatetoaddress', [100, addr]);
+    });
+
+    it('should send multiple OPENs', async () => {
+      const tx = await wclient.execute(
+        'sendbatch',
+        [
+          [['OPEN', 'abc123'], ['OPEN', 'def456'], ['OPEN', 'ghi789']]
+        ]
+      );
+      assert(tx.outputs.length === 4);
+      await nclient.execute('generatetoaddress', [7, addr]);
+    });
+
+    it('should send multiple BIDs', async () => {
+      const tx = await wclient.execute(
+        'sendbatch',
+        [
+          [
+            ['BID', 'abc123', 1, 1],
+            ['BID', 'def456', 2, 2],
+            ['BID', 'ghi789', 3, 3],
+            ['BID', 'ghi789', 4, 4]
+          ]
+        ]
+      );
+      assert(tx.outputs.length === 5);
+      await nclient.execute('generatetoaddress', [7, addr]);
+    });
+
+    it('should send multiple REVEALs', async () => {
+      const tx = await wclient.execute(
+        'sendbatch',
+        [
+          [
+            ['REVEAL', 'abc123'],
+            ['REVEAL', 'def456']
+          ]
+        ]
+      );
+      assert(tx.outputs.length === 3);
+      await nclient.execute('generatetoaddress', [1, addr]);
+    });
+
+    it('should send REVEAL all', async () => {
+      const tx = await wclient.execute(
+        'sendbatch',
+        [
+          [
+            ['REVEAL']
+          ]
+        ]
+      );
+      assert(tx.outputs.length === 3);
+      await nclient.execute('generatetoaddress', [10, addr]);
+    });
+
+    it('should send REDEEM all', async () => {
+      const tx = await wclient.execute(
+        'sendbatch',
+        [
+          [
+            ['REDEEM']
+          ]
+        ]
+      );
+      assert(tx.outputs.length === 2);
+      await nclient.execute('generatetoaddress', [1, addr]);
+    });
+
+    it('should send multiple REGISTERs', async () => {
+      const tx = await wclient.execute(
+        'sendbatch',
+        [
+          [
+            ['UPDATE', 'abc123', {'records': [{'type': 'TXT', 'txt':['abc']}]}],
+            ['UPDATE', 'def456', {'records': [{'type': 'TXT', 'txt':['def']}]}],
+            ['UPDATE', 'ghi789', {'records': [{'type': 'TXT', 'txt':['ghi']}]}]
+          ]
+        ]
+      );
+      assert(tx.outputs.length === 4);
+      await nclient.execute('generatetoaddress', [1, addr]);
+    });
+  });
 });


### PR DESCRIPTION
Creates batching functions in the wallet and exposes two new RPC calls: `sendbatch` and `createbatch`. The argument is an array of "actions". Actions are an array that starts with a string indicating the action type (usually a covenant but could also be meta-covenant type like `CANCEL`) followed by the arguments expected by the corresponding `make___()` function.

Examples:

```
# open multiple names in one TX
hsw-rpc sendbatch [['OPEN', 'menace'], ['OPEN', 'to'], ['OPEN', 'the'], ['OPEN', 'network']]

# send bids (with lockups) for multiple names in one TX:
hsw-rpc sendbatch [['BID', 'menace', 100, 100], ['BID', 'to', 1, 2], ['BID', 'the', 30, 40], ['BID', 'network', 100, 100]]

# mix and match!!!
hsw-rpc sendbatch [['REDEEM', 'menace'], ['REDEEM', 'to'], ['UPDATE', 'the', {"records":[]}], ['UPDATE', 'network', {"records":[]}]]

# even works with NONE!
hsw-rpc sendbatch '[["OPEN", "heynicetomeetyou"], ["NONE", "rs1qruzqgxl4qvs4fj3v8k6zjxwem6236pam0tjv7w", 1.123456]]'
```

TODO:
- [x] consider address reuse: all outputs of a batch will have the same receive address because that index is not incremented until the TX is done and added back to the wallet
- [x] test rpc