### PR TITLE
test: use fixed size 2 for workerpool.

### DIFF
--- a/test/airdrop-test.js
+++ b/test/airdrop-test.js
@@ -14,7 +14,8 @@ const AirdropProof = require('../lib/primitives/airdropproof');
 const network = Network.get('regtest');
 
 const workers = new WorkerPool({
-  enabled: false
+  enabled: false,
+  size: 2
 });
 
 const AIRDROP_PROOF_FILE = resolve(__dirname, 'data', 'airdrop-proof.base64');

--- a/test/auction-reorg-test.js
+++ b/test/auction-reorg-test.js
@@ -20,7 +20,8 @@ const NAME2 = rules.grindName(10, 20, network);
 
 const workers = new WorkerPool({
   // Must be disabled for `ownership.ignore`.
-  enabled: false
+  enabled: false,
+  size: 2
 });
 
 function createNode() {

--- a/test/auction-test.js
+++ b/test/auction-test.js
@@ -16,7 +16,8 @@ const NAME2 = rules.grindName(10, 20, network);
 
 const workers = new WorkerPool({
   // Must be disabled for `ownership.ignore`.
-  enabled: false
+  enabled: false,
+  size: 2
 });
 
 function createNode() {

--- a/test/chain-test.js
+++ b/test/chain-test.js
@@ -21,7 +21,8 @@ const opcodes = Script.opcodes;
 const network = Network.get('regtest');
 
 const workers = new WorkerPool({
-  enabled: true
+  enabled: true,
+  size: 2
 });
 
 const blocks = new BlockStore({

--- a/test/invalid-reorg-test.js
+++ b/test/invalid-reorg-test.js
@@ -11,7 +11,8 @@ const Network = require('../lib/protocol/network');
 const network = Network.get('regtest');
 
 const workers = new WorkerPool({
-  enabled: true
+  enabled: true,
+  size: 2
 });
 
 describe('Invalid Reorg', function() {

--- a/test/mempool-test.js
+++ b/test/mempool-test.js
@@ -37,7 +37,8 @@ ONE_HASH[0] = 0x01;
 
 const network = Network.get('regtest');
 const workers = new WorkerPool({
-  enabled: true
+  enabled: true,
+  size: 2
 });
 
 const blocks = new BlockStore({
@@ -474,7 +475,8 @@ describe('Mempool', function() {
   describe('Mempool disconnect and reorg handling', function () {
     const workers = new WorkerPool({
       // Must be disabled for `ownership.ignore`.
-      enabled: false
+      enabled: false,
+      size: 2
     });
 
     const blocks = new BlockStore({

--- a/test/miner-test.js
+++ b/test/miner-test.js
@@ -13,7 +13,8 @@ const MemWallet = require('./util/memwallet');
 const {BufferSet} = require('buffer-map');
 
 const workers = new WorkerPool({
-  enabled: true
+  enabled: true,
+  size: 2
 });
 
 const blocks = new BlockStore({

--- a/test/wallet-auction-test.js
+++ b/test/wallet-auction-test.js
@@ -20,7 +20,8 @@ const {
 } = network.names;
 
 const workers = new WorkerPool({
-  enabled: false
+  enabled: false,
+  size: 2
 });
 
 const blocks = new BlockStore({

--- a/test/wallet-test.js
+++ b/test/wallet-test.js
@@ -36,8 +36,9 @@ const KEY2 = 'xprv9s21ZrQH143K3mqiSThzPtWAabQ22Pjp3uSNnZ53A5bQ4udp'
   + 'faKekc2m4AChLYH1XDzANhrSdxHYWUeTWjYJwFwWFyHkTMnMeAcW4JyRCZa';
 
 const enabled = true;
+const size = 2;
 const network = Network.get('main');
-const workers = new WorkerPool({ enabled });
+const workers = new WorkerPool({ enabled, size });
 const wdb = new WalletDB({ network, workers });
 
 let currentWallet = null;
@@ -1854,7 +1855,7 @@ describe('Wallet', function() {
 
   describe('Disable TXs', function() {
     const network = Network.get('regtest');
-    const workers = new WorkerPool({ enabled });
+    const workers = new WorkerPool({ enabled, size });
     const wdb = new WalletDB({ network, workers });
 
     before(async () => {
@@ -1916,11 +1917,7 @@ describe('Wallet', function() {
     let wdb = null;
 
     beforeEach(async () => {
-      workers = new WorkerPool({
-        enabled: true,
-        size: 2
-      });
-
+      workers = new WorkerPool({ enabled, size });
       wdb = new WalletDB({ workers });
       await workers.open();
       await wdb.open();
@@ -1977,7 +1974,7 @@ describe('Wallet', function() {
 
   describe('TXDB locked balance', function() {
     const network = Network.get('regtest');
-    const workers = new WorkerPool({ enabled });
+    const workers = new WorkerPool({ enabled, size });
     const wdb = new WalletDB({ network, workers });
     // This test executes a complete auction for this name
     const name = 'satoshi';
@@ -2356,7 +2353,7 @@ describe('Wallet', function() {
 
   describe('TXDB locked balance after simulated rescan', function() {
     const network = Network.get('regtest');
-    const workers = new WorkerPool({ enabled });
+    const workers = new WorkerPool({ enabled, size });
     const wdb = new WalletDB({ network, workers });
     const name = 'satoshi';
     const nameHash = rules.hashName(name);
@@ -2760,7 +2757,7 @@ describe('Wallet', function() {
     // that later 'it' blocks depend on.
     let wallet, update;
     const network = Network.get('regtest');
-    const workers = new WorkerPool({enabled: false});
+    const workers = new WorkerPool({enabled: false, size});
     const wdb = new WalletDB({network, workers});
     // Cloudflare's "custom value" plus the standard "name value".
     // Verifiable with reserved-browser.js and names.json
@@ -2939,7 +2936,7 @@ describe('Wallet', function() {
 
   describe('Create auction-related TX in advance', function () {
     const network = Network.get('regtest');
-    const workers = new WorkerPool({ enabled });
+    const workers = new WorkerPool({ enabled, size });
     const wdb = new WalletDB({ network, workers });
     // This test executes a complete auction for this name
     const name = 'satoshi-in-advance';


### PR DESCRIPTION
Our tests don't need a lot of CPU work and spawning workers takes time. Machines with more cores will take more time spawning workers than the actual work. This issue came up in Bcoin as well on some CIs: https://github.com/bcoin-org/bcoin/pull/777