### PR TITLE
blockstore - separate write and prune batches.

### DIFF
--- a/lib/blockchain/chaindb.js
+++ b/lib/blockchain/chaindb.js
@@ -304,12 +304,16 @@ class ChainDB {
     assert(this.pending);
 
     try {
+      if (this.blocks)
+        await this.blocksBatch.commitWrites();
+
       await this.current.write();
     } catch (e) {
       this.current = null;
       this.pending = null;
       this.cacheHash.drop();
       this.cacheHeight.drop();
+      this.blocksBatch = null;
       throw e;
     }
 
@@ -329,7 +333,7 @@ class ChainDB {
     this.stateCache.commit();
 
     if (this.blocks)
-      await this.blocksBatch.write();
+      await this.blocksBatch.commitPrunes();
   }
 
   /**
@@ -918,7 +922,7 @@ class ChainDB {
     // We do blockstore write first, because if something
     // fails during this batch, then db flag wont be set.
     // If user just reruns the node prune will restart.
-    await blocksBatch.write();
+    await blocksBatch.commit();
 
     try {
       options.prune = true;

--- a/lib/blockstore/file.js
+++ b/lib/blockstore/file.js
@@ -664,8 +664,14 @@ class FileBatch {
 
   constructor(blocks) {
     this.blocks = blocks;
-    this.ops = [];
-    this.written = false;
+    this.writes = [];
+    this.prunes = [];
+    this.committedWrites = false;
+    this.committedPrunes = false;
+  }
+
+  get written() {
+    return this.committedWrites && this.committedPrunes;
   }
 
   /**
@@ -676,7 +682,7 @@ class FileBatch {
    */
 
   writeMerkle(hash, data) {
-    this.ops.push(new WriteOp(types.MERKLE, hash, data));
+    this.writes.push(new WriteOp(types.MERKLE, hash, data));
   }
 
   /**
@@ -687,7 +693,7 @@ class FileBatch {
    */
 
   writeUndo(hash, data) {
-    this.ops.push(new WriteOp(types.UNDO, hash, data));
+    this.writes.push(new WriteOp(types.UNDO, hash, data));
   }
 
   /**
@@ -698,7 +704,7 @@ class FileBatch {
    */
 
   writeBlock(hash, data) {
-    this.ops.push(new WriteOp(types.BLOCK, hash, data));
+    this.writes.push(new WriteOp(types.BLOCK, hash, data));
   }
 
   /**
@@ -708,7 +714,7 @@ class FileBatch {
    */
 
   pruneMerkle(hash) {
-    this.ops.push(new PruneOp(types.MERKLE, hash));
+    this.prunes.push(new PruneOp(types.MERKLE, hash));
   }
 
   /**
@@ -718,7 +724,7 @@ class FileBatch {
    */
 
   pruneUndo(hash) {
-    this.ops.push(new PruneOp(types.UNDO, hash));
+    this.prunes.push(new PruneOp(types.UNDO, hash));
   }
 
   /**
@@ -728,7 +734,7 @@ class FileBatch {
    */
 
   pruneBlock(hash) {
-    this.ops.push(new PruneOp(types.BLOCK, hash));
+    this.prunes.push(new PruneOp(types.BLOCK, hash));
   }
 
   /**
@@ -737,33 +743,49 @@ class FileBatch {
    */
 
   clear() {
-    assert(!this.written, 'Already written.');
-    this.ops.length = 0;
+    assert(!this.written, 'Already written all.');
+    this.writes.length = 0;
+    this.prunes.length = 0;
   }
 
   /**
-   * Write change to the store.
+   * Commit only writes.
    * @returns {Promise}
    */
 
-  async write() {
-    assert(!this.written, 'Already written.');
+  async commitWrites() {
+    assert(!this.committedWrites, 'Already written writes.');
 
-    for (const op of this.ops) {
-      switch(op.type) {
-        case WRITE:
-          await this.blocks._write(op.writeType, op.hash, op.data);
-          break;
-        case PRUNE:
-          await this.blocks._prune(op.pruneType, op.hash);
-          break;
-        default:
-          throw new Error('Bad Op.');
-      }
-    }
+    for (const op of this.writes)
+      await this.blocks._write(op.writeType, op.hash, op.data);
 
-    this.ops.length = 0;
-    this.written = true;
+    this.committedWrites = true;
+  }
+
+  /**
+   * Commit only prunes.
+   * @returns {Promise}
+   */
+
+  async commitPrunes() {
+    assert(!this.committedPrunes, 'Already written prunes.');
+
+    for (const op of this.prunes)
+      await this.blocks._prune(op.pruneType, op.hash);
+
+    this.committedPrunes = true;
+  }
+
+  /**
+   * Commit both.
+   * @returns {Promise}
+   */
+
+  async commit() {
+    assert(!this.written, 'Already written all.');
+
+    await this.commitWrites();
+    await this.commitPrunes();
   }
 }
 

--- a/lib/blockstore/level.js
+++ b/lib/blockstore/level.js
@@ -253,8 +253,14 @@ class LevelBatch {
    */
 
   constructor(db) {
-    this.batch = db.batch();
-    this.written = false;
+    this.writesBatch = db.batch();
+    this.prunesBatch = db.batch();
+    this.committedWrites = false;
+    this.committedPrunes = false;
+  }
+
+  get written() {
+    return this.committedPrunes && this.committedWrites;
   }
 
   /**
@@ -265,7 +271,7 @@ class LevelBatch {
    */
 
   writeMerkle(hash, data) {
-    this.batch.put(layout.b.encode(types.MERKLE, hash), data);
+    this.writesBatch.put(layout.b.encode(types.MERKLE, hash), data);
     return this;
   }
 
@@ -277,7 +283,7 @@ class LevelBatch {
    */
 
   writeUndo(hash, data) {
-    this.batch.put(layout.b.encode(types.UNDO, hash), data);
+    this.writesBatch.put(layout.b.encode(types.UNDO, hash), data);
     return this;
   }
 
@@ -289,7 +295,7 @@ class LevelBatch {
    */
 
   writeBlock(hash, data) {
-    this.batch.put(layout.b.encode(types.BLOCK, hash), data);
+    this.writesBatch.put(layout.b.encode(types.BLOCK, hash), data);
     return this;
   }
 
@@ -300,7 +306,7 @@ class LevelBatch {
    */
 
   pruneMerkle(hash) {
-    this.batch.del(layout.b.encode(types.MERKLE, hash));
+    this.prunesBatch.del(layout.b.encode(types.MERKLE, hash));
     return this;
   }
 
@@ -311,7 +317,7 @@ class LevelBatch {
    */
 
   pruneUndo(hash) {
-    this.batch.del(layout.b.encode(types.UNDO, hash));
+    this.prunesBatch.del(layout.b.encode(types.UNDO, hash));
     return this;
   }
 
@@ -322,7 +328,7 @@ class LevelBatch {
    */
 
   pruneBlock(hash) {
-    this.batch.del(layout.b.encode(types.BLOCK, hash));
+    this.prunesBatch.del(layout.b.encode(types.BLOCK, hash));
     return this;
   }
 
@@ -332,9 +338,26 @@ class LevelBatch {
    */
 
   clear() {
-    assert(!this.written, 'Already written.');
-    this.batch.clear();
+    assert(!this.written, 'Already written all.');
+    this.writesBatch.clear();
+    this.prunesBatch.clear();
     return this;
+  }
+
+  async commitWrites() {
+    assert(!this.committedWrites, 'Already written writes.');
+
+    await this.writesBatch.write();
+
+    this.committedWrites = true;
+  }
+
+  async commitPrunes() {
+    assert(!this.committedPrunes, 'Already written prunes.');
+
+    await this.prunesBatch.write();
+
+    this.committedPrunes = true;
   }
 
   /**
@@ -342,12 +365,11 @@ class LevelBatch {
    * @returns {Promise}
    */
 
-  async write() {
-    assert(!this.written, 'Already written.');
+  async commit() {
+    assert(!this.written, 'Already written all.');
 
-    await this.batch.write();
-
-    this.written = true;
+    await this.commitWrites();
+    await this.commitPrunes();
   }
 }
 

--- a/test/blockstore-test.js
+++ b/test/blockstore-test.js
@@ -1444,7 +1444,7 @@ describe('BlockStore', function() {
           const block = await store.readBlock(hash);
           assert(!block, 'Block should not exist');
         }
-        await batch.write();
+        await batch.commit();
 
         const block2 = await store.readBlock(hash);
         assert.bufferEqual(block1, block2);
@@ -1461,7 +1461,7 @@ describe('BlockStore', function() {
           const undo = await store.readUndo(hash);
           assert(!undo, 'Block should not exist');
         }
-        await batch.write();
+        await batch.commit();
 
         const undo2 = await store.readUndo(hash);
         assert.bufferEqual(undo1, undo2);
@@ -1478,7 +1478,7 @@ describe('BlockStore', function() {
           const merkle = await store.readMerkle(hash);
           assert(!merkle, 'Block should not exist');
         }
-        await batch.write();
+        await batch.commit();
 
         const merkle2 = await store.readMerkle(hash);
         assert.bufferEqual(merkle1, merkle2);
@@ -1504,7 +1504,7 @@ describe('BlockStore', function() {
           assert(!block);
         }
 
-        await batch.write();
+        await batch.commit();
 
         for (const {hash, block} of blocks) {
           const hasBlock = await store.hasBlock(hash);
@@ -1526,7 +1526,7 @@ describe('BlockStore', function() {
           batch1.writeBlock(hash, block);
         }
 
-        await batch1.write();
+        await batch1.commit();
 
         for (const hash of hashes) {
           const hasBlock = await store.hasBlock(hash);
@@ -1537,7 +1537,7 @@ describe('BlockStore', function() {
         for (const hash of hashes)
           batch2.pruneBlock(hash);
 
-        await batch2.write();
+        await batch2.commit();
 
         for (const hash of hashes) {
           const hasBlock = await store.hasBlock(hash);
@@ -1556,7 +1556,7 @@ describe('BlockStore', function() {
           batch1.writeUndo(hash, block);
         }
 
-        await batch1.write();
+        await batch1.commit();
 
         for (const hash of hashes) {
           const hasBlock = await store.hasUndo(hash);
@@ -1567,7 +1567,7 @@ describe('BlockStore', function() {
         for (const hash of hashes)
           batch2.pruneUndo(hash);
 
-        await batch2.write();
+        await batch2.commit();
 
         for (const hash of hashes) {
           const hasBlock = await store.hasUndo(hash);
@@ -1586,7 +1586,7 @@ describe('BlockStore', function() {
           batch1.writeMerkle(hash, block);
         }
 
-        await batch1.write();
+        await batch1.commit();
 
         for (const hash of hashes) {
           const hasBlock = await store.hasMerkle(hash);
@@ -1597,7 +1597,7 @@ describe('BlockStore', function() {
         for (const hash of hashes)
           batch2.pruneMerkle(hash);
 
-        await batch2.write();
+        await batch2.commit();
 
         for (const hash of hashes) {
           const hasBlock = await store.hasMerkle(hash);
@@ -1630,7 +1630,7 @@ describe('BlockStore', function() {
         };
 
         await checkBlocks();
-        await batch.write();
+        await batch.commit();
         await checkBlocks();
       });
 
@@ -1642,14 +1642,14 @@ describe('BlockStore', function() {
 
         batch.writeBlock(hash, block);
 
-        await batch.write();
+        await batch.commit();
 
-        await assert.rejects(() => batch.write(), {
-          message: 'Already written.'
+        await assert.rejects(() => batch.commit(), {
+          message: 'Already written all.'
         });
 
         await assert.rejects(() => batch.clear(), {
-          message: 'Already written.'
+          message: 'Already written all.'
         });
       });
     });
@@ -1691,7 +1691,7 @@ describe('BlockStore', function() {
         batch.writeBlock(hash, block);
       }
 
-      await batch.write();
+      await batch.commit();
 
       for (const {hash, block} of blocks) {
         const block2 = await store.readBlock(hash);
@@ -1728,7 +1728,7 @@ describe('BlockStore', function() {
         batch.writeUndo(hash, undo);
       }
 
-      await batch.write();
+      await batch.commit();
 
       for (const {hash, undo} of undos) {
         const undo2 = await store.readUndo(hash);
@@ -1762,7 +1762,7 @@ describe('BlockStore', function() {
         batch.writeMerkle(hash, merkle);
       }
 
-      await batch.write();
+      await batch.commit();
 
       for (const {hash, merkle} of merkles) {
         const merkle2 = await store.readMerkle(hash);
@@ -1795,7 +1795,7 @@ describe('BlockStore', function() {
         batch1.writeBlock(hash, block);
       }
 
-      await batch1.write();
+      await batch1.commit();
 
       const first = await fs.stat(store.filepath(types.BLOCK, 0));
       const second = await fs.stat(store.filepath(types.BLOCK, 1));
@@ -1810,7 +1810,7 @@ describe('BlockStore', function() {
       for (const hash of hashes)
         batch2.pruneBlock(hash);
 
-      await batch2.write();
+      await batch2.commit();
 
       assert.equal(await fs.exists(store.filepath(types.BLOCK, 0)), false);
       assert.equal(await fs.exists(store.filepath(types.BLOCK, 1)), false);

--- a/test/chain-blockstore-test.js
+++ b/test/chain-blockstore-test.js
@@ -1,0 +1,279 @@
+'use strict';
+
+const assert = require('bsert');
+const {BloomFilter} = require('bfilter');
+const Network = require('../lib/protocol/network');
+const {FileBlockStore, LevelBlockStore} = require('../lib/blockstore');
+const Chain = require('../lib/blockchain/chain');
+const WorkerPool = require('../lib/workers/workerpool');
+const Miner = require('../lib/mining/miner');
+const {rimraf, testdir} = require('./util/common');
+const MemWallet = require('./util/memwallet');
+
+const network = Network.get('regtest');
+
+const blockStoreTypes = {
+  'File': async (location) => {
+    const store = new FileBlockStore({
+      maxFileLength: 1024,
+      location
+    });
+
+    await store.ensure();
+    return store;
+  },
+  'Level': async (location) => {
+    const store = new LevelBlockStore({ location });
+
+    await store.ensure();
+    return store;
+  },
+  'Level-memory': async (location) => {
+    const store = new LevelBlockStore({
+      memory: true
+    });
+
+    return store;
+  }
+};
+
+describe('Chain Blockstore Integration', function() {
+  for (const type of Object.keys(blockStoreTypes)) {
+    describe(`Chain ${type} BlockStore Integration`, function() {
+      const location = testdir('chain-blockstore');
+      const workers = new WorkerPool({
+        enabled: true,
+        size: 2
+      });
+
+      const MINE_BLOCKS = 10;
+
+      let blocks, chain, miner, cpu, wallet;
+
+      before(async () => {
+        await rimraf(location);
+
+        blocks = await blockStoreTypes[type](location);
+
+        chain = new Chain({
+          prefix: location,
+          blocks,
+          network,
+          workers
+        });
+
+        miner = new Miner({ chain, workers });
+        cpu = miner.cpu;
+        wallet = new MemWallet({ network });
+
+        await blocks.open();
+        await chain.open();
+        await miner.open();
+      });
+
+      after(async () => {
+        await miner.close();
+        await chain.close();
+        await blocks.close();
+
+        await rimraf(location);
+      });
+
+      it('should add addrs to miner', async () => {
+        miner.addresses.length = 0;
+        miner.addAddress(wallet.getReceive());
+      });
+
+      it(`should mine ${MINE_BLOCKS} blocks`, async () => {
+        for (let i = 0; i < MINE_BLOCKS; i++) {
+          const block = await cpu.mineBlock();
+          assert(block);
+          assert(await chain.add(block));
+        }
+      });
+
+      it('should rescan', async () => {
+        const filter = new BloomFilter();
+
+        const firstBlock = await chain.getHash(1);
+        const scanned = new Set();
+        await chain.scan(firstBlock, filter, (entry, txs) => {
+          scanned.add(entry.height);
+        });
+
+        for (let i = 1; i <= MINE_BLOCKS; i++)
+          assert.strictEqual(scanned.has(i), true, `Block ${i} was not scanned.`);
+        assert.strictEqual(scanned.size, MINE_BLOCKS);
+      });
+
+      it('should handle blockstore failing to write', async () => {
+        const db = chain.db;
+
+        // backup start method
+        const dbStart = db.start;
+
+        db.start = function() {
+          dbStart.call(this);
+
+          // old API would have
+          // this.blocksBatch.write = () ...
+          this.blocksBatch.commitWrites = () => {
+            throw new Error('Failed to write.');
+          };
+        };
+
+        const block = await cpu.mineBlock();
+        assert(block);
+
+        let err;
+        try {
+          await chain.add(block);
+        } catch (e) {
+          err = e;
+        }
+
+        // recover start method.
+        db.start = dbStart;
+
+        assert(err);
+        assert(err.message, 'Failed to write.');
+      });
+
+      it('should reopen the chain', async () => {
+        await chain.close();
+        await chain.open();
+      });
+
+      it('should handle blockstore failing to prune', async () => {
+        const db = chain.db;
+
+        // backup start method
+        const dbStart = db.start;
+
+        db.start = function() {
+          dbStart.call(this);
+
+          this.blocksBatch.commitPrunes = function() {
+            throw new Error('Failed to prune.');
+          };
+        };
+
+        let err;
+
+        try {
+          await chain.reset(1);
+        } catch (e) {
+          err = e;
+        }
+
+        // recover start method.
+        db.start = dbStart;
+
+        assert(err);
+        assert(err.message, 'Failed to prune.');
+      });
+
+      it('should reopen the chain', async () => {
+        await chain.close();
+        await chain.open();
+      });
+    });
+  }
+
+  describe('Chain File BlockStore Integration 2', function() {
+    const location = testdir('chain-blockstore-2');
+    const workers = new WorkerPool({
+      enabled: true,
+      size: 2
+    });
+
+    const MINE_BLOCKS = 10;
+
+    let blocks, chain, miner, cpu, wallet;
+
+    before(async () => {
+      await rimraf(location);
+
+      blocks = await blockStoreTypes['File'](location);
+
+      chain = new Chain({
+        prefix: location,
+        blocks,
+        network,
+        workers
+      });
+
+      miner = new Miner({ chain, workers });
+      cpu = miner.cpu;
+      wallet = new MemWallet({ network });
+
+      await blocks.open();
+      await chain.open();
+      await miner.open();
+    });
+
+    after(async () => {
+      await miner.close();
+      await chain.close();
+      await blocks.close();
+
+      await rimraf(location);
+    });
+
+    it('should add addrs to miner', async () => {
+      miner.addresses.length = 0;
+      miner.addAddress(wallet.getReceive());
+    });
+
+    it(`should mine ${MINE_BLOCKS} blocks`, async () => {
+      for (let i = 0; i < MINE_BLOCKS; i++) {
+        const block = await cpu.mineBlock();
+        assert(block);
+        assert(await chain.add(block));
+      }
+    });
+
+    it('should handle file blockstore failing to prune', async () => {
+      const db = chain.db;
+
+      // backup start method
+      const dbStart = db.start;
+
+      db.start = function() {
+        dbStart.call(this);
+
+        this.blocksBatch.commitPrunes = function() {
+          if (this.prunes.length === 0) {
+            this.committedPrunes = true;
+            return;
+          }
+
+          throw new Error('Failed to prune.');
+        };
+      };
+
+      let err;
+
+      assert.strictEqual(chain.tip.height, MINE_BLOCKS);
+      try {
+        await chain.reset(1);
+      } catch (e) {
+        err = e;
+      }
+
+      // recover start method.
+      db.start = dbStart;
+
+      assert(err);
+      assert(err.message, 'Failed to prune.');
+    });
+
+    it('should reopen the chain', async () => {
+      await chain.close();
+      await chain.open();
+
+      // Even though pruning failed, we still reverted one block.
+      assert.strictEqual(chain.tip.height, MINE_BLOCKS - 1);
+    });
+  });
+});

--- a/test/chain-migration-test.js
+++ b/test/chain-migration-test.js
@@ -773,7 +773,7 @@ describe('Chain Migrations', function() {
       }
 
       await ldbBatch.write();
-      await blocksBatch.write();
+      await blocksBatch.commit();
     });
 
     it('should fail getting blocks', async () => {


### PR DESCRIPTION
ChainDB and BlockStore are separate and committing to them is not really atomic,
so we need to make sure the order operations can handle failure at any step.
Previously blockstore writes and prunes would happen after the chaindb was
written, but that could lead to the situation where the blockstore did not
actually have a block but chaindb had the information.
  This PR separates write and prune batches for the blockstore, so we can try
writing to blockstore first. In case writing to blockstore fails whole operation
will get aborted. Nothing gets written into the chaindb, so the information is
consistent. In case blockstore writes a block and then chaindb write fails,
we just get extra data in the blockstore. But most of the time, the same block
write will happen again (either main or alt chains).
  Pruning always happens after the chaindb was updated to avoid situation, where
chaindb thinks the data is stored, but blockstore has removed it. If blockstore
fails to prune after chaindb removed the information, worst case scenario
(prune mode) we get a maxFileLength(128 MB by default) space wasted.

Issue found here: https://github.com/kyokan/bob-wallet/issues/453