### PR TITLE
Fix ipv6 support for DNS servers

### DIFF
--- a/lib/dns/server.js
+++ b/lib/dns/server.js
@@ -53,7 +53,7 @@ const {
  * Constants
  */
 
-const RES_OPT = { inet6: false, tcp: true };
+const RES_OPT = { tcp: true };
 const CACHE_TTL = 30 * 60 * 1000;
 
 /**
@@ -541,7 +541,11 @@ class RootServer extends DNSServer {
   async open() {
     await super.open(this.port, this.host);
 
-    this.logger.info('Root nameserver listening on port %d.', this.port);
+    this.logger.info(
+      'Root nameserver listening on %s (port=%d).',
+      this.host,
+      this.port
+    );
   }
 
   getReserved(tld) {
@@ -650,7 +654,6 @@ class RecursiveServer extends DNSServer {
     this.stubPort = 5300;
 
     this.hns = new UnboundResolver({
-      inet6: false,
       tcp: true,
       edns: true,
       dnssec: true,
@@ -716,7 +719,6 @@ class RecursiveServer extends DNSServer {
       assert(typeof options.noUnbound === 'boolean');
       if (options.noUnbound) {
         this.hns = new RecursiveResolver({
-          inet6: false,
           tcp: true,
           edns: true,
           dnssec: true,
@@ -776,7 +778,11 @@ class RecursiveServer extends DNSServer {
 
     await super.open(this.port, this.host);
 
-    this.logger.info('Recursive server listening on port %d.', this.port);
+    this.logger.info(
+      'Recursive server listening on %s (port=%d).',
+      this.host,
+      this.port
+    );
   }
 
   async close() {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "blru": "~0.1.6",
     "blst": "~0.1.5",
     "bmutex": "~0.1.6",
-    "bns": "~0.15.0",
+    "bns": "pinheadmz/bns#ipv6",
     "bsert": "~0.0.10",
     "bsock": "~0.1.9",
     "bsocks": "~0.2.6",


### PR DESCRIPTION
Requires https://github.com/chjj/bns/pull/33

Inspired by https://github.com/handshake-org/hsd/pull/685 I went looking for other problems with `127.0.0.1` and tried configuring hsd's DNS servers to listen on ipv6 addresses `::1`. There were several problems with this that need to be addressed in both bns (see above PR) as well as hsd.

The misbehavior can be observed on master branch:
- start hsd with `hsd --rs-host=::1` 
- try to `dig @::1 ...`

Other combinations will also break such as `hsd --ns-host=::1` and then `dig @127.0.0.1 ...` because the recursive resolver (`unbound`) thinks ipv6 is false and will just return `SERVFAIL` even though the root name server is happily listening on `::1`

**REVIEWERS:** be sure to `rm -rf node_modules && npm i` because this PR pulls in the bns PR
