### PR TITLE
Clarify ports / public ports in node HTTP getinfo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## unreleased
 
-### Node changes
+### Node API changes
+
+- HTTP API endpoint `/` (`hsd-cli getinfo`) now includes "public" networking settings.
 
 - RPCs `getnameinfo` `getnameresource` `verifymessagewithname` and `getnamebyhash`
 now accept an additional boolean parameter `safe` which will resolve the name from the Urkel
@@ -14,11 +16,12 @@ to these calls.
   - `decoderesource` like `decodescript` accepts hex string as input and returns
   JSON formatted DNS records resource.
 
-### Wallet changes
+### Wallet API changes
 
 - New RPC methods:
   - `createbatch` and `sendbatch` create batch transactions with any number
   of outputs with any combination of covenants.
+
 ## v4.0.0
 
 **When upgrading to this version of hsd you must pass

--- a/lib/net/hostlist.js
+++ b/lib/net/hostlist.js
@@ -1033,6 +1033,12 @@ class HostList {
 
     if (!src) {
       for (const dest of this.local.values()) {
+        if (this.network.type === 'main') {
+          // Disable everything else for now.
+          if (dest.type < HostList.scores.UPNP)
+            continue;
+        }
+
         if (dest.addr.hasKey())
           continue;
 

--- a/lib/node/http.js
+++ b/lib/node/http.js
@@ -117,10 +117,20 @@ class HTTP extends Server {
       const orphans = this.mempool ? this.mempool.orphans.size : 0;
       const brontide = this.pool.hosts.brontide;
 
-      let addr = this.pool.hosts.getLocal();
+      const pub = {
+        listen: this.pool.options.listen,
+        host: null,
+        port: null,
+        brontidePort: null
+      };
 
-      if (!addr)
-        addr = this.pool.hosts.address;
+      const addr = this.pool.hosts.getLocal();
+
+      if (addr && pub.listen) {
+        pub.host = addr.host;
+        pub.port = addr.port;
+        pub.brontidePort = brontide.port;
+      }
 
       res.json(200, {
         version: pkg.version,
@@ -138,15 +148,15 @@ class HTTP extends Server {
           }
         },
         pool: {
-          host: addr.host,
-          port: addr.port,
-          brontideHost: brontide.host,
-          brontidePort: brontide.port,
+          host: this.pool.options.host,
+          port: this.pool.options.port,
+          brontidePort: this.pool.options.brontidePort,
           identitykey: brontide.getKey('base32'),
           agent: this.pool.options.agent,
           services: this.pool.options.services.toString(2),
           outbound: this.pool.peers.outbound,
-          inbound: this.pool.peers.inbound
+          inbound: this.pool.peers.inbound,
+          public: pub
         },
         mempool: {
           tx: totalTX,

--- a/test/node-http-test.js
+++ b/test/node-http-test.js
@@ -49,7 +49,7 @@ describe('Node HTTP', function() {
       assert.strictEqual(pub.brontidePort, null);
     });
 
-    it('should have public address: regtest, listen', async () => {
+    it('should not have public address: regtest, listen', async () => {
       const network = Network.get('regtest');
 
       const node = new FullNode({
@@ -73,9 +73,9 @@ describe('Node HTTP', function() {
       const {public: pub} = pool;
 
       assert.strictEqual(pub.listen, true);
-      assert.notStrictEqual(pub.host, null); // will be "discovered" using DNS
-      assert.strictEqual(pub.port, network.port);
-      assert.strictEqual(pub.brontidePort, network.brontidePort);
+      assert.strictEqual(pub.host, null); // we don't discover from external
+      assert.strictEqual(pub.port, null);
+      assert.strictEqual(pub.brontidePort, null);
     });
 
     it('should not have public address: main', async () => {

--- a/test/node-http-test.js
+++ b/test/node-http-test.js
@@ -20,6 +20,157 @@ const mnemonics = require('./data/mnemonic-english.json');
 const phrase = mnemonics[0][1];
 
 describe('Node HTTP', function() {
+  describe('Networking info', function() {
+    it('should not have public address: regtest', async () => {
+      const network = Network.get('regtest');
+
+      const node = new FullNode({
+        network: network.type
+      });
+
+      const nclient = new NodeClient({
+        port: network.rpcPort
+      });
+
+      await node.open();
+      await node.connect();
+      const {pool} = await nclient.getInfo();
+      await node.close();
+
+      assert.strictEqual(pool.host, '0.0.0.0');
+      assert.strictEqual(pool.port, network.port);
+      assert.strictEqual(pool.brontidePort, network.brontidePort);
+
+      const {public: pub} = pool;
+
+      assert.strictEqual(pub.listen, false);
+      assert.strictEqual(pub.host, null);
+      assert.strictEqual(pub.port, null);
+      assert.strictEqual(pub.brontidePort, null);
+    });
+
+    it('should have public address: regtest, listen', async () => {
+      const network = Network.get('regtest');
+
+      const node = new FullNode({
+        network: network.type,
+        listen: true
+      });
+
+      const nclient = new NodeClient({
+        port: network.rpcPort
+      });
+
+      await node.open();
+      await node.connect();
+      const {pool} = await nclient.getInfo();
+      await node.close();
+
+      assert.strictEqual(pool.host, '0.0.0.0');
+      assert.strictEqual(pool.port, network.port);
+      assert.strictEqual(pool.brontidePort, network.brontidePort);
+
+      const {public: pub} = pool;
+
+      assert.strictEqual(pub.listen, true);
+      assert.notStrictEqual(pub.host, null); // will be "discovered" using DNS
+      assert.strictEqual(pub.port, network.port);
+      assert.strictEqual(pub.brontidePort, network.brontidePort);
+    });
+
+    it('should not have public address: main', async () => {
+      const network = Network.get('main');
+
+      const node = new FullNode({
+        network: network.type
+      });
+
+      const nclient = new NodeClient({
+        port: network.rpcPort
+      });
+
+      await node.open();
+      await node.connect();
+      const {pool} = await nclient.getInfo();
+      await node.close();
+
+      assert.strictEqual(pool.host, '0.0.0.0');
+      assert.strictEqual(pool.port, network.port);
+      assert.strictEqual(pool.brontidePort, network.brontidePort);
+
+      const {public: pub} = pool;
+
+      assert.strictEqual(pub.listen, false);
+      assert.strictEqual(pub.host, null);
+      assert.strictEqual(pub.port, null);
+      assert.strictEqual(pub.brontidePort, null);
+    });
+
+    it('should not have public address: main, listen', async () => {
+      const network = Network.get('main');
+
+      const node = new FullNode({
+        network: network.type,
+        listen: true
+      });
+
+      const nclient = new NodeClient({
+        port: network.rpcPort
+      });
+
+      await node.open();
+      await node.connect();
+      const {pool} = await nclient.getInfo();
+      await node.close();
+
+      assert.strictEqual(pool.host, '0.0.0.0');
+      assert.strictEqual(pool.port, network.port);
+      assert.strictEqual(pool.brontidePort, network.brontidePort);
+
+      const {public: pub} = pool;
+
+      assert.strictEqual(pub.listen, true);
+      assert.strictEqual(pub.host, null);
+      assert.strictEqual(pub.port, null);
+      assert.strictEqual(pub.brontidePort, null);
+    });
+
+    it('should have public address: main, listen, publicHost', async () => {
+      const network = Network.get('main');
+      const publicHost = '100.200.11.22';
+      const publicPort = 11111;
+      const publicBrontidePort = 22222;
+
+      const node = new FullNode({
+        network: network.type,
+        listen: true,
+        publicHost,
+        publicPort,
+        publicBrontidePort
+      });
+
+      const nclient = new NodeClient({
+        port: network.rpcPort
+      });
+
+      await node.open();
+      await node.connect();
+      const {pool} = await nclient.getInfo();
+      await node.close();
+
+      assert.strictEqual(pool.host, '0.0.0.0');
+      assert.strictEqual(pool.port, network.port);
+      assert.strictEqual(pool.brontidePort, network.brontidePort);
+
+      const {public: pub} = pool;
+
+      assert.strictEqual(pub.listen, true);
+      assert.strictEqual(pub.host, publicHost);
+      assert.strictEqual(pub.port, publicPort);
+      assert.strictEqual(pub.brontidePort, publicBrontidePort);
+    });
+  });
+
   describe('Websockets', function () {
     this.timeout(15000);
 

--- a/test/p2p-test.js
+++ b/test/p2p-test.js
@@ -1,0 +1,281 @@
+'use strict';
+
+const assert = require('bsert');
+const FullNode = require('../lib/node/fullnode');
+const Network = require('../lib/protocol/network');
+const packets = require('../lib/net/packets');
+const packetTypes = packets.types;
+
+const network = Network.get('main');
+
+describe('P2P', function() {
+  describe('Advertise own address', function() {
+    it('should not share own address by default', async() => {
+      const node1 = new FullNode({
+        network: network.type,
+        memory: true,
+        listen: false,
+        port: 11111,            // avoid port collisions with node2
+        brontidePort: 22222,
+        httpPort: 33333,
+        noDns: true,
+        only: '127.0.0.1'       // connect to node2
+      });
+
+      const node2 = new FullNode({
+        network: network.type,
+        memory: true,
+        listen: true,
+        noDns: true,
+        only: '10.20.30.40'     // won't connect
+      });
+
+      // Listen for ADDR packets from both peers
+      let node1Sent = false;
+      let node2Sent = false;
+      node2.pool.on('packet', (packet) => {
+        if (packet.type === packetTypes.ADDR) {
+          node1Sent = true;
+        }
+      });
+      node1.pool.on('packet', (packet) => {
+        if (packet.type === packetTypes.ADDR) {
+          node2Sent = true;
+        }
+      });
+
+      // Ensure both peers connect successfully
+      const waiter1 = new Promise((resolve, reject) => {
+        node1.pool.on('peer open', () => {
+          resolve();
+        });
+      });
+      const waiter2 = new Promise((resolve, reject) => {
+        node2.pool.on('peer open', () => {
+          resolve();
+        });
+      });
+
+      await node2.open();
+      await node2.connect();
+      node2.pool.hosts.reset(); // empty node2's "only" host to prevent gossip
+
+      await node1.open();
+      await node1.connect();
+
+      await waiter1;
+      await waiter2;
+
+      await node1.close();
+      await node2.close();
+
+      assert.strictEqual(node1Sent, false);
+      assert.strictEqual(node2Sent, false);
+    });
+
+    it('should not share own address if just listening', async() => {
+      const node1 = new FullNode({
+        network: network.type,
+        memory: true,
+        listen: true,
+        port: 11111,            // avoid port collisions with node2
+        brontidePort: 22222,
+        httpPort: 33333,
+        noDns: true,
+        only: '127.0.0.1'       // connect to node2
+      });
+
+      const node2 = new FullNode({
+        network: network.type,
+        memory: true,
+        listen: true,
+        noDns: true,
+        only: '10.20.30.40'     // won't connect
+      });
+
+      // Listen for ADDR packets from both peers
+      let node1Sent = false;
+      let node2Sent = false;
+      node2.pool.on('packet', (packet) => {
+        if (packet.type === packetTypes.ADDR) {
+          node1Sent = true;
+        }
+      });
+      node1.pool.on('packet', (packet) => {
+        if (packet.type === packetTypes.ADDR) {
+          node2Sent = true;
+        }
+      });
+
+      // Ensure both peers connect successfully
+      const waiter1 = new Promise((resolve, reject) => {
+        node1.pool.on('peer open', () => {
+          resolve();
+        });
+      });
+      const waiter2 = new Promise((resolve, reject) => {
+        node2.pool.on('peer open', () => {
+          resolve();
+        });
+      });
+
+      await node2.open();
+      await node2.connect();
+      node2.pool.hosts.reset(); // empty node2's "only" host to prevent gossip
+
+      await node1.open();
+      await node1.connect();
+
+      await waiter1;
+      await waiter2;
+
+      await node1.close();
+      await node2.close();
+
+      assert.strictEqual(node1Sent, false);
+      assert.strictEqual(node2Sent, false);
+    });
+
+    it('should share own address if listening + publicHost', async() => {
+      const publicHost = '4.20.69.100';
+
+      const node1 = new FullNode({
+        network: network.type,
+        memory: true,
+        listen: true,
+        publicHost,
+        port: 11111,            // avoid port collisions with node2
+        brontidePort: 22222,
+        httpPort: 33333,
+        noDns: true,
+        only: '127.0.0.1'       // connect to node2
+      });
+
+      const node2 = new FullNode({
+        network: network.type,
+        memory: true,
+        listen: true,
+        noDns: true,
+        only: '10.20.30.40'     // won't connect
+      });
+
+      // Listen for ADDR packets from both peers
+      let node1Sent = false;
+      let node2Sent = false;
+      node2.pool.on('packet', (packet) => {
+        if (packet.type === packetTypes.ADDR) {
+          node1Sent = true;
+          assert.strictEqual(
+            packet.items[0].hostname,
+            `${publicHost}:${network.port}`
+          );
+        }
+      });
+      node1.pool.on('packet', (packet) => {
+        if (packet.type === packetTypes.ADDR) {
+          node2Sent = true;
+        }
+      });
+
+      // Ensure both peers connect successfully
+      const waiter1 = new Promise((resolve, reject) => {
+        node1.pool.on('peer open', () => {
+          resolve();
+        });
+      });
+      const waiter2 = new Promise((resolve, reject) => {
+        node2.pool.on('peer open', () => {
+          resolve();
+        });
+      });
+
+      await node2.open();
+      await node2.connect();
+      node2.pool.hosts.reset(); // empty node2's "only" host to prevent gossip
+
+      await node1.open();
+      await node1.connect();
+
+      await waiter1;
+      await waiter2;
+
+      await node1.close();
+      await node2.close();
+
+      assert.strictEqual(node1Sent, true);
+      assert.strictEqual(node2Sent, false);
+    });
+
+    it('should share own address with publicHost + publicPort', async() => {
+      const publicHost = '4.20.69.100';
+      const publicPort = 54321; // not the port node1 is actually listening to
+
+      const node1 = new FullNode({
+        network: network.type,
+        memory: true,
+        listen: true,
+        publicHost,
+        publicPort,
+        port: 11111,            // avoid port collisions with node2
+        brontidePort: 22222,
+        httpPort: 33333,
+        noDns: true,
+        only: '127.0.0.1'       // connect to node2
+      });
+
+      const node2 = new FullNode({
+        network: network.type,
+        memory: true,
+        listen: true,
+        noDns: true,
+        only: '10.20.30.40'     // won't connect
+      });
+
+      // Listen for ADDR packets from both peers
+      let node1Sent = false;
+      let node2Sent = false;
+      node2.pool.on('packet', (packet) => {
+        if (packet.type === packetTypes.ADDR) {
+          node1Sent = true;
+          assert.strictEqual(
+            packet.items[0].hostname,
+            `${publicHost}:${publicPort}`
+          );
+        }
+      });
+      node1.pool.on('packet', (packet) => {
+        if (packet.type === packetTypes.ADDR) {
+          node2Sent = true;
+        }
+      });
+
+      // Ensure both peers connect successfully
+      const waiter1 = new Promise((resolve, reject) => {
+        node1.pool.on('peer open', () => {
+          resolve();
+        });
+      });
+      const waiter2 = new Promise((resolve, reject) => {
+        node2.pool.on('peer open', () => {
+          resolve();
+        });
+      });
+
+      await node2.open();
+      await node2.connect();
+      node2.pool.hosts.reset(); // empty node2's "only" host to prevent gossip
+
+      await node1.open();
+      await node1.connect();
+
+      await waiter1;
+      await waiter2;
+
+      await node1.close();
+      await node2.close();
+
+      assert.strictEqual(node1Sent, true);
+      assert.strictEqual(node2Sent, false);
+    });
+  });
+});


### PR DESCRIPTION
Closes https://github.com/handshake-org/hsd/issues/689

The issue is that the ports displayed in `info` are the *public* ports set by `--public-port` and `--public-brontide-port` not `--port` and `--brontide-port`. Public hosts and ports are what we advertise to peers when we are listening for inbound connections, this is the hostname that gets gossiped around the network. The other options set the *actual* host and port the server actually listens to 🤷‍♂️ 

## Current and unchanged behavior of hsd

- We will not advertise our own address unless `--listen=true`
- On mainnet (only) we will not advertise our own address unless an address is specifically passed with `--public-host`
  - This behavior was added to hsd to prevent unreachable nodes from accidentally (user error) advertising

This PR adds some new fields to the `pool` object in the "get info" JSON. The existing data will now indicate the actual listening host/port and the `public` object will indicate the advertised data as set by the user. (See examples below).

This PR also refactors the `node-http-test` module to make more room for this coverage, and introduces a new `p2p-test` module which connects mainnet nodes together with different settings and monitors the `ADDR` packets transmitted.

### ex. 1

` hsd --memory=true --network=main`

```
  "pool": {
    "host": "0.0.0.0",
    "port": 12038,
    "brontidePort": 44806,
    "identitykey": "ang7l54xdrg47duk3jax3f5blmgblfkkwq6t6fs7luyoawehh5jk4",
    "agent": "/hsd:3.0.1/",
    "services": "1",
    "outbound": 8,
    "inbound": 0,
    "public": {
      "listen": false,
      "host": null,
      "port": null,
      "brontidePort": null
    }
  },
```
### ex. 2

` hsd --memory=true --network=main --listen=true`

```
  "pool": {
    "host": "0.0.0.0",
    "port": 12038,
    "brontidePort": 44806,
    "identitykey": "al47esnqoajntzsekilqjoq6fcyeq7uuzxr4d2j62ug34kydhbqbg",
    "agent": "/hsd:3.0.1/",
    "services": "1",
    "outbound": 8,
    "inbound": 0,
    "public": {
      "listen": true,
      "host": null,
      "port": null,
      "brontidePort": null
    }
  },
```

### ex. 3

` hsd --memory=true --network=main --listen=true --public-host=200.99.98.97 --public-port=12345 --public-brontide-port=54321`

```
  "pool": {
    "host": "0.0.0.0",
    "port": 12038,
    "brontidePort": 44806,
    "identitykey": "anv6dprpxnyqjxgmljw2ys7p5yi7s4syg6vc5x2eptym3x7jaluha",
    "agent": "/hsd:3.0.1/",
    "services": "1",
    "outbound": 8,
    "inbound": 0,
    "public": {
      "listen": true,
      "host": "200.99.98.97",
      "port": 12345,
      "brontidePort": 54321
    }
  },
```