### PR TITLE
feat(wallet): sendbid accepts addr to bid to

### DIFF
--- a/lib/wallet/rpc.js
+++ b/lib/wallet/rpc.js
@@ -2098,7 +2098,8 @@ class RPC extends RPCBase {
     const opts = this._validateBid(args, help, 'sendbid');
     const wallet = this.wallet;
     const tx = await wallet.sendBid(opts.name, opts.bid, opts.value, {
-      account: opts.account
+      account: opts.account,
+      address: opts.address
     });
 
     return tx.getJSON(this.network);
@@ -2125,7 +2126,22 @@ class RPC extends RPCBase {
     const name = valid.str(0);
     const bid = valid.ufixed(1, EXP);
     const value = valid.ufixed(2, EXP);
-    const account = valid.str(3);
+    const temp = valid.str(3);
+    let account, address;
+
+    if (temp) {
+      try {
+        // sendbid $name $bid $value $address
+        if (Address.fromString(temp).isValid()) {
+          address = temp;
+        } else {
+          // sendbid $name $bid $value $account
+          account = temp;
+        }
+      } catch(e) {
+        account = temp;
+      }
+    }
 
     if (!name || !rules.verifyName(name))
       throw new RPCError(errs.TYPE_ERROR, 'Invalid name.');
@@ -2140,7 +2156,8 @@ class RPC extends RPCBase {
       name,
       bid,
       value,
-      account
+      account,
+      address
     };
   }
 

--- a/lib/wallet/wallet.js
+++ b/lib/wallet/wallet.js
@@ -1649,15 +1649,15 @@ class Wallet extends EventEmitter {
    * @param {String} name
    * @param {Number} value
    * @param {Number} lockup
-   * @param {Number|String} acct
+   * @param {Number|String} addrOrAcct
    * @returns {MTX}
    */
 
-  async makeBid(name, value, lockup, acct) {
+  async makeBid(name, value, lockup, addrOrAcct) {
     assert(typeof name === 'string');
     assert(Number.isSafeInteger(value) && value >= 0);
     assert(Number.isSafeInteger(lockup) && lockup >= 0);
-    assert((acct >>> 0) === acct || typeof acct === 'string');
+    assert((addrOrAcct >>> 0) === addrOrAcct || typeof addrOrAcct === 'string');
 
     if (!rules.verifyName(name))
       throw new Error('Invalid name.');
@@ -1691,7 +1691,18 @@ class Wallet extends EventEmitter {
     if (value > lockup)
       throw new Error('Bid exceeds lockup value.');
 
-    const addr = await this.receiveAddress(acct);
+    const addr = await (async () => {
+      try {
+        const addr = Address.fromString(addrOrAcct);
+        if (!addr.isValid()) {
+          throw new Error();
+        }
+
+        return addr;
+      } catch (e) {
+        return await this.receiveAddress(addrOrAcct);
+      }
+    })();
     const blind = await this.generateBlind(nameHash, addr, value);
 
     const output = new Output();
@@ -1719,9 +1730,10 @@ class Wallet extends EventEmitter {
    * @returns {MTX}
    */
 
-  async _createBid(name, value, lockup, options) {
-    const acct = options ? options.account || 0 : 0;
-    const mtx = await this.makeBid(name, value, lockup, acct);
+  async _createBid(name, value, lockup, options = {}) {
+    const addrOrAcct = options.address || options.account || 0;
+
+    const mtx = await this.makeBid(name, value, lockup, addrOrAcct);
     await this.fill(mtx, options);
     return this.finalize(mtx, options);
   }

--- a/test/wallet-rpc-test.js
+++ b/test/wallet-rpc-test.js
@@ -738,8 +738,11 @@ describe('Wallet RPC Methods', function() {
     it('should bid on names', async () => {
       // wallet1 will win name1
       await wclient.execute('selectwallet', ['wallet1']);
-      await wclient.execute('sendbid', [name1, 10, 10]);
-      await wclient.execute('sendbid', [name2, 5, 5]);
+      const bid1 = await wclient.execute('sendbid', [name1, 10, 10, addr1]); // using addr to bid
+      const bid2 = await wclient.execute('sendbid', [name2, 5, 5]);
+
+      assert.equal(addr1, bid1.outputs[0].address);
+      assert.notEqual(addr1, bid2.outputs[0].address);
 
       // wallet2 will win name2
       await wclient.execute('selectwallet', ['wallet2']);


### PR DESCRIPTION
This change adds the option to (optionally) pick which address will be used to submit a bid.

```sh
hsw-rpc sendbid $name $amount $lockup [$address]
```