### PR TITLE
mnemonic: standardize phrase

### DIFF
--- a/lib/hd/mnemonic.js
+++ b/lib/hd/mnemonic.js
@@ -34,7 +34,7 @@ class Mnemonic extends bio.Struct {
    * @constructor
    * @param {Object} options
    * @param {Number?} options.bit - Bits of entropy (Must
-   * be a multiple of 8) (default=128).
+   * be a multiple of 8) (default=256).
    * @param {Buffer?} options.entropy - Entropy bytes. Will
    * be generated with `options.bits` bits of entropy
    * if not present.
@@ -259,7 +259,12 @@ class Mnemonic extends bio.Struct {
     this.bits = bits;
     this.language = lang;
     this.entropy = entropy;
-    this.phrase = phrase;
+
+    // Japanese likes double-width spaces.
+    if (this.language === 'japanese')
+      this.phrase = words.join('\u3000');
+    else
+      this.phrase = words.join(' ');
 
     return this;
   }

--- a/test/mnemonic-test.js
+++ b/test/mnemonic-test.js
@@ -61,4 +61,25 @@ describe('Mnemonic', function() {
     assert.strictEqual(m2.language, m1.language);
     assert.bufferEqual(m2.toSeed(), m1.toSeed());
   });
+
+  it('should standardize phrase', () => {
+    for (const language of Object.keys(tests)) {
+      const test = tests[language];
+
+      // modified phrase contains new lines before every space
+      const phrase = test[0][1];
+      const phraseWithNl = phrase.replace(/(\s|\u3000)/g, '\n$&');
+
+      // ensure new lines are added
+      assert(!phrase.includes('\n'));
+      assert(phraseWithNl.includes('\n'));
+
+      const m1 = Mnemonic.fromPhrase(phrase);
+      const m2 = Mnemonic.fromPhrase(phraseWithNl);
+
+      // Both mnemonics should have same phrase without new lines
+      assert(m1.getPhrase() === m2.getPhrase());
+      assert(!m1.getPhrase().includes('\n'));
+    }
+  });
 });


### PR DESCRIPTION
`Mnemonic` verifies words by stripping each word, but stores phrase user input as-is.

![image](https://user-images.githubusercontent.com/5113343/172454782-87454e1b-3966-4c8e-8343-67449b6cc5d6.png)

And when `.toSeed()` is used by HD key: https://github.com/handshake-org/hsd/blob/ba949f348c58ec6a6a6231f411fe3caa7c5e7b80/lib/hd/private.js#L460
the new lines are included and these two phrases are considered different and create different wallets.

For context, a bob user faced this and got two different wallets.

This commit saves the validated words -> phrase instead of the phrase passed as argument.
Added a test that covers both single space and `\u3000` japanese space.