### PR TITLE
Restart compaction if full node quit before compaction finished.

### DIFF
--- a/lib/blockchain/chaindb.js
+++ b/lib/blockchain/chaindb.js
@@ -995,7 +995,6 @@ class ChainDB {
     // If the tree data gets out of sync or corrupted
     // the chain database knows where to resync the tree from.
     this.start();
-    this.pendingTreeState.compact(entry.treeRoot, entry.height);
 
     // Note: the tree root commit height is always one block before its
     // appearence in a header.
@@ -1031,6 +1030,15 @@ class ChainDB {
 
     // Reset in-memory tree delta
     this.txn = this.tree.txn();
+
+    // Mark tree compaction complete
+    this.start();
+    this.pendingTreeState.compact(entry.treeRoot, entry.height);
+    this.put(layout.s.encode(), this.pendingTreeState.commit(
+      entry.treeRoot,
+      entry.height - 1
+    ));
+    await this.commit();
   }
 
   /**


### PR DESCRIPTION
If user kills the process before compaction is done on open, restarted node wont restart the compaction process until next interval. This makes sure we retry compaction after restart. If user somehow decided not to compact anymore and that's the reason of killing the process, they can just disable the compaction flag.