### PR TITLE
net: fixes for SPV

### DIFF
--- a/lib/net/peer.js
+++ b/lib/net/peer.js
@@ -1083,9 +1083,6 @@ class Peer extends EventEmitter {
       return;
 
     switch (packet.type) {
-      case packetTypes.MEMPOOL:
-        this.request(packetTypes.INV, timeout);
-        break;
       case packetTypes.GETBLOCKS:
         if (!this.options.isFull())
           this.request(packetTypes.INV, timeout);

--- a/lib/net/pool.js
+++ b/lib/net/pool.js
@@ -2867,7 +2867,8 @@ class Pool extends EventEmitter {
       items.push(new InvItem(invTypes.TX, hash));
 
     this.logger.debug(
-      'Sending mempool snapshot (%s).',
+      'Peer requested mempool snapshot, queing %d items (%s).',
+      items.length,
       peer.hostname());
 
     peer.queueInv(items);

--- a/lib/net/pool.js
+++ b/lib/net/pool.js
@@ -783,6 +783,11 @@ class Pool extends EventEmitter {
       if (!force && peer.syncing)
         continue;
 
+      if (force) {
+        peer.lastTip = consensus.ZERO_HASH;
+        peer.lastStop = consensus.ZERO_HASH;
+      }
+
       this.sendLocator(locator, peer);
     }
   }

--- a/lib/protocol/networks.js
+++ b/lib/protocol/networks.js
@@ -591,7 +591,7 @@ main.selfConnect = false;
  * @const {Boolean}
  */
 
-main.requestMempool = false;
+main.requestMempool = true;
 
 /**
  * DNSSEC ownership prefix.
@@ -749,7 +749,7 @@ testnet.identityKey = null;
 
 testnet.selfConnect = false;
 
-testnet.requestMempool = false;
+testnet.requestMempool = true;
 
 testnet.claimPrefix = 'hns-testnet:';
 
@@ -1042,7 +1042,7 @@ simnet.identityKey = Buffer.from(
 
 simnet.selfConnect = true;
 
-simnet.requestMempool = false;
+simnet.requestMempool = true;
 
 simnet.claimPrefix = 'hns-simnet:';
 


### PR DESCRIPTION
Related (at least partially) to #705.

This fixes 2 things:

### 1. Mempool
- Nodes always expect a response when they ask for mempool
- If mempool is empty, another peer will not send any response, so the requesting node thinks the peer is stalling and disconnects after timeout (30 secs).
- **To fix:** removed mempool packet from addTimeout so the node doesn't wait for a response
- Also changed `requestMempool` to `true` on all networks (was only for regtest before). This makes SPV nodes request mempool on connecting to loader peers.

### 2. SendGetBlocks
- Once a chain is reset, it tells the pool to force resync.
- But, `sendGetBlocks` has a check to see if it's a repeat request (if the `tip` and `stop` match the last time it had sent `getBlocks` to that peer)
- If it matches, then `getBlocks` is not sent and we don't get the blocks, chain doesn't get blocks, walletdb doesn't get txs, no block connect events are emitted, etc.
- **To fix:** The peer's `lastTip` and `lastStop` are reset so that `sendGetBlocks` will not see it as a repeat request.

---

Added a test to `net-spv-test.js` since that seemed the most relevant (will separate it into a different file if needed).
All tests pass, but this PR probably needs more review/testing since it changes `net` code.