### PR TITLE
feat(Docker): publish docker images to ghcr.io and DockerHub

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,53 @@
+name: Docker
+
+on:
+  push:
+    branches:
+      - master
+    tags:
+      - '*'
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: |
+            ghcr.io/${{ github.repository }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=raw,value=latest,enable=${{ github.ref != 'refs/heads/master' }}
+            type=edge
+          flavor: |
+            latest=false
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Login to GHCR
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -20,6 +20,7 @@ jobs:
         uses: docker/metadata-action@v4
         with:
           images: |
+            ${{ secrets.DOCKERHUB_ACCOUNT }}/hsd
             ghcr.io/${{ github.repository }}
           tags: |
             type=semver,pattern={{version}}
@@ -35,6 +36,12 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Login to GHCR
         uses: docker/login-action@v2

--- a/docs/install.md
+++ b/docs/install.md
@@ -96,6 +96,13 @@ $ COMMIT=$(git rev-parse --short HEAD)
 $ docker build -t hsd:$VERSION-$COMMIT .
 ```
 
+### GitHub Hosted images
+
+Baked images are available [here](https://github.com/handshake-org/hsd/pkgs/container/hsd).
+```
+docker pull ghcr.io/handshake-org/hsd:latest
+```
+
 ### Running a container
 
 To start a container named `hsd` on a `regtest` network with an exposed


### PR DESCRIPTION
The images will be published to ghcr.io and available [here](https://github.com/handshake-org/hsd/packages).

Each new git tag will generate/replace:
Example tag: `v5.6.7`
* handshake-org/hsd:latest
* handshake-org/hsd:5.6.7
* handshake-org/hsd:5.6
* handshake-org/hsd:5

Merges to `master` generates:
* handshake-org/hsd:edge

Depends on #755 