### PR TITLE
hostlist: only return MANUAL addrs in getLocal() for all networks

### DIFF
--- a/lib/net/hostlist.js
+++ b/lib/net/hostlist.js
@@ -1033,11 +1033,9 @@ class HostList {
 
     if (!src) {
       for (const dest of this.local.values()) {
-        if (this.network.type === 'main') {
-          // Disable everything else for now.
-          if (dest.type < HostList.scores.UPNP)
-            continue;
-        }
+        // Disable everything except MANUAL
+        if (dest.type < HostList.scores.UPNP)
+          continue;
 
         if (dest.addr.hasKey())
           continue;
@@ -1052,11 +1050,9 @@ class HostList {
     }
 
     for (const dest of this.local.values()) {
-      if (this.network.type === 'main') {
-        // Disable everything else for now.
-        if (dest.type < HostList.scores.UPNP)
-          continue;
-      }
+      // Disable everything except MANUAL
+      if (dest.type < HostList.scores.UPNP)
+        continue;
 
       if (dest.addr.hasKey())
         continue;


### PR DESCRIPTION
Main goal here is to fix tests that fail locally if the platform has a public ipv6 address. That address may get returned by `getLocal()` even if no `public-host` was set.