### PR TITLE
txdb lock balance accounting fixes.

### DIFF
--- a/lib/primitives/covenant.js
+++ b/lib/primitives/covenant.js
@@ -618,7 +618,8 @@ class Covenant extends bio.Struct {
    */
 
   format() {
-    return `<Covenant: ${this.type}:${this.toString()}>`;
+    const type = typesByVal[this.type] || this.type;
+    return `<Covenant: ${type}:${this.toString()}>`;
   }
 
   /**

--- a/lib/wallet/account.js
+++ b/lib/wallet/account.js
@@ -309,26 +309,28 @@ class Account extends bio.Struct {
 
   /**
    * Create a new receiving address (increments receiveDepth).
-   * @returns {WalletKey}
+   * @param {Batch} b
+   * @returns {Promise<WalletKey>}
    */
 
-  createReceive() {
-    return this.createKey(0);
+  createReceive(b) {
+    return this.createKey(b, 0);
   }
 
   /**
    * Create a new change address (increments changeDepth).
-   * @returns {WalletKey}
+   * @param {Batch} b
+   * @returns {Promise<WalletKey>}
    */
 
-  createChange() {
-    return this.createKey(1);
+  createChange(b) {
+    return this.createKey(b, 1);
   }
 
   /**
    * Create a new address (increments depth).
    * @param {Boolean} change
-   * @returns {Promise} - Returns {@link WalletKey}.
+   * @returns {Promise<WalletKey>}
    */
 
   async createKey(b, branch) {
@@ -516,37 +518,37 @@ class Account extends bio.Struct {
    * @returns {Promise} - Returns {@link WalletKey}.
    */
 
-  async syncDepth(b, receive, change) {
+  async syncDepth(b, receiveDepth, changeDepth) {
     let derived = false;
     let result = null;
 
-    if (receive > this.receiveDepth) {
+    if (receiveDepth > this.receiveDepth) {
       const depth = this.receiveDepth + this.lookahead;
 
-      assert(receive <= depth + 1);
+      assert(receiveDepth <= depth + 1);
 
-      for (let i = depth; i < receive + this.lookahead; i++) {
+      for (let i = depth; i < receiveDepth + this.lookahead; i++) {
         const key = this.deriveReceive(i);
         await this.saveKey(b, key);
         result = key;
       }
 
-      this.receiveDepth = receive;
+      this.receiveDepth = receiveDepth;
 
       derived = true;
     }
 
-    if (change > this.changeDepth) {
+    if (changeDepth > this.changeDepth) {
       const depth = this.changeDepth + this.lookahead;
 
-      assert(change <= depth + 1);
+      assert(changeDepth <= depth + 1);
 
-      for (let i = depth; i < change + this.lookahead; i++) {
+      for (let i = depth; i < changeDepth + this.lookahead; i++) {
         const key = this.deriveChange(i);
         await this.saveKey(b, key);
       }
 
-      this.changeDepth = change;
+      this.changeDepth = changeDepth;
 
       derived = true;
     }

--- a/lib/wallet/layout.js
+++ b/lib/wallet/layout.js
@@ -73,7 +73,7 @@ exports.wdb = {
  *   C[account][hash][index] -> dummy (coin by account)
  *   b[height] -> block record
  *   A[nameHash] -> Name State
- *   U[hash] -> Nme Undo
+ *   U[hash] -> Name Undo
  *   i[nameHash][hash][index] -> BlindBid record
  *   B[nameHash][hash][index] -> BidReveal record
  *   v[blindHash] -> BlindValue record

--- a/lib/wallet/layout.js
+++ b/lib/wallet/layout.js
@@ -72,6 +72,12 @@ exports.wdb = {
  *   H[account][height][hash] -> dummy (tx by height + account)
  *   C[account][hash][index] -> dummy (coin by account)
  *   b[height] -> block record
+ *   A[nameHash] -> Name State
+ *   U[hash] -> Nme Undo
+ *   i[nameHash][hash][index] -> BlindBid record
+ *   B[nameHash][hash][index] -> BidReveal record
+ *   v[blindHash] -> BlindValue record
+ *   o[nameHash] -> TX Hash (Opens)
  */
 
 exports.txdb = {
@@ -91,16 +97,10 @@ exports.txdb = {
   H: bdb.key('H', ['uint32', 'uint32', 'hash256']),
   C: bdb.key('C', ['uint32', 'hash256', 'uint32']),
   b: bdb.key('b', ['uint32']),
-  // Name records
   A: bdb.key('A', ['hash256']),
-  // Name undo records
   U: bdb.key('U', ['hash256']),
-  // Bids
   i: bdb.key('i', ['hash256', 'hash256', 'uint32']),
-  // Reveals
   B: bdb.key('B', ['hash256', 'hash256', 'uint32']),
-  // Blinds
   v: bdb.key('v', ['hash256']),
-  // Opens
   o: bdb.key('o', ['hash256'])
 };

--- a/lib/wallet/txdb.js
+++ b/lib/wallet/txdb.js
@@ -1011,18 +1011,18 @@ class TXDB {
       if (!path)
         continue;
 
-      // If the first time we see a TX is in a block
-      // (i.e. during a rescan) update the "unconfirmed" locked balance
-      // before updating the "confirmed" locked balance.
-      if (height !== -1)
-        this.lockBalances(state, output, path, -1);
-
-      this.lockBalances(state, output, path, height);
-
       details.setOutput(i, path);
 
       const credit = Credit.fromTX(tx, i, height);
       credit.own = own;
+
+      // If the first time we see a TX is in a block
+      // (i.e. during a rescan) update the "unconfirmed" locked balance
+      // before updating the "confirmed" locked balance.
+      if (height !== -1)
+        this.lockBalances(state, credit, path, -1);
+
+      this.lockBalances(state, credit, path, height);
 
       state.tx(path, 1);
       state.coin(path, 1);
@@ -1196,8 +1196,6 @@ class TXDB {
       if (!path)
         continue;
 
-      this.lockBalances(state, output, path, height);
-
       details.setOutput(i, path);
 
       let credit = await this.getCredit(hash, i);
@@ -1217,8 +1215,10 @@ class TXDB {
         state.unconfirmed(path, credit.coin.value);
 
         // Add unconfirmed balances.
-        this.lockBalances(state, output, path, -1);
+        this.lockBalances(state, credit, path, -1);
       }
+
+      this.lockBalances(state, credit, path, height);
 
       // Credits spent in the mempool add an
       // undo coin for ease. If this credit is
@@ -1328,7 +1328,7 @@ class TXDB {
         state.coin(path, 1);
         state.unconfirmed(path, coin.value);
 
-        this.lockBalances(state, coin, path, height);
+        this.lockBalances(state, credit, path, height);
 
         if (block)
           state.confirmed(path, coin.value);
@@ -1515,7 +1515,7 @@ class TXDB {
   /**
    * Unconfirm a transaction. Necessary after a reorg.
    * @param {TXRecord} wtx
-   * @returns {Promise}
+   * @returns {Promise<Details>}
    */
 
   async disconnect(wtx, block) {
@@ -1527,6 +1527,8 @@ class TXDB {
     assert(block);
 
     wtx.unsetBlock();
+
+    let own = false;
 
     if (!tx.isCoinbase()) {
       // We need to reconnect the coins. Start
@@ -1549,7 +1551,7 @@ class TXDB {
         const path = await this.getPath(coin);
         assert(path);
 
-        this.lockBalances(state, coin, path, height);
+        this.lockBalances(state, credit, path, height);
 
         details.setInput(i, path, coin);
 
@@ -1559,6 +1561,7 @@ class TXDB {
         // as spent in the mempool instead.
         credit.spent = true;
         await this.saveCredit(b, credit, path);
+        own = true;
       }
     }
 
@@ -1571,12 +1574,42 @@ class TXDB {
       if (!path)
         continue;
 
-      const credit = await this.getCredit(hash, i);
+      let credit = await this.getCredit(hash, i);
 
       // Potentially update undo coin height.
+      // We may not have credit because it was spent in some unconfirmed tx,
+      // not because we just discovered.
       if (!credit) {
-        await this.updateSpentCoin(b, tx, i, height);
-        continue;
+        // If it is already spent and is ours, no need to add balances.
+        if (await this.updateSpentCoin(b, tx, i, height))
+          continue;
+
+        credit = Credit.fromTX(tx, i, -1);
+        credit.own = own;
+
+        // Is coin spent ? (tracking for double spends)
+        const spent = await this.getSpent(hash, i);
+
+        // If we were tracking coins as spent,
+        // it means it does not introduce any coin
+        // and does not affect the balance.
+        if (spent) {
+          credit.spent = true;
+          this.spendCredit(b, credit, tx, i);
+          details.setOutput(i, path);
+          continue;
+        }
+
+        // If it is not spent, then coin is in unconfirmed state.
+        state.coin(path, 1);
+        state.unconfirmed(path, output.value);
+
+        // will be subtracted below.
+        state.confirmed(path, output.value);
+
+        this.lockBalances(state, credit, path, -1);
+        // will be unlocked below
+        this.lockBalances(state, credit, path, height);
       }
 
       this.unlockBalances(state, credit, path, height);
@@ -1709,13 +1742,13 @@ class TXDB {
    * Inserting or confirming: TX outputs.
    * Removing or undoing: Coins spent by the wallet in tx inputs.
    * @param {State} state
-   * @param {Coin|Output} coin
+   * @param {Credit} credit
    * @param {Path} path
    * @param {Number} height
    */
 
-  lockBalances(state, coin, path, height) {
-    const {value, covenant} = coin;
+  lockBalances(state, credit, path, height) {
+    const {value, covenant} = credit.coin;
 
     switch (covenant.type) {
       case types.CLAIM:    // output is locked until REGISTER
@@ -3003,7 +3036,7 @@ class TXDB {
    * @param {TX} tx - Sending transaction.
    * @param {Number} index
    * @param {Number} height
-   * @returns {Promise}
+   * @returns {Promise<Boolean>}
    */
 
   async updateSpentCoin(b, tx, index, height) {
@@ -3011,16 +3044,18 @@ class TXDB {
     const spent = await this.getSpent(prevout.hash, prevout.index);
 
     if (!spent)
-      return;
+      return false;
 
+    // Was spent coin ours or are we tracking it for double spends.
     const coin = await this.getSpentCoin(spent, prevout);
 
     if (!coin)
-      return;
+      return false;
 
     coin.height = height;
 
     b.put(layout.d.encode(spent.hash, spent.index), coin.encode());
+    return true;
   }
 
   /**
@@ -3327,6 +3362,7 @@ class BalanceDelta {
  * @alias module:wallet.Credit
  * @property {Coin} coin
  * @property {Boolean} spent
+ * @property {Boolean} own
  */
 
 class Credit extends bio.Struct {
@@ -3334,7 +3370,7 @@ class Credit extends bio.Struct {
    * Create a credit.
    * @constructor
    * @param {Coin} coin
-   * @param {Boolean?} spent
+   * @param {Boolean} [spent = false]
    */
 
   constructor(coin, spent) {

--- a/lib/wallet/txdb.js
+++ b/lib/wallet/txdb.js
@@ -24,6 +24,10 @@ const NameUndo = require('../covenants/undo');
 const {TXRecord} = records;
 const {types} = rules;
 
+/**
+ * @typedef {import('./walletdb')} WalletDB
+ */
+
 /*
  * Constants
  */
@@ -33,6 +37,7 @@ const EMPTY = Buffer.alloc(0);
 /**
  * TXDB
  * @alias module:wallet.TXDB
+ * @property {WalletDB} wdb
  */
 
 class TXDB {
@@ -170,30 +175,33 @@ class TXDB {
    * Write input record.
    * @param {TX} tx
    * @param {Number} index
+   * @returns {Promise}
    */
 
   async writeInput(b, tx, index) {
     const prevout = tx.inputs[index].prevout;
     const spender = Outpoint.fromTX(tx, index);
     b.put(layout.s.encode(prevout.hash, prevout.index), spender.encode());
-    return this.addOutpointMap(b, prevout.hash, prevout.index);
+    await this.addOutpointMap(b, prevout.hash, prevout.index);
   }
 
   /**
    * Remove input record.
    * @param {TX} tx
    * @param {Number} index
+   * @returns {Promise}
    */
 
   async removeInput(b, tx, index) {
     const prevout = tx.inputs[index].prevout;
     b.del(layout.s.encode(prevout.hash, prevout.index));
-    return this.removeOutpointMap(b, prevout.hash, prevout.index);
+    await this.removeOutpointMap(b, prevout.hash, prevout.index);
   }
 
   /**
    * Update wallet balance.
    * @param {BalanceDelta} state
+   * @returns {Promise<Balance>}
    */
 
   async updateBalance(b, state) {
@@ -207,6 +215,7 @@ class TXDB {
    * Update account balance.
    * @param {Number} acct
    * @param {Balance} delta
+   * @returns {Promise<Balance>}
    */
 
   async updateAccountBalance(b, acct, delta) {
@@ -217,10 +226,10 @@ class TXDB {
   }
 
   /**
-   * Test a whether a coin has been spent.
+   * Get a spent coin outpoint.
    * @param {Hash} hash
    * @param {Number} index
-   * @returns {Promise} - Returns Boolean.
+   * @returns {Promise<Outpoint>}
    */
 
   async getSpent(hash, index) {
@@ -236,7 +245,7 @@ class TXDB {
    * Test a whether a coin has been spent.
    * @param {Hash} hash
    * @param {Number} index
-   * @returns {Promise} - Returns Boolean.
+   * @returns {Promise<Boolean>}
    */
 
   isSpent(hash, index) {
@@ -440,7 +449,7 @@ class TXDB {
   /**
    * Test whether we have a name.
    * @param {Buffer} nameHash
-   * @returns {Boolean}
+   * @returns {Promise<Boolean>}
    */
 
   async hasNameState(nameHash) {
@@ -450,7 +459,7 @@ class TXDB {
   /**
    * Get a name state if present.
    * @param {Buffer} nameHash
-   * @returns {NameState}
+   * @returns {Promise<NameState>}
    */
 
   async getNameState(nameHash) {
@@ -467,7 +476,7 @@ class TXDB {
 
   /**
    * Get all names.
-   * @returns {NameState[]}
+   * @returns {Promise<NameState[]>}
    */
 
   async getNames() {
@@ -493,7 +502,7 @@ class TXDB {
    * Test whether we have a bid.
    * @param {Buffer} nameHash
    * @param {Outpoint} outpoint
-   * @returns {Boolean}
+   * @returns {Promise<Boolean>}
    */
 
   async hasBid(nameHash, outpoint) {
@@ -504,8 +513,8 @@ class TXDB {
   /**
    * Get a bid if present.
    * @param {Buffer} nameHash
-   * @param {Outpoint} outpoint
-   * @returns {BlindBid}
+   * @param {Outpoint|Coin} outpoint
+   * @returns {Promise<BlindBid>}
    */
 
   async getBid(nameHash, outpoint) {
@@ -693,7 +702,7 @@ class TXDB {
   /**
    * Remove all reveals by name.
    * @param {Object} b
-   * @param {Buffer} nameHash
+   * @param {Promise<Buffer>} nameHash
    */
 
   async removeReveals(b, nameHash) {
@@ -708,7 +717,7 @@ class TXDB {
   /**
    * Test whether a blind value is present.
    * @param {Buffer} blind - Blind hash.
-   * @returns {Boolean}
+   * @returns {Promise<Boolean>}
    */
 
   async hasBlind(blind) {
@@ -718,7 +727,7 @@ class TXDB {
   /**
    * Get a blind value if present.
    * @param {Buffer} blind - Blind hash.
-   * @returns {BlindValue}
+   * @returns {Promise<BlindValue>}
    */
 
   async getBlind(blind) {
@@ -749,6 +758,7 @@ class TXDB {
    * Save blind value.
    * @param {Buffer} blind
    * @param {Object} options
+   * @returns {Promise}
    */
 
   async saveBlind(blind, options) {
@@ -817,7 +827,7 @@ class TXDB {
    * Test whether the transaction
    * has a duplicate open.
    * @param {TX}
-   * @returns {Boolean}
+   * @returns {Promise<Boolean>}
    */
 
   async isDoubleOpen(tx) {
@@ -2672,7 +2682,7 @@ class TXDB {
   /**
    * Fill a transaction with coins (all historical coins).
    * @param {TX} tx
-   * @returns {Promise} - Returns {@link TX}.
+   * @returns {Promise<Credit[]>}
    */
 
   async getSpentCredits(tx) {
@@ -2725,7 +2735,7 @@ class TXDB {
   /**
    * Get coins by account.
    * @param {Number} acct
-   * @returns {Promise} - Returns {@link Coin}[].
+   * @returns {Promise<Coin[]>}
    */
 
   async getAccountCoins(acct) {
@@ -2770,7 +2780,7 @@ class TXDB {
   /**
    * Get a coin viewpoint.
    * @param {TX} tx
-   * @returns {Promise} - Returns {@link CoinView}.
+   * @returns {Promise<CoinView>}
    */
 
   async getCoinView(tx) {
@@ -2819,7 +2829,7 @@ class TXDB {
   /**
    * Get transaction.
    * @param {Hash} hash
-   * @returns {Promise} - Returns {@link TX}.
+   * @returns {Promise<TXRecord>}
    */
 
   async getTX(hash) {
@@ -2834,7 +2844,7 @@ class TXDB {
   /**
    * Get transaction details.
    * @param {Hash} hash
-   * @returns {Promise} - Returns {@link TXDetails}.
+   * @returns {Promise<Details>}
    */
 
   async getDetails(hash) {
@@ -2848,8 +2858,8 @@ class TXDB {
 
   /**
    * Convert transaction to transaction details.
-   * @param {TXRecord[]} wtxs
-   * @returns {Promise}
+   * @param {TXRecord[]|TXRecord} wtxs
+   * @returns {Promise<Details[]|Details>}
    */
 
   async toDetails(wtxs) {
@@ -2874,7 +2884,7 @@ class TXDB {
    * Convert transaction to transaction details.
    * @private
    * @param {TXRecord} wtx
-   * @returns {Promise}
+   * @returns {Promise<Details>}
    */
 
   async _toDetails(wtx) {
@@ -2906,7 +2916,7 @@ class TXDB {
   /**
    * Test whether the database has a transaction.
    * @param {Hash} hash
-   * @returns {Promise} - Returns Boolean.
+   * @returns {Promise<Boolean>}
    */
 
   hasTX(hash) {
@@ -2917,7 +2927,7 @@ class TXDB {
    * Get coin.
    * @param {Hash} hash
    * @param {Number} index
-   * @returns {Promise} - Returns {@link Coin}.
+   * @returns {Promise<Coin>}
    */
 
   async getCoin(hash, index) {
@@ -2933,7 +2943,7 @@ class TXDB {
    * Get coin.
    * @param {Hash} hash
    * @param {Number} index
-   * @returns {Promise} - Returns {@link Coin}.
+   * @returns {Promise<Credit>}
    */
 
   async getCredit(hash, index) {
@@ -2953,7 +2963,7 @@ class TXDB {
    * Get spender coin.
    * @param {Outpoint} spent
    * @param {Outpoint} prevout
-   * @returns {Promise} - Returns {@link Coin}.
+   * @returns {Promise<Coin>}
    */
 
   async getSpentCoin(spent, prevout) {
@@ -2973,7 +2983,7 @@ class TXDB {
   /**
    * Test whether the database has a spent coin.
    * @param {Outpoint} spent
-   * @returns {Promise} - Returns {@link Coin}.
+   * @returns {Promise<Boolean>}
    */
 
   hasSpentCoin(spent) {
@@ -3008,7 +3018,7 @@ class TXDB {
   /**
    * Test whether the database has a transaction.
    * @param {Hash} hash
-   * @returns {Promise} - Returns Boolean.
+   * @returns {Promise<Boolean>}
    */
 
   async hasCoin(hash, index) {
@@ -3017,8 +3027,8 @@ class TXDB {
 
   /**
    * Calculate balance.
-   * @param {Number?} account
-   * @returns {Promise} - Returns {@link Balance}.
+   * @param {Number} [account]
+   * @returns {Promise<Balance>}
    */
 
   async getBalance(acct) {
@@ -3032,7 +3042,7 @@ class TXDB {
 
   /**
    * Calculate balance.
-   * @returns {Promise} - Returns {@link Balance}.
+   * @returns {Promise<Balance>}
    */
 
   async getWalletBalance() {
@@ -3047,7 +3057,7 @@ class TXDB {
   /**
    * Calculate balance by account.
    * @param {Number} acct
-   * @returns {Promise} - Returns {@link Balance}.
+   * @returns {Promise<Balance>}
    */
 
   async getAccountBalance(acct) {
@@ -3065,7 +3075,7 @@ class TXDB {
    * Zap pending transactions older than `age`.
    * @param {Number} acct
    * @param {Number} age - Age delta.
-   * @returns {Promise}
+   * @returns {Promise<Hash[]>}
    */
 
   async zap(acct, age) {

--- a/lib/wallet/txdb.js
+++ b/lib/wallet/txdb.js
@@ -1205,6 +1205,9 @@ class TXDB {
         // Add coin to "unconfirmed" balance (which includes confirmed coins)
         state.coin(path, 1);
         state.unconfirmed(path, credit.coin.value);
+
+        // Add unconfirmed balances.
+        this.lockBalances(state, output, path, -1);
       }
 
       // Credits spent in the mempool add an

--- a/lib/wallet/txdb.js
+++ b/lib/wallet/txdb.js
@@ -972,9 +972,9 @@ class TXDB {
         // (i.e. during a rescan) update the "unconfirmed" unlocked balance
         // before updating the "confirmed" locked balance.
         if (height !== -1)
-          this.unlockBalances(state, coin, path, -1);
+          this.unlockBalances(state, credit, path, -1);
 
-        this.unlockBalances(state, coin, path, height);
+        this.unlockBalances(state, credit, path, height);
 
         if (!block) {
           // If the tx is not mined, we do not
@@ -1168,7 +1168,7 @@ class TXDB {
         assert(path);
         own = true;
 
-        this.unlockBalances(state, coin, path, height);
+        this.unlockBalances(state, credit, path, height);
 
         details.setInput(i, path, coin);
 
@@ -1349,11 +1349,19 @@ class TXDB {
       if (!path)
         continue;
 
-      this.unlockBalances(state, output, path, height);
+      let credit = await this.getCredit(hash, i);
+
+      if (!credit) {
+        credit = Credit.fromTX(tx, i, height);
+        await this.removeCredit(b, credit, path);
+        continue;
+      }
+
+      this.unlockBalances(state, credit, path, height);
 
       details.setOutput(i, path);
 
-      const credit = Credit.fromTX(tx, i, height);
+      credit = Credit.fromTX(tx, i, height);
 
       state.tx(path, -1);
       state.coin(path, -1);
@@ -1563,8 +1571,6 @@ class TXDB {
       if (!path)
         continue;
 
-      this.unlockBalances(state, output, path, height);
-
       const credit = await this.getCredit(hash, i);
 
       // Potentially update undo coin height.
@@ -1572,6 +1578,8 @@ class TXDB {
         await this.updateSpentCoin(b, tx, i, height);
         continue;
       }
+
+      this.unlockBalances(state, credit, path, height);
 
       if (credit.spent)
         await this.updateSpentCoin(b, tx, i, height);
@@ -1736,13 +1744,13 @@ class TXDB {
    * Inserting or confirming: Coins spent by the wallet in TX inputs.
    * Removing or undoing: TX outputs.
    * @param {State} state
-   * @param {Coin|Output} coin
+   * @param {Credit} credit
    * @param {Path} path
    * @param {Number} height
    */
 
-  unlockBalances(state, coin, path, height) {
-    const {value, covenant} = coin;
+  unlockBalances(state, credit, path, height) {
+    const {value, covenant} = credit.coin;
 
     switch (covenant.type) {
       case types.CLAIM:    // output is locked until REGISTER

--- a/lib/wallet/txdb.js
+++ b/lib/wallet/txdb.js
@@ -1705,8 +1705,7 @@ class TXDB {
       case types.RENEW:
       case types.TRANSFER:
       case types.FINALIZE:
-      case types.REVOKE:
-      {
+      case types.REVOKE: {
         if (height === -1)
           state.ulocked(path, value);
         else
@@ -1714,7 +1713,7 @@ class TXDB {
         break;
       }
 
-      case types.REDEEM:   // noop: already unlocked by the BID in the input
+      case types.REDEEM:   // noop: already unlocked by the REVEAL in the input
         break;
     }
   }
@@ -1741,15 +1740,15 @@ class TXDB {
       case types.RENEW:
       case types.TRANSFER:
       case types.FINALIZE:
-      case types.REVOKE:
-      {
+      case types.REVOKE: {
         if (height === -1)
           state.ulocked(path, -value);
         else
           state.clocked(path, -value);
         break;
       }
-      case types.REDEEM:   // noop: already unlocked by the BID in the input
+
+      case types.REDEEM:   // noop: already unlocked by the REVEAL in the input
         break;
     }
   }

--- a/lib/wallet/txdb.js
+++ b/lib/wallet/txdb.js
@@ -958,17 +958,13 @@ class TXDB {
         state.coin(path, -1);
         state.unconfirmed(path, -coin.value);
 
-        // FINALIZE is a special case: locked coins _leave_ the wallet.
-        if (tx.output(i) && tx.covenant(i).isFinalize()) {
-          if (!block) {
-            state.ulocked(path, -tx.outputs[i].value);
-          } else {
-            state.clocked(path, -tx.outputs[i].value);
-            // This is the first time we've seen this tx and it is in a block
-            // (probably from a rescan). Update unconfirmed locked balance also.
-            state.ulocked(path, -tx.outputs[i].value);
-          }
-        }
+        // If the first time we see a TX is in a block
+        // (i.e. during a rescan) update the "unconfirmed" unlocked balance
+        // before updating the "confirmed" locked balance.
+        if (height !== -1)
+          this.unlockBalances(state, coin, path, -1);
+
+        this.unlockBalances(state, coin, path, height);
 
         if (!block) {
           // If the tx is not mined, we do not
@@ -1009,9 +1005,9 @@ class TXDB {
       // (i.e. during a rescan) update the "unconfirmed" locked balance
       // before updating the "confirmed" locked balance.
       if (height !== -1)
-        await this.lockBalances(b, state, tx, i, path, -1);
+        this.lockBalances(state, output, path, -1);
 
-      await this.lockBalances(b, state, tx, i, path, height);
+      this.lockBalances(state, output, path, height);
 
       details.setOutput(i, path);
 
@@ -1162,6 +1158,8 @@ class TXDB {
         assert(path);
         own = true;
 
+        this.unlockBalances(state, coin, path, height);
+
         details.setInput(i, path, coin);
 
         if (resolved) {
@@ -1173,10 +1171,6 @@ class TXDB {
         // entirely, now that we know it's also
         // been removed on-chain.
         state.confirmed(path, -coin.value);
-
-        // FINALIZE is a special case: locked coins _leave_ the wallet.
-        if (tx.output(i) && tx.covenant(i).isFinalize())
-          state.clocked(path, -tx.outputs[i].value);
 
         await this.removeCredit(b, credit, path);
 
@@ -1192,7 +1186,7 @@ class TXDB {
       if (!path)
         continue;
 
-      await this.lockBalances(b, state, tx, i, path, height);
+      this.lockBalances(state, output, path, height);
 
       details.setOutput(i, path);
 
@@ -1321,14 +1315,7 @@ class TXDB {
         state.coin(path, 1);
         state.unconfirmed(path, coin.value);
 
-        // FINALIZE is a special case: locked coins _leave_ the wallet.
-        // In this case a TX is erased, adding them back.
-        if (tx.output(i) && tx.covenant(i).isFinalize()) {
-          if (!block)
-            state.ulocked(path, tx.outputs[i].value);
-          else
-            state.clocked(path, tx.outputs[i].value);
-        }
+        this.lockBalances(state, coin, path, height);
 
         if (block)
           state.confirmed(path, coin.value);
@@ -1349,7 +1336,7 @@ class TXDB {
       if (!path)
         continue;
 
-      await this.unlockBalances(b, state, tx, i, path, height);
+      this.unlockBalances(state, output, path, height);
 
       details.setOutput(i, path);
 
@@ -1541,14 +1528,11 @@ class TXDB {
         const path = await this.getPath(coin);
         assert(path);
 
+        this.lockBalances(state, coin, path, height);
+
         details.setInput(i, path, coin);
 
         state.confirmed(path, coin.value);
-
-        // FINALIZE is a special case: locked coins _leave_ the wallet.
-        // In this case a TX is reversed, adding them back.
-        if (tx.output(i) && tx.covenant(i).isFinalize())
-            state.clocked(path, tx.outputs[i].value);
 
         // Resave the credit and mark it
         // as spent in the mempool instead.
@@ -1566,7 +1550,7 @@ class TXDB {
       if (!path)
         continue;
 
-      await this.unlockBalances(b, state, tx, i, path, height);
+      this.unlockBalances(state, output, path, height);
 
       const credit = await this.getCredit(hash, i);
 
@@ -1700,167 +1684,73 @@ class TXDB {
   }
 
   /**
-   * Lock balances according to covenants.
-   * @param {Object} b
+   * Lock balances according to covenant.
+   * Inserting or confirming: TX outputs.
+   * Removing or undoing: Coins spent by the wallet in tx inputs.
    * @param {State} state
-   * @param {TX} tx
-   * @param {Number} i
+   * @param {Coin|Output} coin
    * @param {Path} path
    * @param {Number} height
    */
 
-  async lockBalances(b, state, tx, i, path, height) {
-    const output = tx.outputs[i];
-    const covenant = output.covenant;
+  lockBalances(state, coin, path, height) {
+    const {value, covenant} = coin;
 
     switch (covenant.type) {
-      case types.CLAIM:
-      case types.BID: {
+      case types.CLAIM:    // output is locked until REGISTER
+      case types.BID:      // output is locked until REVEAL
+      case types.REVEAL:   // output is locked until REDEEM
+      case types.REGISTER: // output is now locked or "burned"
+      case types.UPDATE:   // output has been locked since REGISTER
+      case types.RENEW:
+      case types.TRANSFER:
+      case types.FINALIZE:
+      case types.REVOKE:
+      {
         if (height === -1)
-          state.ulocked(path, output.value);
+          state.ulocked(path, value);
         else
-          state.clocked(path, output.value);
+          state.clocked(path, value);
         break;
       }
 
-      case types.REVEAL: {
-        assert(i < tx.inputs.length);
-
-        const nameHash = covenant.getHash(0);
-        const prevout = tx.inputs[i].prevout;
-
-        const bb = await this.getBid(nameHash, prevout);
-        if (!bb)
-          break;
-
-        if (height === -1) {
-          state.ulocked(path, -bb.lockup);
-          state.ulocked(path, output.value);
-        } else {
-          state.clocked(path, -bb.lockup);
-          state.clocked(path, output.value);
-        }
-
+      case types.REDEEM:   // noop: already unlocked by the BID in the input
         break;
-      }
-
-      case types.REDEEM: {
-        if (height === -1)
-          state.ulocked(path, -output.value);
-        else
-          state.clocked(path, -output.value);
-        break;
-      }
-
-      case types.REGISTER: {
-        assert(i < tx.inputs.length);
-
-        const prevout = tx.inputs[i].prevout;
-
-        const coin = await this.getCoin(prevout.hash, prevout.index);
-        assert(coin);
-        assert(coin.covenant.isReveal() || coin.covenant.isClaim());
-
-        if (height === -1) {
-          state.ulocked(path, -coin.value);
-          state.ulocked(path, output.value);
-        } else {
-          state.clocked(path, -coin.value);
-          state.clocked(path, output.value);
-        }
-
-        break;
-      }
-
-      case types.FINALIZE: {
-        if (height === -1)
-          state.ulocked(path, output.value);
-        else
-          state.clocked(path, output.value);
-        break;
-      }
     }
   }
 
   /**
    * Unlock balances according to covenants.
-   * @param {Object} b
+   * Inserting or confirming: Coins spent by the wallet in TX inputs.
+   * Removing or undoing: TX outputs.
    * @param {State} state
-   * @param {TX} tx
-   * @param {Number} i
+   * @param {Coin|Output} coin
    * @param {Path} path
    * @param {Number} height
    */
 
-  async unlockBalances(b, state, tx, i, path, height) {
-    const output = tx.outputs[i];
-    const covenant = output.covenant;
+  unlockBalances(state, coin, path, height) {
+    const {value, covenant} = coin;
 
     switch (covenant.type) {
-      case types.CLAIM:
-      case types.BID: {
+      case types.CLAIM:    // output is locked until REGISTER
+      case types.BID:      // output is locked until REVEAL
+      case types.REVEAL:   // output is locked until REDEEM
+      case types.REGISTER: // output is now locked or "burned"
+      case types.UPDATE:   // output has been locked since REGISTER
+      case types.RENEW:
+      case types.TRANSFER:
+      case types.FINALIZE:
+      case types.REVOKE:
+      {
         if (height === -1)
-          state.ulocked(path, -output.value);
+          state.ulocked(path, -value);
         else
-          state.clocked(path, -output.value);
+          state.clocked(path, -value);
         break;
       }
-
-      case types.REVEAL: {
-        assert(i < tx.inputs.length);
-
-        const nameHash = covenant.getHash(0);
-        const prevout = tx.inputs[i].prevout;
-
-        const bb = await this.getBid(nameHash, prevout);
-        if (!bb)
-          break;
-
-        if (height === -1) {
-          state.ulocked(path, bb.lockup);
-          state.ulocked(path, -output.value);
-        } else {
-          state.clocked(path, bb.lockup);
-          state.clocked(path, -output.value);
-        }
-
+      case types.REDEEM:   // noop: already unlocked by the BID in the input
         break;
-      }
-
-      case types.REDEEM: {
-        if (height === -1)
-          state.ulocked(path, output.value);
-        else
-          state.clocked(path, output.value);
-        break;
-      }
-
-      case types.REGISTER: {
-        assert(i < tx.inputs.length);
-
-        const coins = await this.getSpentCoins(tx);
-        const coin = coins[i];
-        assert(coin);
-        assert(coin.covenant.isReveal() || coin.covenant.isClaim());
-
-        if (height === -1) {
-          state.ulocked(path, coin.value);
-          state.ulocked(path, -output.value);
-        } else {
-          state.clocked(path, coin.value);
-          state.clocked(path, -output.value);
-        }
-
-        break;
-      }
-
-      case types.FINALIZE: {
-        if (height === -1)
-          state.ulocked(path, -output.value);
-        else
-          state.clocked(path, -output.value);
-        break;
-      }
     }
   }
 

--- a/lib/wallet/wallet.js
+++ b/lib/wallet/wallet.js
@@ -1523,7 +1523,7 @@ class Wallet extends EventEmitter {
    * @param {Number|String} acct
    * @param {Boolean} force
    * @param {MTX?} mtx
-   * @returns {MTX}
+   * @returns {Promise<MTX>}
    */
 
   async makeOpen(name, force, acct, mtx) {
@@ -1653,7 +1653,7 @@ class Wallet extends EventEmitter {
    * @param {Number} lockup
    * @param {Number|String} acct
    * @param {MTX?} mtx
-   * @returns {MTX}
+   * @returns {Promise<MTX>}
    */
 
   async makeBid(name, value, lockup, acct, mtx) {
@@ -1861,7 +1861,7 @@ class Wallet extends EventEmitter {
    * @param {String} name
    * @param {(Number|String)?} acct
    * @param {MTX?} mtx
-   * @returns {MTX}
+   * @returns {Promise<MTX>}
    */
 
   async makeReveal(name, acct, mtx) {
@@ -2009,7 +2009,7 @@ class Wallet extends EventEmitter {
    * Make a reveal MTX.
    * @param {MTX?} mtx
    * @param {Number?} witnessSize
-   * @returns {MTX}
+   * @returns {Promise<MTX>}
    */
 
   async makeRevealAll(mtx, witnessSize) {
@@ -2144,7 +2144,7 @@ class Wallet extends EventEmitter {
    * @param {String} name
    * @param {(Number|String)?} acct
    * @param {MTX?} mtx
-   * @returns {MTX}
+   * @returns {Promise<MTX>}
    */
 
   async makeRedeem(name, acct, mtx) {
@@ -2286,7 +2286,7 @@ class Wallet extends EventEmitter {
    * @param {String} name
    * @param {MTX?} mtx
    * @param {Number?} witnessSize
-   * @returns {MTX}
+   * @returns {Promise<MTX>}
    */
 
   async makeRedeemAll(mtx, witnessSize) {
@@ -2498,7 +2498,7 @@ class Wallet extends EventEmitter {
    * @param {Resource} resource
    * @param {(Number|String)?} acct
    * @param {MTX?} mtx
-   * @returns {MTX}
+   * @returns {Promise<MTX>}
    */
 
   async makeUpdate(name, resource, acct, mtx) {
@@ -2643,7 +2643,7 @@ class Wallet extends EventEmitter {
    * @param {String} name
    * @param {(Number|String)?} acct
    * @param {MTX?} mtx
-   * @returns {MTX}
+   * @returns {Promise<MTX>}
    */
 
   async makeRenewal(name, acct, mtx) {
@@ -2715,7 +2715,7 @@ class Wallet extends EventEmitter {
    * Make a renewal MTX for all expiring names.
    * @param {MTX?} mtx
    * @param {Number?} witnessSize
-   * @returns {MTX}
+   * @returns {Promise<MTX>}
    */
 
   async makeRenewalAll(mtx, witnessSize) {
@@ -2862,7 +2862,7 @@ class Wallet extends EventEmitter {
    * @param {Address} address
    * @param {(Number|String)?} acct
    * @param {MTX?} mtx
-   * @returns {MTX}
+   * @returns {Promise<MTX>}
    */
 
   async makeTransfer(name, address, acct, mtx) {
@@ -3004,7 +3004,7 @@ class Wallet extends EventEmitter {
    * @param {String} name
    * @param {(Number|String)?} acct
    * @param {MTX?} mtx
-   * @returns {MTX}
+   * @returns {Promise<MTX>}
    */
 
   async makeCancel(name, acct, mtx) {
@@ -3132,7 +3132,7 @@ class Wallet extends EventEmitter {
    * @param {String} name
    * @param {(Number|String)?} acct
    * @param {MTX?} mtx
-   * @returns {MTX}
+   * @returns {Promise<MTX>}
    */
 
   async makeFinalize(name, acct, mtx) {
@@ -3214,7 +3214,7 @@ class Wallet extends EventEmitter {
    * @private
    * @param {MTX?} mtx
    * @param {Number?} witnessSize
-   * @returns {MTX}
+   * @returns {Promise<MTX>}
    */
 
   async makeFinalizeAll(mtx, witnessSize) {
@@ -3352,7 +3352,7 @@ class Wallet extends EventEmitter {
    * @param {String} name
    * @param {(Number|String)?} acct
    * @param {MTX?} mtx
-   * @returns {MTX}
+   * @returns {Promise<MTX>}
    */
 
   async makeRevoke(name, acct, mtx) {
@@ -3505,7 +3505,7 @@ class Wallet extends EventEmitter {
    * vsize. Input data like prevout and sequence count as base data
    * and must be added in outside this function.
    * @param {Address} addr
-   * @returns {Number}
+   * @returns {Promise<Number>}
    */
 
   async estimateSize(addr) {
@@ -3609,7 +3609,7 @@ class Wallet extends EventEmitter {
    * Make a batch transaction with multiple actions.
    * @param {Array} actions
    * @param {Object} options
-   * @returns {MTX}
+   * @returns {Promise<MTX>}
    */
 
   async makeBatch(actions, options) {
@@ -3657,73 +3657,89 @@ class Wallet extends EventEmitter {
       assert(typeof type === 'string');
 
       switch (type) {
-        case 'NONE':
+        case 'NONE': {
           assert(action.length === 2);
-          await this.createTX(
-            {outputs: [{
+
+          const options = {
+            outputs: [{
               address: action[0],
               value: action[1]
-            }]},
-            force,
-            mtx
-          );
+            }]
+          };
+
+          await this.createTX(options, force, mtx);
           break;
-        case 'OPEN':
+        }
+        case 'OPEN': {
           assert(action.length === 1, 'Bad arguments for OPEN.');
           await this.makeOpen(...action, force, acct, mtx);
           break;
-        case 'BID':
+        }
+        case 'BID': {
           assert(action.length === 3, 'Bad arguments for BID.');
           await this.makeBid(...action, acct, mtx);
           break;
-        case 'REVEAL':
+        }
+        case 'REVEAL': {
           if (action.length === 1) {
             await this.makeReveal(...action, acct, mtx);
-          } else {
-            assert(action.length === 0, 'Bad arguments for REVEAL.');
-            await this.makeRevealAll(mtx, witnessSize);
+            break;
           }
+
+          assert(action.length === 0, 'Bad arguments for REVEAL.');
+          await this.makeRevealAll(mtx, witnessSize);
           break;
-        case 'REDEEM':
+        }
+        case 'REDEEM': {
           if (action.length === 1) {
             await this.makeRedeem(...action, acct, mtx);
-          } else {
-            assert(action.length === 0, 'Bad arguments for REDEEM.');
-            await this.makeRedeemAll(mtx, witnessSize);
+            break;
           }
+
+          assert(action.length === 0, 'Bad arguments for REDEEM.');
+          await this.makeRedeemAll(mtx, witnessSize);
           break;
-        case 'UPDATE':
+        }
+        case 'UPDATE': {
           assert(action.length === 2, 'Bad arguments for UPDATE.');
           await this.makeUpdate(...action, acct, mtx);
           break;
-        case 'RENEW':
+        }
+        case 'RENEW': {
           if (action.length === 1) {
             await this.makeRenewal(...action, acct, mtx);
-          } else {
-            assert(action.length === 0, 'Bad arguments for RENEW.');
-            await this.makeRenewalAll(mtx, witnessSize);
+            break;
           }
+
+          assert(action.length === 0, 'Bad arguments for RENEW.');
+          await this.makeRenewalAll(mtx, witnessSize);
           break;
-        case 'TRANSFER':
+        }
+        case 'TRANSFER': {
           assert(action.length === 2, 'Bad arguments for TRANSFER.');
           await this.makeTransfer(...action, acct, mtx);
           break;
-        case 'FINALIZE':
+        }
+        case 'FINALIZE': {
           if (action.length === 1) {
             await this.makeFinalize(...action, acct, mtx);
-          } else {
-            assert(action.length === 0, 'Bad arguments for FINALIZE.');
-            await this.makeFinalizeAll(mtx, witnessSize);
+            break;
           }
+
+          assert(action.length === 0, 'Bad arguments for FINALIZE.');
+          await this.makeFinalizeAll(mtx, witnessSize);
           break;
-        case 'CANCEL':
+        }
+        case 'CANCEL': {
           assert(action.length === 1, 'Bad arguments for CANCEL.');
           await this.makeCancel(...action, acct, mtx);
           break;
-        case 'REVOKE':
+        }
+        case 'REVOKE': {
           assert(action.length === 1, 'Bad arguments for REVOKE.');
           await this.makeRevoke(...action, acct, mtx);
           break;
+        }
         default:
           throw new Error(`Unknown action type: ${type}`);
       }
@@ -5006,7 +5022,7 @@ class Wallet extends EventEmitter {
   /**
    * Get current change address.
    * @param {Number} [acct=0]
-   * @returns {Address}
+   * @returns {Promise<Address>}
    */
 
   async changeAddress(acct = 0) {

--- a/lib/wallet/wallet.js
+++ b/lib/wallet/wallet.js
@@ -793,8 +793,8 @@ class Wallet extends EventEmitter {
 
   /**
    * Create a new receiving address (increments receiveDepth).
-   * @param {(Number|String)?} acct
-   * @returns {Promise} - Returns {@link WalletKey}.
+   * @param {(Number|String)} [acct = 0]
+   * @returns {Promise<WalletKey>}
    */
 
   createReceive(acct = 0) {
@@ -2935,7 +2935,7 @@ class Wallet extends EventEmitter {
    * @param {String} name
    * @param {Address} address
    * @param {Object} options
-   * @returns {MTX}
+   * @returns {Promise<MTX>}
    */
 
   async _createTransfer(name, address, options) {
@@ -2951,7 +2951,7 @@ class Wallet extends EventEmitter {
    * @param {String} name
    * @param {Address} address
    * @param {Object} options
-   * @returns {MTX}
+   * @returns {Promise<MTX>}
    */
 
   async createTransfer(name, address, options) {
@@ -2969,6 +2969,7 @@ class Wallet extends EventEmitter {
    * @param {String} name
    * @param {Address} address
    * @param {Object} options
+   * @returns {Promise<TX>}
    */
 
   async _sendTransfer(name, address, options) {
@@ -3807,7 +3808,7 @@ class Wallet extends EventEmitter {
    * Make a batch transaction with multiple actions.
    * @param {Array} actions
    * @param {Object} options
-   * @returns {MTX}
+   * @returns {Promise<MTX>}
    */
 
   async _createBatch(actions, options) {
@@ -3889,7 +3890,7 @@ class Wallet extends EventEmitter {
    * Finalize and template an MTX.
    * @param {MTX} mtx
    * @param {Object} options
-   * @returns {MTX}
+   * @returns {Promise<MTX>}
    */
 
   async finalize(mtx, options) {
@@ -3959,6 +3960,7 @@ class Wallet extends EventEmitter {
    * Sign and send a (templated) mutable transaction.
    * @param {MTX} mtx
    * @param {String} passphrase
+   * @param {Promise<TX>}
    */
 
   async sendMTX(mtx, passphrase) {
@@ -5009,7 +5011,7 @@ class Wallet extends EventEmitter {
   /**
    * Get current receive address.
    * @param {Number} [acct=0]
-   * @returns {Address}
+   * @returns {Promise<Address>}
    */
 
   async receiveAddress(acct = 0) {

--- a/lib/wallet/walletdb.js
+++ b/lib/wallet/walletdb.js
@@ -1877,7 +1877,7 @@ class WalletDB extends EventEmitter {
   /**
    * Get a wallet map.
    * @param {Buffer} key
-   * @returns {Promise}
+   * @returns {Promise<MapRecord>}
    */
 
   async getMap(key) {
@@ -1894,6 +1894,7 @@ class WalletDB extends EventEmitter {
    * @param {Wallet} wallet
    * @param {Buffer} key
    * @param {Number} wid
+   * @returns {Promise}
    */
 
   async addMap(b, key, wid) {
@@ -1921,6 +1922,7 @@ class WalletDB extends EventEmitter {
    * @param {Wallet} wallet
    * @param {Buffer} key
    * @param {Number} wid
+   * @returns {Promise}
    */
 
   async removeMap(b, key, wid) {
@@ -2052,10 +2054,11 @@ class WalletDB extends EventEmitter {
    * @param {Wallet} wallet
    * @param {Buffer} key
    * @param {Number} wid
+   * @returns {Promise}
    */
 
   async addOutpointMap(b, hash, index, wid) {
-    await this.addOutpoint(hash, index);
+    this.addOutpoint(hash, index);
     return this.addMap(b, layout.o.encode(hash, index), wid);
   }
 
@@ -2064,6 +2067,7 @@ class WalletDB extends EventEmitter {
    * @param {Wallet} wallet
    * @param {Buffer} key
    * @param {Number} wid
+   * @returns {Promise}
    */
 
   async removeOutpointMap(b, hash, index, wid) {

--- a/test/wallet-locked-balance-test.js
+++ b/test/wallet-locked-balance-test.js
@@ -1051,12 +1051,12 @@ describe('Wallet Lock Balance', function() {
 
     // NOTE: If the transaction did not contain anything related to the wallet,
     // it would be totally missed on revert until rescan.
-    it.only('should handle missed bid (on confirm)', async () => {
+    it('should handle missed bid (on confirm)', async () => {
       const name = grindName(GRIND_NAME_LEN, chain.tip.height, network);
       const wallet = alicew;
       const accountName = defaultAcc;
       const opts = { account: accountName, hardFee };
-      let account = await wallet.getAccount(accountName);
+      const account = await wallet.getAccount(accountName);
 
       const blindAmount = 1e6;
       const bidAmount = blindAmount / 4;

--- a/test/wallet-locked-balance-test.js
+++ b/test/wallet-locked-balance-test.js
@@ -1,0 +1,1065 @@
+'use strict';
+
+const assert = require('bsert');
+const Network = require('../lib/protocol/network');
+const FullNode = require('../lib/node/fullnode');
+const WalletPlugin = require('../lib/wallet/plugin');
+const {Resource} = require('../lib/dns/resource');
+const {types, grindName} = require('../lib/covenants/rules');
+const {forEventCondition} = require('./util/common');
+
+const network = Network.get('regtest');
+
+const {
+  treeInterval,
+  biddingPeriod,
+  revealPeriod,
+  transferLockup
+} = network.names;
+
+const openingPeriod = treeInterval + 2;
+
+const GRIND_NAME_LEN = 10;
+const hardFee = 1e4;
+
+describe('Wallet Lock Balance', function() {
+  let node, chain, wdb;
+  // wallets
+  let primary;
+
+  const defaultAcc = 'default';
+  const altAccount1 = 'alt1';
+
+  let aliceID, alicew;
+  let bobID, bobw;
+  let carolID, carolw;
+
+  const INIT_BLOCKS = 10;
+  const INIT_FUND = 10e6;
+
+  const prepare = () => {
+    node = new FullNode({
+      network: network.type,
+      memory: true,
+      plugins: [WalletPlugin],
+      noDNS: true,
+      noNS: true
+    });
+
+    chain = node.chain;
+
+    node.once('error', (err) => {
+      assert(false, err);
+    });
+
+    wdb = node.require('walletdb').wdb;
+  };
+
+  const getAddrStr = async (wallet, acct = 0) => {
+    return (await wallet.receiveAddress(acct)).toString(network);
+  };
+
+  const forWTX = (id, hash) => {
+    return forEventCondition(wdb, 'tx', (wallet, tx) => {
+      return wallet.id === id && tx.hash().equals(hash);
+    });
+  };
+
+  const mineBlocks = async (blocks) => {
+    const tipHeight = chain.tip.height;
+    const forWalletBlock = forEventCondition(wdb, 'block connect', (entry) => {
+      return entry.height === tipHeight + 1;
+    });
+    await node.rpc.generateToAddress([blocks, await getAddrStr(primary)]);
+    await forWalletBlock;
+  };
+
+  const setupWallets = async () => {
+    primary = await wdb.get('primary');
+
+    aliceID = 'alice';
+    alicew = await wdb.create({ id: aliceID });
+    await alicew.createAccount({ name: altAccount1 });
+
+    bobID = 'bob';
+    bobw = await wdb.create({ id: bobID });
+    await bobw.createAccount({ name: altAccount1 });
+
+    carolID = 'carol';
+    carolw = await wdb.create({ id: carolID });
+    await carolw.createAccount({ name: altAccount1 });
+  };
+
+  const fundWallets = async () => {
+    await mineBlocks(INIT_BLOCKS);
+    const addrs = [];
+
+    addrs.push(await getAddrStr(alicew, defaultAcc));
+    addrs.push(await getAddrStr(alicew, altAccount1));
+    addrs.push(await getAddrStr(bobw, defaultAcc));
+    addrs.push(await getAddrStr(bobw, altAccount1));
+
+    await primary.send({
+      outputs: addrs.map((addr) => {
+        return {
+          value: INIT_FUND,
+          address: addr
+        };
+      })
+    });
+    await mineBlocks(1);
+  };
+
+  const beforeAll = async () => {
+    prepare();
+
+    await node.open();
+    await setupWallets();
+    await fundWallets();
+  };
+
+  const afterAll = async () => {
+    await node.close();
+    node = null;
+  };
+
+  const assertBalance = (balance, obj) => {
+    for (const [key, val] of Object.entries(obj)) {
+      assert.strictEqual(balance[key], val, `Incorrect ${key} balance.`);
+    }
+  };
+
+  const applyDelta = (balance, delta) => {
+    const nbalance = { ...balance };
+
+    for (const [key, value] of Object.entries(delta))
+      nbalance[key] += value;
+
+    return nbalance;
+  };
+
+  const getRegisteredName = async (name, wallet, price, opts) => {
+    await primary.sendOpen(name, true);
+    await mineBlocks(openingPeriod);
+
+    await wallet.sendBid(name, price, price, opts);
+    await primary.sendBid(name, price, price);
+    await mineBlocks(biddingPeriod);
+
+    await wallet.sendReveal(name, opts);
+    await primary.sendReveal(name);
+    await mineBlocks(revealPeriod);
+
+    const resource = Resource.fromJSON({ records: [] });
+    await primary.sendRedeem(name);
+    await wallet.sendUpdate(name, resource, opts);
+    await mineBlocks(1);
+  };
+
+  describe('NONE -> BID', function() {
+    before(beforeAll);
+    after(afterAll);
+
+    it('should handle own bid', async () => {
+      const name = grindName(GRIND_NAME_LEN, chain.tip.height, network);
+      const wallet = alicew;
+      const account = defaultAcc;
+      const opts = { account, hardFee};
+
+      const bidAmount = 1e6 / 4;
+      const blindAmount = 1e6;
+
+      const expectedBalances = [];
+      expectedBalances.push({
+        tx: 1,
+        coin: 1,
+        unconfirmed: INIT_FUND,
+        confirmed: INIT_FUND,
+        clocked: 0,
+        ulocked: 0
+      });
+
+      // starting balance should be just coinbases.
+      assertBalance(await wallet.getBalance(account), expectedBalances[0]);
+
+      // +1 tx, +1 coin (TODO: Update when we remove opens from UTXO set)
+      await wallet.sendOpen(name, false, opts);
+
+      expectedBalances.push(applyDelta(expectedBalances[0], {
+        // we got new tx (open)
+        tx: 1,
+        // new coin OPEN (TODO: remove OPENs)
+        coin: 1,
+        // Only cost us fee.
+        unconfirmed: -hardFee
+      }));
+
+      assertBalance(await wallet.getBalance(account), expectedBalances[1]);
+
+      await mineBlocks(openingPeriod);
+
+      // We just confirmed fee spent in open.
+      expectedBalances.push(applyDelta(expectedBalances[1], {
+        // fee got confirmed
+        confirmed: -hardFee
+      }));
+
+      assertBalance(await wallet.getBalance(account), expectedBalances[2]);
+
+      // bidding period.
+      await wallet.sendBid(name, bidAmount, blindAmount, opts);
+
+      // bid should have locked BLIND unconfirmed
+      expectedBalances.push(applyDelta(expectedBalances[2], {
+        // new bid tx.
+        tx: 1,
+        // new bid coin (does not consume OPEN coin)
+        coin: 1,
+        // another fee
+        unconfirmed: -hardFee,
+        // locks blind Amount
+        ulocked: blindAmount
+      }));
+
+      assertBalance(await wallet.getBalance(account), expectedBalances[3]);
+
+      // confirm
+      await mineBlocks(1);
+
+      // Now it's confirmed.
+      expectedBalances.push(applyDelta(expectedBalances[3], {
+        confirmed: -hardFee,
+        clocked: blindAmount
+      }));
+
+      assertBalance(await wallet.getBalance(account), expectedBalances[4]);
+
+      // We go back to unconfirmed state.
+      await wdb.revert(node.chain.height - 1);
+      assertBalance(await wallet.getBalance(account), expectedBalances[3]);
+
+      // Now we also remove unconfirmed txs.
+      await wallet.zap(account, 0);
+      assertBalance(await wallet.getBalance(account), expectedBalances[2]);
+    });
+
+    it('should handle foreign out bid', async () => {
+      const name = grindName(GRIND_NAME_LEN, chain.tip.height, network);
+      const wid = bobID;
+      const wallet = bobw;
+      const account = defaultAcc;
+
+      const bidAmount = 1e6 / 4;
+      const blindAmount = 1e6;
+
+      const expectedBalances = [];
+      // initial balances.
+      expectedBalances.push({
+        tx: 1,
+        coin: 1,
+        unconfirmed: INIT_FUND,
+        confirmed: INIT_FUND,
+        clocked: 0,
+        ulocked: 0
+      });
+
+      assertBalance(await wallet.getBalance(account), expectedBalances[0]);
+
+      await primary.sendOpen(name, true);
+      await mineBlocks(openingPeriod);
+
+      const altRecv1 = await wallet.receiveAddress(account);
+      const bidMTX = await primary.createBid(name, bidAmount, blindAmount);
+      assert.strictEqual(bidMTX.outputs.length, 2);
+      assert.strictEqual(bidMTX.outputs[0].covenant.type, types.BID);
+      bidMTX.outputs[0].address = altRecv1;
+
+      for (const input of bidMTX.inputs)
+        input.witness.length = 0;
+
+      await primary.sign(bidMTX);
+      const waitForBidTX = forWTX(wid, bidMTX.hash());
+      await wdb.send(bidMTX.toTX());
+      await waitForBidTX;
+
+      expectedBalances.push(applyDelta(expectedBalances[0], {
+        // we got new bid tx.
+        tx: 1,
+        // we got bid utxo
+        coin: 1,
+        // bid blind value is part of our balance
+        unconfirmed: blindAmount,
+        // it's also locked
+        ulocked: blindAmount
+      }));
+
+      assertBalance(await wallet.getBalance(account), expectedBalances[1]);
+
+      await mineBlocks(1);
+
+      // it got confirmed
+      expectedBalances.push(applyDelta(expectedBalances[1], {
+        confirmed: blindAmount,
+        clocked: blindAmount
+      }));
+
+      assertBalance(await wallet.getBalance(account), expectedBalances[2]);
+
+      await wdb.revert(node.chain.tip.height - 1);
+      assertBalance(await wallet.getBalance(account), expectedBalances[1]);
+
+      await wallet.zap(account, 0);
+      assertBalance(await wallet.getBalance(account), expectedBalances[0]);
+    });
+  });
+
+  describe('BID -> REVEAL', function() {
+    before(beforeAll);
+    after(afterAll);
+
+    it('should handle normal BID -> REVEAL', async () => {
+      const name = grindName(GRIND_NAME_LEN, chain.tip.height, network);
+      const wallet = alicew;
+      const account = defaultAcc;
+      const opts = { account, hardFee };
+
+      const bidAmount = 1e6 / 4;
+      const blindAmount = 1e6;
+
+      await primary.sendOpen(name, true);
+      await mineBlocks(openingPeriod);
+      await wallet.sendBid(name, bidAmount, blindAmount, opts);
+      await mineBlocks(biddingPeriod);
+
+      const expectedBalances = [];
+
+      // initial balance, bid and initial fund txs/coins
+      expectedBalances.push({
+        tx: 2,
+        coin: 2,
+        confirmed: INIT_FUND - hardFee,
+        unconfirmed: INIT_FUND - hardFee,
+        clocked: blindAmount,
+        ulocked: blindAmount
+      });
+
+      assertBalance(await wallet.getBalance(account), expectedBalances[0]);
+
+      await wallet.sendReveal(name, opts);
+
+      // after reveal
+      expectedBalances.push(applyDelta(expectedBalances[0], {
+        // we got reveal tx
+        tx: 1,
+        // we consume bid, produce -> freed coin + reveal out
+        coin: 1,
+        // just the fee.
+        unconfirmed: -hardFee,
+        // now only bidAmount is locked, we unlock everything else.
+        ulocked: -blindAmount + bidAmount
+      }));
+
+      assertBalance(await wallet.getBalance(account), expectedBalances[1]);
+      await mineBlocks(1);
+
+      // add all unconfirmed to the confirmed.
+      expectedBalances.push(applyDelta(expectedBalances[1], {
+        confirmed: -hardFee,
+        clocked: -blindAmount + bidAmount
+      }));
+
+      assertBalance(await wallet.getBalance(account), expectedBalances[2]);
+
+      // revert last block
+      await wdb.revert(chain.tip.height - 1);
+      assertBalance(await wallet.getBalance(account), expectedBalances[1]);
+
+      // erase tx.
+      await wallet.zap(account, 0);
+      assertBalance(await wallet.getBalance(account), expectedBalances[0]);
+    });
+
+    it('should handle cross acct BID -> REVEAL', async () => {
+      const name = grindName(GRIND_NAME_LEN, chain.tip.height, network);
+      const wallet = bobw;
+      const account = defaultAcc;
+      const altAccount = altAccount1;
+      const opts = { account, hardFee };
+
+      const bidAmount = 2e6 / 4;
+      const blindAmount = 2e6;
+
+      // mine on default account.
+      await primary.sendOpen(name, true);
+      await mineBlocks(openingPeriod);
+      await wallet.sendBid(name, bidAmount, blindAmount, opts);
+      await mineBlocks(biddingPeriod);
+
+      const expectedDefaultBalances = [];
+      const expectedAltBalances = [];
+
+      // initial balances.
+      expectedDefaultBalances.push({
+        tx: 2,
+        coin: 2,
+        confirmed: INIT_FUND - hardFee,
+        unconfirmed: INIT_FUND - hardFee,
+        clocked: blindAmount,
+        ulocked: blindAmount
+      });
+
+      expectedAltBalances.push({
+        tx: 1,
+        coin: 1,
+        confirmed: INIT_FUND,
+        unconfirmed: INIT_FUND,
+        clocked: 0,
+        ulocked: 0
+      });
+
+      assertBalance(await wallet.getBalance(account), expectedDefaultBalances[0]);
+      assertBalance(await wallet.getBalance(altAccount), expectedAltBalances[0]);
+
+      const altAddr = await wallet.receiveAddress(altAccount);
+      const revealMTX = await wallet.createReveal(name, opts);
+      const {outputs} = revealMTX;
+      assert.strictEqual(outputs.length, 2);
+      assert.strictEqual(outputs[0].covenant.type, types.REVEAL);
+      outputs[0].address = altAddr;
+
+      for (const input of revealMTX.inputs)
+        input.witness.length = 0;
+
+      await wallet.sign(revealMTX);
+      const tx = revealMTX.toTX();
+      const txAdded = forWTX(bobID, tx.hash());
+      await wdb.send(tx);
+      await txAdded;
+
+      // default sent bid to alt acct.
+      expectedDefaultBalances.push(applyDelta(expectedDefaultBalances[0], {
+        // reveal tx.
+        tx: 1,
+        // coin does not change:
+        // we consume bid ->
+        //  + we add freed coins to our balance
+        //  + send reveal to other.
+        coin: 0,
+        // we sent bid to others.
+        unconfirmed: -hardFee - bidAmount,
+        // we don't have any locked value left
+        ulocked: -blindAmount // 0.
+      }));
+
+      expectedAltBalances.push(applyDelta(expectedAltBalances[0], {
+        // we received reveal tx.
+        tx: 1,
+        // we received REVEAL coin
+        coin: 1,
+        // we received REVEAL value
+        unconfirmed: bidAmount,
+        // these coins are locked until redeem/register
+        ulocked: bidAmount
+      }));
+
+      assertBalance(await wallet.getBalance(account), expectedDefaultBalances[1]);
+      assertBalance(await wallet.getBalance(altAccount), expectedAltBalances[1]);
+      await mineBlocks(1);
+
+      // confirmed.
+      expectedDefaultBalances.push(applyDelta(expectedDefaultBalances[1], {
+        confirmed: -hardFee - bidAmount,
+        clocked: -blindAmount
+      }));
+
+      expectedAltBalances.push(applyDelta(expectedAltBalances[1], {
+        confirmed: bidAmount,
+        clocked: bidAmount
+      }));
+
+      assertBalance(await wallet.getBalance(account), expectedDefaultBalances[2]);
+      assertBalance(await wallet.getBalance(altAccount), expectedAltBalances[2]);
+
+      await wdb.revert(chain.tip.height - 1);
+      assertBalance(await wallet.getBalance(account), expectedDefaultBalances[1]);
+      assertBalance(await wallet.getBalance(altAccount), expectedAltBalances[1]);
+
+      await wallet.zap(account, 0);
+      await wallet.zap(altAccount, 0);
+      assertBalance(await wallet.getBalance(account), expectedDefaultBalances[0]);
+      assertBalance(await wallet.getBalance(altAccount), expectedAltBalances[0]);
+    });
+
+    it('should handle external BID -> REVEAL', async () => {
+      const name = grindName(GRIND_NAME_LEN, chain.tip.height, network);
+      const wallet = alicew;
+      const account = altAccount1;
+      const opts = { hardFee };
+
+      const bidAmount = 3e6 / 4;
+      const blindAmount = 3e6;
+
+      await primary.sendOpen(name, true);
+      await mineBlocks(openingPeriod);
+      await primary.sendBid(name, bidAmount, blindAmount, opts);
+      await mineBlocks(biddingPeriod);
+
+      const expectedBalances = [];
+      expectedBalances.push({
+        tx: 1,
+        coin: 1,
+        confirmed: INIT_FUND,
+        unconfirmed: INIT_FUND,
+        clocked: 0,
+        ulocked: 0
+      });
+
+      assertBalance(await wallet.getBalance(account), expectedBalances[0]);
+
+      const addr = await wallet.receiveAddress(account);
+      const revealMTX = await primary.createReveal(name, opts);
+      const {outputs} = revealMTX;
+      assert.strictEqual(outputs.length, 2);
+      assert.strictEqual(outputs[0].covenant.type, types.REVEAL);
+      outputs[0].address = addr;
+
+      for (const input of revealMTX.inputs)
+        input.witness.length = 0;
+
+      await primary.sign(revealMTX);
+      const tx = revealMTX.toTX();
+      const txAdded = forWTX(aliceID, tx.hash());
+      await wdb.send(tx);
+      await txAdded;
+
+      expectedBalances.push(applyDelta(expectedBalances[0], {
+        // we got new reveal tx
+        tx: 1,
+        // we got reveal coin
+        coin: 1,
+        // we got bidAmount to our balance.
+        unconfirmed: bidAmount,
+        // and it's locked
+        ulocked: bidAmount
+      }));
+
+      assertBalance(await wallet.getBalance(account), expectedBalances[1]);
+
+      await mineBlocks(1);
+
+      // confirmed.
+      expectedBalances.push(applyDelta(expectedBalances[1], {
+        confirmed: bidAmount,
+        clocked: bidAmount
+      }));
+
+      assertBalance(await wallet.getBalance(account), expectedBalances[2]);
+
+      await wdb.revert(chain.tip.height - 1);
+      assertBalance(await wallet.getBalance(account), expectedBalances[1]);
+
+      await wallet.zap(account, 0);
+      assertBalance(await wallet.getBalance(account), expectedBalances[0]);
+    });
+  });
+
+  describe('REVEAL -> REDEEM/REGISTER', function () {
+    before(beforeAll);
+    after(afterAll);
+
+    it('should handle normal REVEAL -> REDEEM/REGISTER', async () => {
+      const name = grindName(GRIND_NAME_LEN, chain.tip.height, network);
+
+      const winner = alicew;
+      const winnerAcct = defaultAcc;
+      const winnerOpts = { account: defaultAcc, hardFee };
+      const loser = bobw;
+      const loserAcct = defaultAcc;
+      const loserOpts = { account: loserAcct, hardFee };
+
+      const winnerBidAmount = 2e6 / 4;
+      const winnerBlindAmount = 2e6;
+      const loserBidAmount = 1e6 / 4;
+      const loserBlindAmount = 1e6;
+
+      await primary.sendOpen(name, true);
+      await mineBlocks(openingPeriod);
+      await loser.sendBid(name, loserBidAmount, loserBlindAmount, loserOpts);
+      await winner.sendBid(name, winnerBidAmount, winnerBlindAmount, winnerOpts);
+      await mineBlocks(biddingPeriod);
+      await loser.sendReveal(name, loserOpts);
+      await winner.sendReveal(name, winnerOpts);
+      await mineBlocks(revealPeriod);
+
+      const expectedLoserBalances = [];
+      const expectedWinnerBalances = [];
+
+      expectedLoserBalances.push({
+        tx: 3,
+        coin: 3,
+        confirmed: INIT_FUND - (hardFee * 2),
+        unconfirmed: INIT_FUND - (hardFee * 2),
+        clocked: loserBidAmount,
+        ulocked: loserBidAmount
+      });
+
+      expectedWinnerBalances.push({
+        ...expectedLoserBalances[0],
+        clocked: winnerBidAmount,
+        ulocked: winnerBidAmount
+      });
+
+      assertBalance(await winner.getBalance(winnerAcct), expectedWinnerBalances[0]);
+      assertBalance(await loser.getBalance(loserAcct), expectedLoserBalances[0]);
+
+      const resource = Resource.fromJSON({ records: [] });
+      await winner.sendUpdate(name, resource, winnerOpts);
+      await loser.sendRedeem(name, loserOpts);
+
+      expectedLoserBalances.push(applyDelta(expectedLoserBalances[0], {
+        // redeem tx.
+        tx: 1,
+        // fund fees + reveal -> redeem + change
+        coin: 0,
+        // fees
+        unconfirmed: -hardFee,
+        // unlock bid
+        ulocked: -loserBidAmount // 0
+      }));
+
+      expectedWinnerBalances.push(applyDelta(expectedWinnerBalances[0], {
+        // register tx.
+        tx: 1,
+        // consume REVEAL -> REGISTER (losing bid was lower) + leftover
+        coin: 1,
+        // consume fees.
+        unconfirmed: -hardFee,
+        // only lock second highest bid
+        ulocked: -winnerBidAmount + loserBidAmount
+      }));
+
+      assertBalance(await loser.getBalance(loserAcct), expectedLoserBalances[1]);
+      assertBalance(await winner.getBalance(winnerAcct), expectedWinnerBalances[1]);
+      await mineBlocks(1);
+
+      // confirm above
+      expectedLoserBalances.push(applyDelta(expectedLoserBalances[1], {
+        confirmed: -hardFee,
+        clocked: -loserBidAmount
+      }));
+
+      expectedWinnerBalances.push(applyDelta(expectedWinnerBalances[1], {
+        confirmed: -hardFee,
+        clocked: -winnerBidAmount + loserBidAmount
+      }));
+
+      assertBalance(await loser.getBalance(loserAcct), expectedLoserBalances[2]);
+      assertBalance(await winner.getBalance(winnerAcct), expectedWinnerBalances[2]);
+
+      await wdb.revert(chain.tip.height - 1);
+      assertBalance(await loser.getBalance(loserAcct), expectedLoserBalances[1]);
+      assertBalance(await winner.getBalance(winnerAcct), expectedWinnerBalances[1]);
+
+      await loser.zap(loserAcct, 0);
+      await winner.zap(winnerAcct, 0);
+      assertBalance(await loser.getBalance(loserAcct), expectedLoserBalances[0]);
+      assertBalance(await winner.getBalance(winnerAcct), expectedWinnerBalances[0]);
+    });
+
+    it('should handle normal REVEAL -> REDEEM/REGISTER (same amount)', async () => {
+      const name = grindName(GRIND_NAME_LEN, chain.tip.height, network);
+
+      const winner = alicew;
+      const winnerAcct = altAccount1;
+      const winnerOpts = { account: winnerAcct, hardFee };
+      const loser = bobw;
+      const loserAcct = altAccount1;
+      const loserOpts = { account: loserAcct, hardFee };
+
+      const winnerBidAmount = 1e6 / 4;
+      const winnerBlindAmount = 1e6;
+      const loserBidAmount = 1e6 / 4;
+      const loserBlindAmount = 1e6;
+
+      await primary.sendOpen(name, true);
+      await mineBlocks(openingPeriod);
+      await loser.sendBid(name, loserBidAmount, loserBlindAmount, loserOpts);
+      await winner.sendBid(name, winnerBidAmount, winnerBlindAmount, winnerOpts);
+      await mineBlocks(biddingPeriod);
+      await winner.sendReveal(name, winnerOpts);
+      // make sure loser is second.
+      await loser.sendReveal(name, loserOpts);
+      await mineBlocks(revealPeriod);
+
+      const expectedLoserBalances = [];
+      const expectedWinnerBalances = [];
+
+      expectedLoserBalances.push({
+        tx: 3,
+        coin: 3,
+        confirmed: INIT_FUND - (hardFee * 2),
+        unconfirmed: INIT_FUND - (hardFee * 2),
+        clocked: loserBidAmount,
+        ulocked: loserBidAmount
+      });
+
+      expectedWinnerBalances.push({
+        ...expectedLoserBalances[0],
+        clocked: winnerBidAmount,
+        ulocked: winnerBidAmount
+      });
+
+      assertBalance(await winner.getBalance(winnerAcct), expectedWinnerBalances[0]);
+      assertBalance(await loser.getBalance(loserAcct), expectedLoserBalances[0]);
+
+      const resource = Resource.fromJSON({ records: [] });
+      await winner.sendUpdate(name, resource, winnerOpts);
+      await loser.sendRedeem(name, loserOpts);
+
+      expectedLoserBalances.push(applyDelta(expectedLoserBalances[0], {
+        // redeem tx.
+        tx: 1,
+        // fund fees + reveal -> redeem + change
+        coin: 0,
+        // fees
+        unconfirmed: -hardFee,
+        // unlock bid
+        ulocked: -loserBidAmount // 0
+      }));
+
+      expectedWinnerBalances.push(applyDelta(expectedWinnerBalances[0], {
+        // register tx.
+        tx: 1,
+        // consume REVEAL + fundFee -> REGISTER + change.
+        // This is different from above, because losing bid is the same as winning.
+        coin: 0,
+        // consume fees.
+        unconfirmed: -hardFee,
+        // only lock second highest bid
+        ulocked: -winnerBidAmount + loserBidAmount
+      }));
+
+      assertBalance(await loser.getBalance(loserAcct), expectedLoserBalances[1]);
+      assertBalance(await winner.getBalance(winnerAcct), expectedWinnerBalances[1]);
+      await mineBlocks(1);
+
+      // confirm above
+      expectedLoserBalances.push(applyDelta(expectedLoserBalances[1], {
+        confirmed: -hardFee,
+        clocked: -loserBidAmount
+      }));
+
+      expectedWinnerBalances.push(applyDelta(expectedWinnerBalances[1], {
+        confirmed: -hardFee,
+        clocked: -winnerBidAmount + loserBidAmount
+      }));
+
+      assertBalance(await loser.getBalance(loserAcct), expectedLoserBalances[2]);
+      assertBalance(await winner.getBalance(winnerAcct), expectedWinnerBalances[2]);
+
+      await wdb.revert(chain.tip.height - 1);
+      assertBalance(await loser.getBalance(loserAcct), expectedLoserBalances[1]);
+      assertBalance(await winner.getBalance(winnerAcct), expectedWinnerBalances[1]);
+
+      await loser.zap(loserAcct, 0);
+      await winner.zap(winnerAcct, 0);
+      assertBalance(await loser.getBalance(loserAcct), expectedLoserBalances[0]);
+      assertBalance(await winner.getBalance(winnerAcct), expectedWinnerBalances[0]);
+    });
+  });
+
+  describe('REGISTER -> UPDATE/RENEW', function() {
+    before(beforeAll);
+    after(afterAll);
+
+    const fromRegisterCheck = async (wallet, acct, type) => {
+      const name = grindName(GRIND_NAME_LEN, chain.tip.height, network);
+      const price = 1e6;
+      const opts = { account: acct, hardFee };
+
+      await getRegisteredName(name, wallet, price, opts);
+      const expectedBalances = [];
+
+      expectedBalances.push({
+        tx: 4,
+        // REGISTER + change
+        coin: 2,
+        confirmed: INIT_FUND - (hardFee * 3),
+        unconfirmed: INIT_FUND - (hardFee * 3),
+        ulocked: price,
+        clocked: price
+      });
+
+      assertBalance(await wallet.getBalance(acct), expectedBalances[0]);
+
+      switch (type) {
+        case 'update': {
+          const resource = Resource.fromJSON({ records: [] });
+          await wallet.sendUpdate(name, resource, opts);
+          break;
+        }
+        case 'renew': {
+          await mineBlocks(treeInterval);
+          await wallet.sendRenewal(name, opts);
+          break;
+        }
+        default:
+          assert(false, 'unknown test');
+      }
+
+      expectedBalances.push(applyDelta(expectedBalances[0], {
+        tx: 1,
+        unconfirmed: -hardFee
+      }));
+
+      assertBalance(await wallet.getBalance(acct), expectedBalances[1]);
+      await mineBlocks(1);
+
+      expectedBalances.push(applyDelta(expectedBalances[1], {
+        confirmed: -hardFee
+      }));
+
+      assertBalance(await wallet.getBalance(acct), expectedBalances[2]);
+
+      await wdb.revert(chain.tip.height - 1);
+      assertBalance(await wallet.getBalance(acct), expectedBalances[1]);
+
+      await wallet.zap(acct, 0);
+      assertBalance(await wallet.getBalance(acct), expectedBalances[0]);
+    };
+
+    it('should -> UPDATE', async () => {
+      await fromRegisterCheck(alicew, defaultAcc, 'update');
+    });
+
+    it('should -> RENEW', async () => {
+      await fromRegisterCheck(alicew, altAccount1, 'renew');
+    });
+  });
+
+  describe('REGISTER/UPDATE -> TRANSFER/REVOKE', function() {
+    before(beforeAll);
+    after(afterAll);
+
+    const PRICE = 1e6;
+    const initRegBalance = {
+      tx: 4,
+      coin: 2,
+      confirmed: INIT_FUND - (hardFee * 3),
+      unconfirmed: INIT_FUND - (hardFee * 3),
+      ulocked: PRICE,
+      clocked: PRICE
+    };
+
+    it('should -> REVOKE', async () => {
+      const name = grindName(GRIND_NAME_LEN, chain.tip.height, network);
+      const wallet = alicew;
+      const account = defaultAcc;
+      const opts = { account, hardFee };
+
+      await getRegisteredName(name, wallet, PRICE, opts);
+
+      const expectedBalances = [];
+
+      expectedBalances.push({ ...initRegBalance });
+
+      assertBalance(await wallet.getBalance(account), expectedBalances[0]);
+
+      await wallet.sendRevoke(name, opts);
+
+      // Revoke does not unlock coins nor remove balance, only consumes fee.
+      expectedBalances.push(applyDelta(expectedBalances[0], {
+        tx: 1,
+        unconfirmed: -hardFee
+      }));
+
+      assertBalance(await wallet.getBalance(account), expectedBalances[1]);
+
+      await mineBlocks(1);
+
+      expectedBalances.push(applyDelta(expectedBalances[1], {
+        confirmed: -hardFee
+      }));
+
+      assertBalance(await wallet.getBalance(account), expectedBalances[2]);
+
+      await wdb.revert(chain.tip.height - 1);
+      assertBalance(await wallet.getBalance(account), expectedBalances[1]);
+
+      await wallet.zap(account, 0);
+      assertBalance(await wallet.getBalance(account), expectedBalances[0]);
+    });
+
+    it('should TRANSFER -> FINALIZE', async () => {
+      const name = grindName(GRIND_NAME_LEN, chain.tip.height, network);
+      const wallet = alicew;
+      const wallet2 = bobw;
+      const account = altAccount1;
+      const account2 = defaultAcc;
+      const opts = { account, hardFee };
+      const w2addr = await wallet2.receiveAddress(account2);
+
+      await getRegisteredName(name, wallet, PRICE, opts);
+
+      const expectedSenderBalances = [];
+      const expectedReceiverBalances = [];
+
+      expectedSenderBalances.push({ ...initRegBalance });
+      expectedReceiverBalances.push({
+        tx: 1,
+        coin: 1,
+        confirmed: INIT_FUND,
+        unconfirmed: INIT_FUND,
+        ulocked: 0,
+        clocked: 0
+      });
+
+      assertBalance(await wallet.getBalance(account), expectedSenderBalances[0]);
+      assertBalance(await wallet2.getBalance(account2), expectedReceiverBalances[0]);
+
+      await wallet.sendTransfer(name, w2addr, opts);
+
+      expectedSenderBalances.push(applyDelta(expectedSenderBalances[0], {
+        tx: 1,
+        unconfirmed: -hardFee
+      }));
+
+      // Transfer is still within wallet state transition.
+      // Finalize is when the UTXO leaves the wallet.
+      expectedReceiverBalances.push(applyDelta(expectedReceiverBalances[0], {}));
+
+      assertBalance(await wallet.getBalance(account), expectedSenderBalances[1]);
+      assertBalance(await wallet2.getBalance(account2), expectedReceiverBalances[1]);
+
+      // confirm
+      await mineBlocks(1);
+      expectedSenderBalances.push(applyDelta(expectedSenderBalances[1], {
+        confirmed: -hardFee
+      }));
+      expectedReceiverBalances.push(applyDelta(expectedReceiverBalances[1], {}));
+
+      assertBalance(await wallet.getBalance(account), expectedSenderBalances[2]);
+      assertBalance(await wallet2.getBalance(account2), expectedReceiverBalances[2]);
+
+      // proceed to finalize
+      await mineBlocks(transferLockup);
+      await wallet.sendFinalize(name, opts);
+
+      expectedSenderBalances.push(applyDelta(expectedSenderBalances[2], {
+        tx: 1,
+        coin: -1,
+        unconfirmed: -hardFee - PRICE,
+        ulocked: -PRICE
+      }));
+
+      expectedReceiverBalances.push(applyDelta(expectedReceiverBalances[2], {
+        tx: 1,
+        coin: 1,
+        unconfirmed: PRICE,
+        ulocked: PRICE
+      }));
+
+      assertBalance(await wallet.getBalance(account), expectedSenderBalances[3]);
+      assertBalance(await wallet2.getBalance(account2), expectedReceiverBalances[3]);
+
+      // confirm finalize.
+      await mineBlocks(1);
+
+      expectedSenderBalances.push(applyDelta(expectedSenderBalances[3], {
+        confirmed: -hardFee - PRICE,
+        clocked: -PRICE
+      }));
+
+      expectedReceiverBalances.push(applyDelta(expectedReceiverBalances[3], {
+        confirmed: PRICE,
+        clocked: PRICE
+      }));
+
+      assertBalance(await wallet.getBalance(account), expectedSenderBalances[4]);
+      assertBalance(await wallet2.getBalance(account2), expectedReceiverBalances[4]);
+
+      // Now let's revert.
+      await wdb.revert(chain.tip.height - 1);
+      assertBalance(await wallet.getBalance(account), expectedSenderBalances[3]);
+      assertBalance(await wallet2.getBalance(account2), expectedReceiverBalances[3]);
+
+      await wallet.zap(account, 0);
+      await wallet2.zap(account2, 0);
+      assertBalance(await wallet.getBalance(account), expectedSenderBalances[2]);
+      assertBalance(await wallet2.getBalance(account2), expectedReceiverBalances[2]);
+
+      // revert transfer
+      await wdb.revert(chain.tip.height - 1 - transferLockup - 1);
+      assertBalance(await wallet.getBalance(account), expectedSenderBalances[1]);
+      assertBalance(await wallet2.getBalance(account2), expectedReceiverBalances[1]);
+
+      await wallet.zap(account, 0);
+      await wallet2.zap(account2, 0);
+      assertBalance(await wallet.getBalance(account), expectedSenderBalances[0]);
+      assertBalance(await wallet2.getBalance(account2), expectedReceiverBalances[0]);
+    });
+
+    it('should TRANSFER -> REVOKE', async () => {
+      const name = grindName(GRIND_NAME_LEN, chain.tip.height, network);
+      const wallet = bobw;
+      const account = altAccount1;
+      const opts = { account, hardFee };
+      const w2addr = await carolw.receiveAddress(defaultAcc);
+
+      await getRegisteredName(name, wallet, PRICE, opts);
+
+      const expectedBalances = [];
+      expectedBalances.push({ ...initRegBalance });
+
+      assertBalance(await wallet.getBalance(account), expectedBalances[0]);
+
+      await wallet.sendTransfer(name, w2addr, opts);
+
+      expectedBalances.push(applyDelta(expectedBalances[0], {
+        tx: 1,
+        unconfirmed: -hardFee
+      }));
+
+      assertBalance(await wallet.getBalance(account), expectedBalances[1]);
+
+      await mineBlocks(1);
+
+      expectedBalances.push(applyDelta(expectedBalances[1], {
+        confirmed: -hardFee
+      }));
+
+      assertBalance(await wallet.getBalance(account), expectedBalances[2]);
+
+      await wallet.sendRevoke(name, opts);
+
+      // Revoke does not unlock coins nor remove balance, only consumes fee.
+      expectedBalances.push(applyDelta(expectedBalances[2], {
+        tx: 1,
+        unconfirmed: -hardFee
+      }));
+
+      assertBalance(await wallet.getBalance(account), expectedBalances[3]);
+
+      await mineBlocks(1);
+
+      expectedBalances.push(applyDelta(expectedBalances[3], {
+        confirmed: -hardFee
+      }));
+
+      assertBalance(await wallet.getBalance(account), expectedBalances[4]);
+
+      // revert
+      await wdb.revert(chain.tip.height - 1);
+      assertBalance(await wallet.getBalance(account), expectedBalances[3]);
+
+      await wallet.zap(account, 0);
+      assertBalance(await wallet.getBalance(account), expectedBalances[2]);
+
+      await wdb.revert(chain.tip.height - 2);
+      assertBalance(await wallet.getBalance(account), expectedBalances[1]);
+
+      await wallet.zap(account, 0);
+      assertBalance(await wallet.getBalance(account), expectedBalances[0]);
+    });
+  });
+});

--- a/test/wallet-test.js
+++ b/test/wallet-test.js
@@ -2270,7 +2270,7 @@ describe('Wallet', function() {
       uTXCount++;
 
       // Check
-        const senderBal3 = await wallet.getBalance();
+      const senderBal3 = await wallet.getBalance();
       assert.strictEqual(senderBal3.tx, 7);
       // One less wallet coin because name UTXO belongs to recip now
       assert.strictEqual(senderBal3.coin, 3);
@@ -3217,7 +3217,7 @@ describe('Wallet', function() {
       assert.strictEqual(bal.ulocked, value);
       assert.strictEqual(bal.clocked, value + secondHighest);
 
-      // Confirm REGISTER
+      // Confirm REDEEM
       const block = {
         height: wdb.height + 1,
         hash: Buffer.alloc(32),


### PR DESCRIPTION
The assertions were only there in the first place because of weird covenant accounting: for some covenants like REVEAL, we dig up the corresponding BID from the database and we MUST HAVE THAT DATA or we can't compute the change to the wallet's locked balance.

The new approach is: we process all inputs and all outputs of every TX, meaning that the BID in the input of the transaction is applied to our balance mere moments before we process the REVEAL in the output of the same transaction. This simplifies balance locking really well (we eliminate DB lookups and the functions are no longer `async/await`).

The assertion errors we've been getting almost daily from users occurs when the BID is not in the database yet because we don't recognize our own address because it's a wallet recovery and we haven't generated the address yet.

What this PR does is "not care": if we see a REVEAL before we see the BID, then we have a *negative locked balance*. Yep that really sucks but it can be fixed with a rescan or two... and no one's node has to crash.

There is one other drawback to this, which is why I'm pausing here and opening as draft:

TODO:

- [ ] `class Balance` in txdb needs to allow negative values. Remove `assert >= 0` and switch all `writeU64` to `writeI64` which interestingly, because it's javascript, I think means we don't need a migration ... ?!