### PR TITLE
wallet: use correct fee in rpc gettransaction

### DIFF
--- a/lib/wallet/rpc.js
+++ b/lib/wallet/rpc.js
@@ -646,6 +646,7 @@ class RPC extends RPCBase {
     }
 
     const det = [];
+    const fee = details.getFee();
     let sent = 0;
     let received = 0;
 
@@ -680,7 +681,7 @@ class RPC extends RPCBase {
           : null,
         category: 'send',
         amount: -(Amount.coin(member.value, true)),
-        fee: -(Amount.coin(details.fee, true)),
+        fee: -(Amount.coin(fee, true)),
         vout: i
       });
 
@@ -2498,8 +2499,8 @@ class RPC extends RPCBase {
     return mtx.getJSON(this.network);
   }
 
- _validateBatch(args, help, method) {
-  if (help || args.length < 1 || args.length > 2) {
+  _validateBatch(args, help, method) {
+    if (help || args.length < 1 || args.length > 2) {
       throw new RPCError(errs.MISC_ERROR,
         `${method} [["type", ...args], ...] ( options )`);
     }


### PR DESCRIPTION
Fixes #783.

A non-existent value was being passed to `Amount.coin()` for fee. `Details` has a `getFee()` only, not `.fee` unless it's in JSON form.

It only reached that if branch and errored when a "send" tx was queried (no ouptut path).

Fee is negative, TIL that's how it should be as per bitcoin docs too: https://developer.bitcoin.org/reference/rpc/gettransaction.html

```js
❯ hsw-cli --http-port 14039 rpc gettransaction d4769eac97426952183cb97b864af630e1707228f866941406b967e7c15a5862
{
  "amount": -15,
  "blockhash": "5a6b4320ad4b34bae89bd90ff0e5720fa940dfb8e81ac2abc273b0c736fe12b8",
  "blocktime": 1671435071,
  "txid": "d4769eac97426952183cb97b864af630e1707228f866941406b967e7c15a5862",
  "walletconflicts": [],
  "time": 1671435063,
  "timereceived": 1671435063,
  "bip125-replaceable": "no",
  "details": [
    {
      "account": "",
      "address": "rs1q7q3h4chglps004u3yn79z0cp9ed24rfrhvrxnx",
      "category": "send",
      "amount": -15,
      "fee": -0.0028,
      "vout": 0
    }
  ],
  "hex": "0000000001daddeba7c30ddb0401757fc18a1b83ef8b98fd18692dd98cacc58e835f3b580000000000ffffffff02c0e1e400000000000014f0237ae2e8f860f7d79124fc513f012e5aaa8d23000050a750760000000000149c079ee36286b6cee8915ccbe4e86155ae3b5bb00000000000000241b2cd70c8a3b1a6a5d6f4f8a21d986cc3bfc8e16259e4718bcae47e9c60d63952494145d4d22ca8c135104f7773c2caf086f67fc6e86db7bf394a8e9ac8ae41a90121034646c0520758d549e8e354e98c36ff83d4e6b4fc2edac76c96017e64818e3149"
}
```