### PR TITLE
Wallet http endpoint for updating account lookahead

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,17 +6,21 @@
   Validation and request paremeter errors will no longer return (and log) `500`
 status code, instead will return `400`.
 
-### Wallet configuration
-`hsd.conf` can now be used to define wallet options, when wallet is running as a plugin.
-Configurations with `wallet-` prefix will be passed to the wallet. `hsd.conf` wont be used
-if the wallet is running in standalone mode.
+### Wallet Changes
+#### Configuration
+  `hsd.conf` can now be used to define wallet options, when wallet is running as
+a plugin. Configurations with `wallet-` prefix will be passed to the wallet.
+`hsd.conf` wont be used if the wallet is running in standalone mode.
 
-### Wallet API
+- Remove `check-lookahead` option from walletdb.
+
+#### Wallet API
 
 - HTTP Changes:
   - `/wallet/:id/open` no longer accepts `force` flag. (it was not used)
 - RPC Changes:
   - `createopen` and `sendopen` no longer accept `force` as an argument. (was not used)
+  - Introduce new API to modify account: `PATCH /wallet/:id/account/:account`.
 
 ## v5.0.0
 
@@ -28,10 +32,10 @@ you run it for the first time.**
 - HTTP API endpoint `/` (`hsd-cli getinfo`) now includes "public" networking settings.
 
 - RPCs `getnameinfo` `getnameresource` `verifymessagewithname` and `getnamebyhash`
-now accept an additional boolean parameter `safe` which will resolve the name from the Urkel
-tree at the last "safe height" (committed tree root with > 12 confirmations). SPV
-nodes can use this option and retrieve Urkel proofs from the p2p network to respond
-to these calls.
+now accept an additional boolean parameter `safe` which will resolve the name
+from the Urkel tree at the last "safe height" (committed tree root with > 12
+confirmations). SPV nodes can use this option and retrieve Urkel proofs from the
+p2p network to respond to these calls.
 
 - New RPC methods:
   - `decoderesource` like `decodescript` accepts hex string as input and returns
@@ -47,13 +51,15 @@ to these calls.
   of outputs with any combination of covenants.
 
 - Updates related to nonces and blinds
-  - Multisig wallets will compute nonces based on the LOWEST public key in the group.
-  This makes multiparty bidding and revealing more deteministic. Older versions would
-  always use the wallet's OWN public key. To preserve compatability with older software:
-    - RPC method `importnonce` now returns an array of blinds instead of a single blind.
-    - HTTP endpoint `/wallet/:id/nonce/:name`'s response replaces 2 string fields (`nonce`, `blind`) with arrays of the same type (`nonces`, `blinds`)
-
-- Remove `check-lookahead` option from walletdb.
+  - Multisig wallets will compute nonces based on the LOWEST public key in the
+  group.
+  This makes multiparty bidding and revealing more deteministic. Older versions
+  would always use the wallet's OWN public key. To preserve compatability with
+  older software:
+    - RPC method `importnonce` now returns an array of blinds instead of a
+    single blind.
+    - HTTP endpoint `/wallet/:id/nonce/:name`'s response replaces 2 string
+    fields (`nonce`, `blind`) with arrays of the same type (`nonces`, `blinds`)
 
 ## v4.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,8 @@ to these calls.
     - RPC method `importnonce` now returns an array of blinds instead of a single blind.
     - HTTP endpoint `/wallet/:id/nonce/:name`'s response replaces 2 string fields (`nonce`, `blind`) with arrays of the same type (`nonces`, `blinds`)
 
+- Remove `check-lookahead` option from walletdb.
+
 ## v4.0.0
 
 **When upgrading to this version of hsd you must pass

--- a/bin/hsw-cli
+++ b/bin/hsw-cli
@@ -21,6 +21,7 @@ const HELP = `
 Commands:
   $ abandon [hash]: Abandon a transaction.
   $ account create [account-name]: Create account.
+  $ account modify [account-name]: Set account options.
   $ account get [account-name]: Get account details.
   $ account list: List account names.
   $ address [account-name]: Derive new address.
@@ -229,6 +230,18 @@ class CLI {
     };
 
     const account = await this.wallet.createAccount(name, options);
+
+    this.log(account);
+  }
+
+  async modifyAccount() {
+    const name = this.config.str([0, 'name']);
+
+    const options = {
+      lookahead: this.config.uint('lookahead')
+    };
+
+    const account = await this.wallet.modifyAccount(name, options);
 
     this.log(account);
   }
@@ -577,6 +590,11 @@ class CLI {
         if (this.argv[0] === 'create') {
           this.argv.shift();
           await this.createAccount();
+          break;
+        }
+        if (this.argv[0] === 'modify') {
+          this.argv.shift();
+          await this.modifyAccount();
           break;
         }
         if (this.argv[0] === 'get')

--- a/lib/client/wallet.js
+++ b/lib/client/wallet.js
@@ -682,7 +682,22 @@ class WalletClient extends Client {
    */
 
   createAccount(id, name, options) {
+    if (name == null)
+      throw new Error('Account name is required.');
+
     return this.put(`/wallet/${id}/account/${name}`, options);
+  }
+
+  /**
+   * Modify account.
+   * @param {String} id
+   * @param {String} name
+   * @param {Object} options
+   * @returns {Promise<Object>}
+   */
+
+  modifyAccount(id, name, options) {
+    return this.patch(`/wallet/${id}/account/${name}`, options);
   }
 
   /**
@@ -1363,10 +1378,18 @@ class Wallet extends EventEmitter {
    */
 
   createAccount(name, options) {
-    if (name == null)
-      throw new Error('Account name is required.');
-
     return this.client.createAccount(this.id, name, options);
+  }
+
+  /**
+   * Modify account.
+   * @param {String} name
+   * @param {Object} options
+   * @returns {Promise<Object>}
+   */
+
+  modifyAccount(name, options) {
+    return this.client.modifyAccount(this.id, name, options);
   }
 
   /**

--- a/lib/wallet/account.js
+++ b/lib/wallet/account.js
@@ -563,6 +563,8 @@ class Account extends bio.Struct {
    */
 
   async setLookahead(b, lookahead) {
+    assert((lookahead >>> 0) === lookahead, 'Lookahead must be a number.');
+
     if (lookahead === this.lookahead)
       return;
 

--- a/lib/wallet/http.js
+++ b/lib/wallet/http.js
@@ -362,6 +362,22 @@ class HTTP extends Server {
       res.json(200, account.getJSON(balance));
     });
 
+    // Modify account
+    this.patch('/wallet/:id/account/:account', async (req, res) => {
+      const valid = Validator.fromRequest(req);
+      const passphrase = valid.str('passphrase');
+      const acct = valid.str('account');
+
+      const options = {
+        lookahead: valid.u32('lookahead')
+      };
+
+      const account = await req.wallet.modifyAccount(acct, options, passphrase);
+      const balance = await req.wallet.getBalance(account.accountIndex);
+
+      res.json(200, account.getJSON(balance));
+    });
+
     // Change passphrase
     this.post('/wallet/:id/passphrase', async (req, res) => {
       const valid = Validator.fromRequest(req);

--- a/lib/wallet/node.js
+++ b/lib/wallet/node.js
@@ -51,8 +51,7 @@ class WalletNode extends Node {
       cacheSize: this.config.mb('cache-size'),
       wipeNoReally: this.config.bool('wipe-no-really'),
       spv: this.config.bool('spv'),
-      walletMigrate: this.config.uint('migrate'),
-      checkLookahead: this.config.bool('check-lookahead', false)
+      walletMigrate: this.config.uint('migrate')
     });
 
     this.rpc = new RPC(this);

--- a/lib/wallet/plugin.js
+++ b/lib/wallet/plugin.js
@@ -56,8 +56,7 @@ class Plugin extends EventEmitter {
       cacheSize: this.config.mb('cache-size'),
       wipeNoReally: this.config.bool('wipe-no-really'),
       spv: node.spv,
-      walletMigrate: this.config.uint('migrate'),
-      checkLookahead: this.config.bool('check-lookahead', false)
+      walletMigrate: this.config.uint('migrate')
     });
 
     this.rpc = new RPC(this);

--- a/lib/wallet/wallet.js
+++ b/lib/wallet/wallet.js
@@ -660,6 +660,50 @@ class Wallet extends EventEmitter {
   }
 
   /**
+   * Modify an account. Requires passphrase if master key is encrypted.
+   * @param {String|Number} acct
+   * @param {Object} options
+   * @param {String} [passphrase]
+   * @returns {Promise<Account>}
+   */
+
+  async modifyAccount(acct, options, passphrase) {
+    const unlock = await this.writeLock.lock();
+    try {
+      return await this._modifyAccount(acct, options, passphrase);
+    } finally {
+      unlock();
+    }
+  }
+
+  /**
+   * Create an account without a lock.
+   * @param {String|Number} acct
+   * @param {Object} options
+   * @param {String} [passphrase]
+   * @returns {Promise<Account>}
+   */
+
+  async _modifyAccount(acct, options, passphrase) {
+    if (!await this.hasAccount(acct))
+      throw new Error(`Account ${acct} does not exist.`);
+
+    await this.unlock(passphrase);
+
+    const account = await this.getAccount(acct);
+    assert(account);
+
+    const b = this.db.batch();
+
+    if (options.lookahead != null)
+      await account.setLookahead(b, options.lookahead);
+
+    await b.write();
+
+    return account;
+  }
+
+  /**
    * Ensure an account. Requires passphrase if master key is encrypted.
    * @param {Object} options - See {@link Account} options.
    * @returns {Promise} - Returns {@link Account}.
@@ -714,7 +758,7 @@ class Wallet extends EventEmitter {
   /**
    * Retrieve an account from the database.
    * @param {Number|String} acct
-   * @returns {Promise} - Returns {@link Account}.
+   * @returns {Promise<Account>}
    */
 
   async getAccount(acct) {
@@ -4326,41 +4370,6 @@ class Wallet extends EventEmitter {
     }
 
     return paths;
-  }
-
-  /**
-   * Increase lookahead for account.
-   * @param {(Number|String)?} account
-   * @param {Number} lookahead
-   * @returns {Promise}
-   */
-
-  async setLookahead(acct, lookahead) {
-    const unlock = await this.writeLock.lock();
-    try {
-      return this._setLookahead(acct, lookahead);
-    } finally {
-      unlock();
-    }
-  }
-
-  /**
-   * Increase lookahead for account (without a lock).
-   * @private
-   * @param {(Number|String)?} account
-   * @param {Number} lookahead
-   * @returns {Promise}
-   */
-
-  async _setLookahead(acct, lookahead) {
-    const account = await this.getAccount(acct);
-
-    if (!account)
-      throw new Error('Account not found.');
-
-    const b = this.db.batch();
-    await account.setLookahead(b, lookahead);
-    await b.write();
   }
 
   /**

--- a/lib/wallet/walletdb.js
+++ b/lib/wallet/walletdb.js
@@ -224,8 +224,6 @@ class WalletDB extends EventEmitter {
       this.logger.info('Rescanning...');
       await this.scan(0);
     }
-
-    await this.checkLookahead();
   }
 
   /**
@@ -242,40 +240,6 @@ class WalletDB extends EventEmitter {
 
     b.put(layout.V.encode(), value);
   }
-
-  /**
-   * Update account lookahead & depth
-   * @returns {Promise}
-   */
-
-   async checkLookahead() {
-    if (!this.options.checkLookahead)
-      return;
-
-    const b = this.db.batch();
-
-    const wids = await this.db.keys({
-      gte: layout.W.min(),
-      lte: layout.W.max(),
-      parse: key => layout.W.decode(key)[0]
-    });
-
-    for (const wid of wids) {
-      const wallet = await this.get(wid);
-
-      for (let i = 0; i < wallet.accountDepth; i++) {
-        this.logger.warning(
-          'Setting lookahead for wallet %s account %d',
-          wallet.id,
-          i
-        );
-        const account = await wallet.getAccount(i);
-        await account.setLookahead(b, Account.MAX_LOOKAHEAD);
-      }
-    }
-
-    await b.write();
-   }
 
   /**
    * Verify network.
@@ -2504,7 +2468,6 @@ class WalletOptions {
     this.spv = false;
     this.wipeNoReally = false;
     this.walletMigrate = -1;
-    this.checkLookahead = false;
 
     if (options)
       this.fromOptions(options);
@@ -2585,11 +2548,6 @@ class WalletOptions {
     if (options.walletMigrate != null) {
       assert(typeof options.walletMigrate === 'number');
       this.walletMigrate = options.walletMigrate;
-    }
-
-    if (options.checkLookahead != null) {
-      assert(typeof options.checkLookahead === 'boolean');
-      this.checkLookahead = options.checkLookahead;
     }
 
     return this;

--- a/test/wallet-http-test.js
+++ b/test/wallet-http-test.js
@@ -124,6 +124,19 @@ describe('Wallet HTTP', function() {
     assert.strictEqual(getNewAccount.lookahead, 1001);
   });
 
+  it('should modify account lookahead to 1000', async () => {
+    const wname = 'lookahead2';
+    await wclient.createWallet(wname);
+
+    const defAccount = await wclient.getAccount(wname, 'default');
+    assert.strictEqual(defAccount.lookahead, 200);
+
+    const modified = await wclient.modifyAccount(wname, 'default', {
+      lookahead: 1000
+    });
+    assert.strictEqual(modified.lookahead, 1000);
+  });
+
   it('should get key by address from watch-only', async () => {
     const phrase = 'abandon abandon abandon abandon abandon abandon '
       + 'abandon abandon abandon abandon abandon about';


### PR DESCRIPTION
This is based on #796, so if it does not make it I can rebase on current master, but #796 makes it much easier.

Summary:
  - Add modify account endpoint
  - Change create account endpoint
  - Remove wallet check-lookahead flag.


Note, this update changes existing API call for `createAccount`, which used to be `PUT /wallet/:id/account/:account`. Until now it was okay, even though it's not RESTish. But this PR adds ability to modify account, so these need to change:
  - Create account becomes: `POST /wallet/:id/account/:account`
  - `PUT /wallet/:id/account/:account` becomes MODIFY/UPDATE the existing account entry.

Currently, only thing that can be changed about account is `lookahead`.

This also deprecates `check-lookahead` which was used previously to max out lookahead for all the wallets. Now this can be done via this endpoint and new accounts already use 200 by default.

To make review easier, you can check the commits since [`2dc2c48`](https://github.com/handshake-org/hsd/pull/796/commits/2dc2c488d95adae93ed379cc37fcf5f4e6df5f51): https://github.com/handshake-org/hsd/compare/2dc2c48...1c5fd1a

NOTE: Users increasing lookahead MAY want to rescan.