### PR TITLE
wallet: remove force option from wallet.makeOpen.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # HSD Release Notes & Changelog
 
+## v6.0.0
+
+### Wallet changes
+
+- HTTP Changes:
+  - `/wallet/:id/open` no longer accepts `force` flag. (it was not used)
+- RPC Changes:
+  - `createopen` and `sendopen` no longer accept `force` as an argument. (was not used)
+
 ## v5.0.0
 
 **When upgrading to this version of hsd, you must pass `--wallet-migrate=2` when

--- a/lib/wallet/http.js
+++ b/lib/wallet/http.js
@@ -1047,7 +1047,6 @@ class HTTP extends Server {
     this.post('/wallet/:id/open', async (req, res) => {
       const valid = Validator.fromRequest(req);
       const name = valid.str('name');
-      const force = valid.bool('force', false);
       const passphrase = valid.str('passphrase');
       const broadcast = valid.bool('broadcast', true);
       const sign = valid.bool('sign', true);
@@ -1056,7 +1055,7 @@ class HTTP extends Server {
       assert(broadcast ? sign : true, 'Must sign when broadcasting.');
 
       const options = TransactionOptions.fromValidator(valid);
-      const mtx = await req.wallet.createOpen(name, force, options);
+      const mtx = await req.wallet.createOpen(name, options);
 
       if (broadcast) {
         const tx = await req.wallet.sendMTX(mtx, passphrase);

--- a/lib/wallet/rpc.js
+++ b/lib/wallet/rpc.js
@@ -2062,7 +2062,7 @@ class RPC extends RPCBase {
   async sendOpen(args, help) {
     const opts = this._validateOpen(args, help, 'sendopen');
     const wallet = this.wallet;
-    const tx = await wallet.sendOpen(opts.name, opts.force, {
+    const tx = await wallet.sendOpen(opts.name, {
       account: opts.account
     });
 
@@ -2072,7 +2072,7 @@ class RPC extends RPCBase {
   async createOpen(args, help) {
     const opts = this._validateOpen(args, help, 'createopen');
     const wallet = this.wallet;
-    const mtx = await wallet.createOpen(opts.name, opts.force, {
+    const mtx = await wallet.createOpen(opts.name, {
       paths: true,
       account: opts.account
     });
@@ -2081,20 +2081,19 @@ class RPC extends RPCBase {
   }
 
   _validateOpen(args, help, method) {
-    const msg = `${method} "name" ( force "account" )`;
+    const msg = `${method} "name" ( "account" )`;
 
     if (help || args.length < 1 || args.length > 3)
       throw new RPCError(errs.MISC_ERROR, msg);
 
     const valid = new Validator(args);
     const name = valid.str(0);
-    const force = valid.bool(1, false);
-    const account = valid.str(2);
+    const account = valid.str(1);
 
     if (!name || !rules.verifyName(name))
       throw new RPCError(errs.TYPE_ERROR, 'Invalid name.');
 
-    return {name, force, account};
+    return {name, account};
   }
 
   async sendBid(args, help) {
@@ -2467,6 +2466,7 @@ class RPC extends RPCBase {
 
     return mtx.getJSON(this.network);
   }
+
   _validateRevoke(args, help, method) {
     if (help || args.length < 1 || args.length > 2)
       throw new RPCError(errs.MISC_ERROR, `${method} "name" ( "account" )`);

--- a/lib/wallet/txdb.js
+++ b/lib/wallet/txdb.js
@@ -817,7 +817,7 @@ class TXDB {
    * Test whether the transaction
    * has a duplicate open.
    * @param {TX}
-   * @returns {Boolean}
+   * @returns {Promise<Boolean>}
    */
 
   async isDoubleOpen(tx) {

--- a/lib/wallet/wallet.js
+++ b/lib/wallet/wallet.js
@@ -1584,14 +1584,12 @@ class Wallet extends EventEmitter {
    * Make a open MTX.
    * @param {String} name
    * @param {Number|String} acct
-   * @param {Boolean} force
    * @param {MTX?} mtx
-   * @returns {MTX}
+   * @returns {Promise<MTX>}
    */
 
-  async makeOpen(name, force, acct, mtx) {
+  async makeOpen(name, acct, mtx) {
     assert(typeof name === 'string');
-    assert(typeof force === 'boolean');
     assert((acct >>> 0) === acct || typeof acct === 'string');
 
     if (!rules.verifyName(name))
@@ -1648,14 +1646,13 @@ class Wallet extends EventEmitter {
    * Create and finalize an open
    * MTX without a lock.
    * @param {String} name
-   * @param {Boolean} force
    * @param {Object} options
-   * @returns {MTX}
+   * @returns {Promise<MTX>}
    */
 
-  async _createOpen(name, force, options) {
+  async _createOpen(name, options) {
     const acct = options ? options.account || 0 : 0;
-    const mtx = await this.makeOpen(name, force, acct);
+    const mtx = await this.makeOpen(name, acct);
     await this.fill(mtx, options);
     return this.finalize(mtx, options);
   }
@@ -1664,15 +1661,14 @@ class Wallet extends EventEmitter {
    * Create and finalize an open
    * MTX with a lock.
    * @param {String} name
-   * @param {Boolean} force
    * @param {Object} options
-   * @returns {MTX}
+   * @returns {Promise<MTX>}
    */
 
-  async createOpen(name, force, options) {
+  async createOpen(name, options) {
     const unlock = await this.fundLock.lock();
     try {
-      return await this._createOpen(name, force, options);
+      return await this._createOpen(name, options);
     } finally {
       unlock();
     }
@@ -1682,13 +1678,13 @@ class Wallet extends EventEmitter {
    * Create and send an open
    * MTX without a lock.
    * @param {String} name
-   * @param {Boolean} force
    * @param {Object} options
+   * @returns {Promise<TX>}
    */
 
-  async _sendOpen(name, force, options) {
+  async _sendOpen(name, options) {
     const passphrase = options ? options.passphrase : null;
-    const mtx = await this._createOpen(name, force, options);
+    const mtx = await this._createOpen(name, options);
     return this.sendMTX(mtx, passphrase);
   }
 
@@ -1696,14 +1692,14 @@ class Wallet extends EventEmitter {
    * Create and send an open
    * MTX with a lock.
    * @param {String} name
-   * @param {Boolean} force
    * @param {Object} options
+   * @returns {Promise<TX>}
    */
 
-  async sendOpen(name, force, options) {
+  async sendOpen(name, options) {
     const unlock = await this.fundLock.lock();
     try {
-      return await this._sendOpen(name, force, options);
+      return await this._sendOpen(name, options);
     } finally {
       unlock();
     }
@@ -3689,7 +3685,6 @@ class Wallet extends EventEmitter {
     assert(Array.isArray(actions));
     assert(actions.length, 'Batches require at least one action.');
 
-    const force = false;
     const acct = options ? options.account || 0 : 0;
     const mtx = new MTX();
 
@@ -3739,7 +3734,7 @@ class Wallet extends EventEmitter {
           break;
         case 'OPEN':
           assert(action.length === 1, 'Bad arguments for OPEN.');
-          await this.makeOpen(...action, force, acct, mtx);
+          await this.makeOpen(...action, acct, mtx);
           break;
         case 'BID':
           assert(action.length === 3, 'Bad arguments for BID.');
@@ -3942,7 +3937,7 @@ class Wallet extends EventEmitter {
    * Finalize and template an MTX.
    * @param {MTX} mtx
    * @param {Object} options
-   * @returns {MTX}
+   * @returns {Promise<MTX>}
    */
 
   async finalize(mtx, options) {
@@ -4012,6 +4007,7 @@ class Wallet extends EventEmitter {
    * Sign and send a (templated) mutable transaction.
    * @param {MTX} mtx
    * @param {String} passphrase
+   * @returns {Promise<TX>}
    */
 
   async sendMTX(mtx, passphrase) {

--- a/test/anyone-can-renew-test.js
+++ b/test/anyone-can-renew-test.js
@@ -105,7 +105,7 @@ describe('Anyone-can-renew address', function() {
   it('should win name with Alice\'s wallet', async () => {
     heightBeforeOpen = node.chain.height;
 
-    await alice.sendOpen(name, false);
+    await alice.sendOpen(name);
     await mineBlocks(network.names.treeInterval + 1);
 
     await alice.sendBid(name, 100000, 200000);

--- a/test/interactive-swap-test.js
+++ b/test/interactive-swap-test.js
@@ -83,7 +83,7 @@ describe('Interactive name swap', function() {
   });
 
   it('should win name with Alice\'s wallet', async () => {
-    await alice.sendOpen(name, false);
+    await alice.sendOpen(name);
     await mineBlocks(network.names.treeInterval + 1);
 
     await alice.sendBid(name, 100000, 200000);

--- a/test/net-spv-test.js
+++ b/test/net-spv-test.js
@@ -116,7 +116,7 @@ describe('SPV', function() {
     });
 
     it('should run auction and register name', async () => {
-      await wallet.sendOpen(name, false);
+      await wallet.sendOpen(name);
       await mineBlocks(treeInterval + 1);
       await wallet.sendBid(name, 10000, 10000);
       await mineBlocks(biddingPeriod);

--- a/test/wallet-accounts-auction-test.js
+++ b/test/wallet-accounts-auction-test.js
@@ -74,7 +74,7 @@ describe('Multiple accounts participating in same auction', function() {
   });
 
   it('should open an auction and proceed to REVEAL phase', async () => {
-    await wallet.sendOpen(name, false, {account: 0});
+    await wallet.sendOpen(name, {account: 0});
     await mineBlocks(network.names.treeInterval + 2);
     let ns = await node.chain.db.getNameStateByName(name);
     assert(ns.isBidding(node.chain.height, network));

--- a/test/wallet-auction-test.js
+++ b/test/wallet-auction-test.js
@@ -89,7 +89,7 @@ describe('Wallet Auction', function() {
 
   describe('Duplicate OPENs', function() {
     it('should open auction', async () => {
-      openAuctionMTX = await winner.createOpen(NAME1, false);
+      openAuctionMTX = await winner.createOpen(NAME1);
       await winner.sign(openAuctionMTX);
       const tx = openAuctionMTX.toTX();
       await wdb.addTX(tx);
@@ -98,7 +98,7 @@ describe('Wallet Auction', function() {
     it('should fail to create duplicate open', async () => {
       let err;
       try {
-        await winner.createOpen(NAME1, false);
+        await winner.createOpen(NAME1);
       } catch (e) {
         err = e;
       }
@@ -120,7 +120,7 @@ describe('Wallet Auction', function() {
     it('should fail to re-open auction during OPEN phase', async () => {
       let err;
       try {
-        await winner.createOpen(NAME1, false);
+        await winner.createOpen(NAME1);
       } catch (e) {
         err = e;
       }
@@ -151,7 +151,7 @@ describe('Wallet Auction', function() {
     it('should fail to re-open auction during BIDDING phase', async () => {
       let err;
       try {
-        await winner.createOpen(NAME1, false);
+        await winner.createOpen(NAME1);
       } catch (e) {
         err = e;
       }
@@ -169,7 +169,7 @@ describe('Wallet Auction', function() {
     });
 
     it('should open auction (again)', async () => {
-      openAuctionMTX2 = await winner.createOpen(NAME1, false);
+      openAuctionMTX2 = await winner.createOpen(NAME1);
       await winner.sign(openAuctionMTX2);
       const tx = openAuctionMTX2.toTX();
       await wdb.addTX(tx);
@@ -178,7 +178,7 @@ describe('Wallet Auction', function() {
     it('should fail to create duplicate open (again)', async () => {
       let err;
       try {
-        await winner.createOpen(NAME1, false);
+        await winner.createOpen(NAME1);
       } catch (e) {
         err = e;
       }

--- a/test/wallet-deepclean-test.js
+++ b/test/wallet-deepclean-test.js
@@ -75,7 +75,7 @@ describe('Wallet Deep Clean', function() {
       const name = i < 5 ? `alice${i}` : `bob${i}`;
       const array = i < 5 ? aliceBlinds : bobBlinds;
 
-      await w.sendOpen(name, false, {account: 0});
+      await w.sendOpen(name, {account: 0});
       await mineBlocks(network.names.treeInterval + 2);
 
       // Send two bids so there is a winner/loser and name gets a value

--- a/test/wallet-importname-test.js
+++ b/test/wallet-importname-test.js
@@ -86,8 +86,8 @@ describe('Wallet Import Name', function() {
     const ns2 = await bob.getNameStateByName(name);
     assert(ns2 === null);
 
-    await alice.sendOpen(name, false);
-    await alice.sendOpen(wrongName, false);
+    await alice.sendOpen(name);
+    await alice.sendOpen(wrongName);
 
     await mineBlocks(network.names.treeInterval);
     await wdb.rescan(0);
@@ -239,9 +239,9 @@ describe('Wallet Import Name', function() {
     let startHeight;
 
     it('should open and bid from Alice\'s wallet', async () => {
-      await alice.sendOpen(name1, false);
-      await alice.sendOpen(name2, false);
-      await alice.sendOpen(name3, false);
+      await alice.sendOpen(name1);
+      await alice.sendOpen(name2);
+      await alice.sendOpen(name3);
       startHeight = node.chain.tip.height;
 
       await mineBlocks(network.names.treeInterval + 1);

--- a/test/wallet-rescan-test.js
+++ b/test/wallet-rescan-test.js
@@ -106,7 +106,7 @@ describe('Wallet rescan with namestate transitions', function() {
     it('should run auction', async () => {
       // Poor Bob, all he does is send an OPEN but his wallet will
       // watch all the other activity including TRANSFERS for this name
-      await bob.sendOpen(NAME, true);
+      await bob.sendOpen(NAME);
       // Scatter unrelated TXs throughout the test.
       // This will ensure that txdb.removeBlock() removes TXs
       // in the reverse order from when they were added
@@ -590,7 +590,7 @@ describe('Wallet rescan with namestate transitions', function() {
     });
 
     it('should open and bid from wallet 1', async () => {
-      await wallet1.sendOpen(name, false);
+      await wallet1.sendOpen(name);
       await node.rpc.generateToAddress([treeInterval + 1, addr1]);
       await wallet1.sendBid(name, 1e6, 1e6);
       await node.rpc.generateToAddress([1, addr1]);

--- a/test/wallet-test.js
+++ b/test/wallet-test.js
@@ -2048,7 +2048,7 @@ describe('Wallet', function() {
     });
 
     it('should send and confirm OPEN', async () => {
-      const open = await wallet.sendOpen(name, false, {hardFee: fee});
+      const open = await wallet.sendOpen(name, {hardFee: fee});
       uTXCount++;
 
       // Check
@@ -2414,7 +2414,7 @@ describe('Wallet', function() {
     });
 
     it('should confirm new OPEN', async () => {
-      const open = await wallet.createOpen(name, false, {hardFee: fee});
+      const open = await wallet.createOpen(name, { hardFee: fee });
 
       // Check
       let bal = await wallet.getBalance();
@@ -3006,7 +3006,7 @@ describe('Wallet', function() {
     });
 
     it('should send and confirm OPEN', async () => {
-      const open = await wallet.sendOpen(name, false, { hardFee: fee });
+      const open = await wallet.sendOpen(name, { hardFee: fee });
       uTXCount++;
 
       // Check


### PR DESCRIPTION
`force` option is leftover after refactors as far as I can see in the history.
As it is not used and no one knows why it was there, might as well clean up.