### PR TITLE
wallet: refactor createTX to be more flexible

### DIFF
--- a/lib/wallet/wallet.js
+++ b/lib/wallet/wallet.js
@@ -3613,27 +3613,19 @@ class Wallet extends EventEmitter {
     return size;
   }
 
-  /**
-   * Build a transaction, fill it with outputs and inputs,
-   * sort the members according to BIP69 (set options.sort=false
-   * to avoid sorting), set locktime, and template it.
-   * @param {Object} options - See {@link Wallet#fund options}.
-   * @param {Object[]} options.outputs - See {@link MTX#addOutput}.
-   * @param {Object[]} options.outputs - See {@link MTX#addOutput}.
-   * @param {MTX?} mtx
-   * @returns {Promise} - Returns {@link MTX}.
-   */
+ /**
+  * Make a transaction with normal outputs.
+  * @param {Object[]} outputs - See {@link MTX#addOutput}
+  * @param {MTX} [mtx=null] - MTX to modify instead of new one.
+  * @returns {MTX} - MTX with populated outputs.
+  */
 
-  async createTX(options, force, mtx) {
-    const outputs = options.outputs;
-    let finish = false;
-    if (!mtx) {
-      finish = true;
+  makeTX(outputs, mtx) {
+    assert(Array.isArray(outputs), 'output must be an array.');
+    assert(outputs.length > 0, 'At least one output is required.');
+
+    if (!mtx)
       mtx = new MTX();
-    }
-
-    assert(Array.isArray(outputs), 'Outputs must be an array.');
-    assert(outputs.length > 0, 'At least one output required.');
 
     // Add the outputs
     for (const obj of outputs) {
@@ -3654,18 +3646,36 @@ class Wallet extends EventEmitter {
       mtx.outputs.push(output);
     }
 
-    // If a MTX was passed in to this function as an argument,
-    // we assume the caller is constructing a bigger TX and
-    // may still have more ins/out to add to it.
-    // That caller will have to call fund() and finalize()
-    // on their own when they are ready.
-    if (!finish)
-      return mtx;
+    return mtx;
+  }
 
-    // Fill the inputs with unspents
-    await this.fund(mtx, options, force);
+  /**
+   * Build a transaction, fill and finalize without a lock.
+   * @param {Object} options - See {@link Wallet#fund options}.
+   * @param {Object[]} options.outputs - See {@link MTX#addOutput}.
+   * @returns {Promise<MTX>} - MTX with populated inputs and outputs.
+   */
 
+  async _createTX(options) {
+    const mtx = this.makeTX(options.outputs);
+    await this.fill(mtx, options);
     return this.finalize(mtx, options);
+  }
+
+  /**
+   * Build a transaction, fill and finalize with a lock.
+   * @param {Object} options - See {@link Wallet#fund options}.
+   * @param {Object[]} options.outputs - See {@link MTX#addOutput}.
+   * @returns {Promise} - Returns {@link MTX}.
+   */
+
+  async createTX(options) {
+    const unlock = await this.fundLock.lock();
+    try {
+      return await this._createTX(options);
+    } finally {
+      unlock();
+    }
   }
 
   /**
@@ -3722,14 +3732,10 @@ class Wallet extends EventEmitter {
       switch (type) {
         case 'NONE':
           assert(action.length === 2);
-          await this.createTX(
-            {outputs: [{
-              address: action[0],
-              value: action[1]
-            }]},
-            force,
-            mtx
-          );
+          this.makeTX([{
+            address: action[0],
+            value: action[1]
+          }], mtx);
           break;
         case 'OPEN':
           assert(action.length === 1, 'Bad arguments for OPEN.');
@@ -3998,7 +4004,7 @@ class Wallet extends EventEmitter {
    */
 
   async _send(options, passphrase) {
-    const mtx = await this.createTX(options, true);
+    const mtx = await this._createTX(options);
     return this.sendMTX(mtx, passphrase);
   }
 

--- a/test/wallet-test.js
+++ b/test/wallet-test.js
@@ -1845,7 +1845,7 @@ describe('Wallet', function() {
    }
 
     assert(err);
-    assert.equal(err.message, 'At least one output required.');
+    assert.equal(err.message, 'At least one output is required.');
   });
 
   it('should cleanup', async () => {


### PR DESCRIPTION
Remove fundlock force hack for the send.

It now will repeat the same signature as others like it. (open, bid, ..)