### PR TITLE
wallet-http: reveals all now can be created without broadcasting.

### DIFF
--- a/lib/wallet/http.js
+++ b/lib/wallet/http.js
@@ -1152,12 +1152,13 @@ class HTTP extends Server {
         options
       );
 
+      if (broadcastBid)
+        auctionTxs.bid = await req.wallet.sendMTX(auctionTxs.bid, passphrase);
+
       if (sign) {
-        if (broadcastBid) {
-          auctionTxs.bid = await req.wallet.sendMTX(auctionTxs.bid, passphrase);
-        } else {
+        if (!broadcastBid)
           await req.wallet.sign(auctionTxs.bid, passphrase);
-        }
+
         await req.wallet.sign(auctionTxs.reveal, passphrase);
       }
 
@@ -1185,13 +1186,15 @@ class HTTP extends Server {
 
       enforce(broadcast ? sign : true, 'Must sign when broadcasting.');
 
-      if (!name) {
-        const tx = await req.wallet.sendRevealAll();
-        return res.json(200, tx.getJSON(this.network));
-      }
-
       const options = TransactionOptions.fromValidator(valid);
-      const mtx = await req.wallet.createReveal(name, options);
+
+      let mtx;
+
+      if (!name) {
+        mtx = await req.wallet.createRevealAll(options);
+      } else {
+        mtx = await req.wallet.createReveal(name, options);
+      }
 
       if (broadcast) {
         const tx = await req.wallet.sendMTX(mtx, passphrase);


### PR DESCRIPTION
Noticed on previous pr.

Now revealAll will be similar to redeemAll.