### PR TITLE
Don't reserve Alexa Top100 names, only reserve ICANN TLDs and "custom" list

### DIFF
--- a/lib/blockchain/chain.js
+++ b/lib/blockchain/chain.js
@@ -705,7 +705,7 @@ class Chain extends AsyncEmitter {
     if (await this.isActive(prev, deployments.hardening))
       state.nameFlags |= rules.nameFlags.VERIFY_COVENANTS_HARDENED;
 
-    // Disable ICANN, TOP100 and CUSTOM TLDs from getting auctioned.
+    // Disable ICANN and CUSTOM TLDs from getting auctioned.
     if (await this.isActive(prev, deployments.icannlockup))
       state.nameFlags |= rules.nameFlags.VERIFY_COVENANTS_LOCKUP;
 

--- a/lib/covenants/rules.js
+++ b/lib/covenants/rules.js
@@ -421,7 +421,7 @@ rules.isLockedUp = function isLockedUp(nameHash, height, network) {
   if (!item)
     return false;
 
-  if (item.root || item.top100 || item.custom)
+  if (item.root || item.custom)
     return true;
 
   return false;

--- a/test/chain-icann-lockup-test.js
+++ b/test/chain-icann-lockup-test.js
@@ -44,7 +44,7 @@ const ACTUAL_RENEWAL_WINDOW = network.names.renewalWindow;
  * Test will run failure and success paths and make sure both give
  * results soft-fork expects:
  *  - on failure: names can be auctioned.
- *  - on success: root, top100, custom and zero become
+ *  - on success: root, custom, and zero become
  *  unauctionable via mempool and blocks, for those running
  *  the node with updated software.
  */
@@ -118,14 +118,14 @@ describe('BIP9 - ICANN lockup (integration)', function() {
       });
     }
 
-    for (const name of [...ROOT, ...TOP100, ...CUSTOM]) {
+    for (const name of [...ROOT, ...CUSTOM]) {
       testCases.push({
         name,
         lockup: true,
         reserved: false,
         height: claimPeriod,
         testName: `should lockup after extended period times out (${name}), `
-          + 'and not be reserved (ROOT, TOP100, CUSTOM)'
+          + 'and not be reserved (ROOT, CUSTOM)'
       });
     }
 
@@ -884,9 +884,8 @@ describe('BIP9 - ICANN lockup (integration)', function() {
     it('should fail to open the auction for ICANN TLDs', async () => {
       const root = FROOT.shift();
       const custom = FCUSTOM.shift();
-      const top100 = FTOP100.shift();
 
-      const names = [root, custom, top100];
+      const names = [root, custom];
 
       for (const name of names) {
         const mtx = await wallet.createOpen(name);


### PR DESCRIPTION
### An update to existing SOFT FORK #819.

By looking at the full Alexa list of 100K names, it becomes clear there are many names which are just as popular or arguably more deserving than our _outdated_ [list of top 100](https://gist.github.com/nodech/a5a308e2b01456d1ea0e34f4be4bd609#file-top100-json). Because our list of top 100 is neither comprehensive nor maintained, it seems arbitrary to reserve them and not others. Why should `pinterest` be reserved but not `craigslist`? Additionally, two very generic terms `mail` and `ok` would potentially be reserved forever, requiring a hard fork to be released. Rather than trying to pick and choose which names should make the cut and relying on additional forks to re-enable claims, I think it's better to just let the claim period end as originally intended. We made a good faith effort to allow claims for 4 years, now time to move on.

This PR removes ALL Alexa names from the reserved list, which means they will ALL become available to OPEN around Jan 1st, 2024. Only ICANN TLDs and the short [list of 27 "custom" names](https://gist.github.com/nodech/da108d035cb3c694144cc564b07659e4) chosen by Handshake founders will be permanently reserved.

**Any discussion or feedback on this change should be resolved before July 1st in order to wrap up the HSD release and begin distribution and signaling.**

**Custom list of 27 names to be reserved (chosen by Handshake founders):**
https://gist.github.com/nodech/da108d035cb3c694144cc564b07659e4

**Alexa Top 100 names (to be released) here:**
https://gist.github.com/nodech/a5a308e2b01456d1ea0e34f4be4bd609#file-top100-json

**Alexa Top 100k names (to be released) here:**
https://gist.github.com/paste/4228c764c139a447de30de62afb9a393