### PR TITLE
Add http handlers for createclaim/sendclaim

### DIFF
--- a/lib/wallet/http.js
+++ b/lib/wallet/http.js
@@ -1439,6 +1439,38 @@ class HTTP extends Server {
 
       return res.json(200, json);
     });
+
+    // Create Claim
+    this.get('/wallet/:id/createclaim/:name', async (req, res) => {
+      const valid = Validator.fromRequest(req);
+      const name = valid.str('name');
+      
+      enforce(name, 'Must pass name.');
+      enforce(rules.verifyName(name), 'Must pass valid name.');
+
+      const claim = await req.wallet.createClaim(name);
+      return res.json(200, {
+        name: claim.name,
+        target: claim.target,
+        value: claim.value,
+        size: claim.size,
+        fee: claim.fee,
+        address: claim.address.toString(this.network),
+        txt: claim.txt
+      });
+    });
+
+    // Send Claim
+    this.post('/wallet/:id/sendclaim/:name', async (req, res) => {
+      const valid = Validator.fromRequest(req);
+      const name = valid.str('name');
+      
+      enforce(name, 'Must pass name.');
+      enforce(rules.verifyName(name), 'Must pass valid name.');
+
+      const claim = await req.wallet.sendClaim(name);
+      return res.json(200, claim.getJSON(this.network));
+    });
   }
 
   /**


### PR DESCRIPTION
This adds http handlers for the createclaim/sendclaim rpc methods.

This was made for shakestation so I could select which wallet to create/send claims from without having to rpc selectwallet which could potentially break other scripts that may have been running at the same time.