### PR TITLE
bin: fix config api-key alias

### DIFF
--- a/bin/hsd-cli
+++ b/bin/hsd-cli
@@ -42,7 +42,7 @@ class CLI {
         'n': 'network',
         'u': 'url',
         'uri': 'url',
-        'k': 'api-key',
+        'k': 'apikey',
         's': 'ssl',
         'h': 'httphost',
         'p': 'httpport'

--- a/bin/hsw-cli
+++ b/bin/hsw-cli
@@ -85,7 +85,7 @@ class CLI {
         'n': 'network',
         'u': 'url',
         'uri': 'url',
-        'k': 'api-key',
+        'k': 'apikey',
         's': 'ssl',
         'h': 'httphost',
         'p': 'httpport'


### PR DESCRIPTION
problem:

```sh
# start node
❯ hsd --memory --network regtest --api-key apikey

# use short arg name
❯ hsd-cli -k apikey info
Error: Unauthorized (bad API key).
    at NodeClient.request (/media/data/Projects/handshake/hsd/node_modules/bcurl/lib/client.js:221:13)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
    at async CLI.getInfo (/media/data/Projects/handshake/hsd/bin/hsd-cli:82:18)
    at async CLI.open (/media/data/Projects/handshake/hsd/bin/hsd-cli:233:9)
    at async /media/data/Projects/handshake/hsd/bin/hsd-cli:262:3
```

moved from hs-client repo:
- https://github.com/handshake-org/hs-client/pull/53