### PR TITLE
Fix bip9 signalling

### DIFF
--- a/lib/blockchain/chain.js
+++ b/lib/blockchain/chain.js
@@ -3582,7 +3582,7 @@ class Chain extends AsyncEmitter {
       const state = await this.getState(prev, deployment);
 
       if (state === thresholdStates.LOCKED_IN
-          || (state === thresholdStates.STARTED && deployment.force)) {
+          || state === thresholdStates.STARTED) {
         version |= 1 << deployment.bit;
       }
     }

--- a/lib/mining/miner.js
+++ b/lib/mining/miner.js
@@ -469,7 +469,7 @@ class MinerOptions {
     this.chain = null;
     this.mempool = null;
 
-    this.version = 0;
+    this.version = -1;
     this.addresses = [];
     this.coinbaseFlags = Buffer.from(`mined by ${pkg.name}`, 'ascii');
     this.preverify = false;

--- a/test/chain-icann-lockup-test.js
+++ b/test/chain-icann-lockup-test.js
@@ -1062,6 +1062,10 @@ async function mineBlock(node, opts = {}) {
 
   const job = await miner.cpu.createJob(chain.tip);
 
+  // opt out of all (esp. `hardening`) as
+  // some domains in this test still use RSA-1024
+  job.attempt.version = 0;
+
   if (setICANNLockup)
     job.attempt.version |= (1 << deployments[SOFT_FORK_NAME].bit);
 


### PR DESCRIPTION
Currently, it is not possible to signal for deployments which are `force: false`. This PR changes that by reverting 2 previous commits:
- https://github.com/handshake-org/hsd/pull/583 - `chain.computeBlockVersion()`
- https://github.com/handshake-org/hsd/commit/5e20a5aaaa7d4254ba88b14acd3b85f025330029 - `MinerOptions.version`

The way it's supposed to work is:
- `chain.computeBlockVersion` opts into all deployments
- `GetBlockTemplate` then opts out for those not included in `rules`

But,
- `getwork` and other software (b/hstratum) that depend on `Miner` directly, do not opt out at all
- and implicitly signal for all

To prevent this, the 2 temporary measures taken ~3 years ago:
- hard-coded Miner (used by getwork) to version 0 to skip calculating from chain, and
- made `chain.computeBlockVersion` only set force deployments bits
- which makes it impossible to signal non-force ones.

### Potential Breaking Change for miners

- Miners using `getblocktemplate` aren't affected, and can use `rules` to signal
- Miners using `getwork` will start signalling for all by default (including `hardening`)

Since `getwork` now activates `hardening`, it needs to be explicitly disabled in claim tests that use domains with weak keys (`cloudflare`, `nlnetlabs`, `dnscrypt`, etc.)

h/t @nodech who found all of this