### PR TITLE
wallet-http: put send transaction endpoints behind fund locks.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # HSD Release Notes & Changelog
 
+## Unreleased
+
+### Wallet API:
+
+- HTTP Changes:
+  - All transaction creating endpoints now accept `hardFee` for specifying the
+    exact fee.
+  - All transaction sending endpoints now fundlock/queue tx creation. (no more
+    conflicting transactions)
+
 ## v6.0.0
 
 ### Node and Wallet HTTP API

--- a/lib/wallet/http.js
+++ b/lib/wallet/http.js
@@ -1211,10 +1211,10 @@ class HTTP extends Server {
 
       // TODO: Add create TX with locks for used Coins and/or
       // adds to the pending list.
-      if (!name) {
-        mtx = await req.wallet.createRevealAll(options);
-      } else {
+      if (name) {
         mtx = await req.wallet.createReveal(name, options);
+      } else {
+        mtx = await req.wallet.createRevealAll(options);
       }
 
       if (sign)

--- a/lib/wallet/http.js
+++ b/lib/wallet/http.js
@@ -457,10 +457,9 @@ class HTTP extends Server {
     // Send TX
     this.post('/wallet/:id/send', async (req, res) => {
       const valid = Validator.fromRequest(req);
-      const passphrase = valid.str('passphrase');
 
       const options = TransactionOptions.fromValidator(valid);
-      const tx = await req.wallet.send(options, passphrase);
+      const tx = await req.wallet.send(options);
 
       const details = await req.wallet.getDetails(tx.hash());
 
@@ -470,7 +469,6 @@ class HTTP extends Server {
     // Create TX
     this.post('/wallet/:id/create', async (req, res) => {
       const valid = Validator.fromRequest(req);
-      const passphrase = valid.str('passphrase');
       const sign = valid.bool('sign', true);
 
       // TODO: Add create TX with locks for used Coins and/or
@@ -479,7 +477,7 @@ class HTTP extends Server {
       const tx = await req.wallet.createTX(options);
 
       if (sign)
-        await req.wallet.sign(tx, passphrase);
+        await req.wallet.sign(tx, options.passphrase);
 
       const json = tx.getJSON(this.network);
 

--- a/lib/wallet/http.js
+++ b/lib/wallet/http.js
@@ -473,6 +473,8 @@ class HTTP extends Server {
       const passphrase = valid.str('passphrase');
       const sign = valid.bool('sign', true);
 
+      // TODO: Add create TX with locks for used Coins and/or
+      // adds to the pending list.
       const options = TransactionOptions.fromValidator(valid);
       const tx = await req.wallet.createTX(options);
 
@@ -1068,7 +1070,6 @@ class HTTP extends Server {
     this.post('/wallet/:id/open', async (req, res) => {
       const valid = Validator.fromRequest(req);
       const name = valid.str('name');
-      const passphrase = valid.str('passphrase');
       const broadcast = valid.bool('broadcast', true);
       const sign = valid.bool('sign', true);
 
@@ -1076,15 +1077,19 @@ class HTTP extends Server {
       enforce(broadcast ? sign : true, 'Must sign when broadcasting.');
 
       const options = TransactionOptions.fromValidator(valid);
-      const mtx = await req.wallet.createOpen(name, options);
 
       if (broadcast) {
-        const tx = await req.wallet.sendMTX(mtx, passphrase);
+        // TODO: Add abort signal to close when request closes.
+        const tx = await req.wallet.sendOpen(name, options);
         return res.json(200, tx.getJSON(this.network));
       }
 
+      // TODO: Add create TX with locks for used Coins and/or
+      // adds to the pending list.
+      const mtx = await req.wallet.createOpen(name, options);
+
       if (sign)
-        await req.wallet.sign(mtx, passphrase);
+        await req.wallet.sign(mtx, options.passphrase);
 
       const json = mtx.getJSON(this.network);
 
@@ -1100,7 +1105,6 @@ class HTTP extends Server {
       const name = valid.str('name');
       const bid = valid.u64('bid');
       const lockup = valid.u64('lockup');
-      const passphrase = valid.str('passphrase');
       const broadcast = valid.bool('broadcast', true);
       const sign = valid.bool('sign', true);
 
@@ -1110,15 +1114,19 @@ class HTTP extends Server {
       enforce(broadcast ? sign : true, 'Must sign when broadcasting.');
 
       const options = TransactionOptions.fromValidator(valid);
-      const mtx = await req.wallet.createBid(name, bid, lockup, options);
 
       if (broadcast) {
-        const tx = await req.wallet.sendMTX(mtx, passphrase);
+        // TODO: Add abort signal to close when request closes.
+        const tx = await req.wallet.sendBid(name, bid, lockup, options);
         return res.json(200, tx.getJSON(this.network));
       }
 
+      // TODO: Add create TX with locks for used Coins and/or
+      // adds to the pending list.
+      const mtx = await req.wallet.createBid(name, bid, lockup, options);
+
       if (sign)
-        await req.wallet.sign(mtx, passphrase);
+        await req.wallet.sign(mtx, options.passphrase);
 
       const json = mtx.getJSON(this.network);
 
@@ -1180,7 +1188,6 @@ class HTTP extends Server {
     this.post('/wallet/:id/reveal', async (req, res) => {
       const valid = Validator.fromRequest(req);
       const name = valid.str('name');
-      const passphrase = valid.str('passphrase');
       const broadcast = valid.bool('broadcast', true);
       const sign = valid.bool('sign', true);
 
@@ -1188,21 +1195,32 @@ class HTTP extends Server {
 
       const options = TransactionOptions.fromValidator(valid);
 
+      if (broadcast) {
+        let tx;
+
+        if (name) {
+          // TODO: Add abort signal to close when request closes.
+          tx = await req.wallet.sendReveal(name, options);
+        } else {
+          // TODO: Add abort signal to close when request closes.
+          tx = await req.wallet.sendRevealAll(options);
+        }
+
+        return res.json(200, tx.getJSON(this.network));
+      }
+
       let mtx;
 
+      // TODO: Add create TX with locks for used Coins and/or
+      // adds to the pending list.
       if (!name) {
         mtx = await req.wallet.createRevealAll(options);
       } else {
         mtx = await req.wallet.createReveal(name, options);
       }
 
-      if (broadcast) {
-        const tx = await req.wallet.sendMTX(mtx, passphrase);
-        return res.json(200, tx.getJSON(this.network));
-      }
-
       if (sign)
-        await req.wallet.sign(mtx, passphrase);
+        await req.wallet.sign(mtx, options.passphrase);
 
       const json = mtx.getJSON(this.network);
 
@@ -1216,7 +1234,6 @@ class HTTP extends Server {
     this.post('/wallet/:id/redeem', async (req, res) => {
       const valid = Validator.fromRequest(req);
       const name = valid.str('name');
-      const passphrase = valid.str('passphrase');
       const broadcast = valid.bool('broadcast', true);
       const sign = valid.bool('sign', true);
 
@@ -1224,21 +1241,32 @@ class HTTP extends Server {
 
       const options = TransactionOptions.fromValidator(valid);
 
+      if (broadcast) {
+        let tx;
+
+        if (name) {
+          // TODO: Add abort signal to close when request closes.
+          tx = await req.wallet.sendRedeem(name, options);
+        } else {
+          // TODO: Add abort signal to close when request closes.
+          tx = await req.wallet.sendRedeemAll(options);
+        }
+
+        return res.json(200, tx.getJSON(this.network));
+      }
+
       let mtx;
 
+      // TODO: Add create TX with locks for used Coins and/or
+      // adds to the pending list.
       if (!name) {
         mtx = await req.wallet.createRedeemAll(options);
       } else {
         mtx = await req.wallet.createRedeem(name, options);
       }
 
-      if (broadcast) {
-        const tx = await req.wallet.sendMTX(mtx, passphrase);
-        return res.json(200, tx.getJSON(this.network));
-      }
-
       if (sign)
-        await req.wallet.sign(mtx, passphrase);
+        await req.wallet.sign(mtx, options.passphrase);
 
       const json = mtx.getJSON(this.network);
 
@@ -1253,7 +1281,6 @@ class HTTP extends Server {
       const valid = Validator.fromRequest(req);
       const name = valid.str('name');
       const data = valid.obj('data');
-      const passphrase = valid.str('passphrase');
       const broadcast = valid.bool('broadcast', true);
       const sign = valid.bool('sign', true);
 
@@ -1269,15 +1296,19 @@ class HTTP extends Server {
       }
 
       const options = TransactionOptions.fromValidator(valid);
-      const mtx = await req.wallet.createUpdate(name, resource, options);
 
       if (broadcast) {
-        const tx = await req.wallet.sendMTX(mtx, passphrase);
+        // TODO: Add abort signal to close when request closes.
+        const tx = await req.wallet.sendUpdate(name, resource, options);
         return res.json(200, tx.getJSON(this.network));
       }
 
+      // TODO: Add create TX with locks for used Coins and/or
+      // adds to the pending list.
+      const mtx = await req.wallet.createUpdate(name, resource, options);
+
       if (sign)
-        await req.wallet.sign(mtx, passphrase);
+        await req.wallet.sign(mtx, options.passphrase);
 
       const json = mtx.getJSON(this.network);
 
@@ -1291,7 +1322,6 @@ class HTTP extends Server {
     this.post('/wallet/:id/renewal', async (req, res) => {
       const valid = Validator.fromRequest(req);
       const name = valid.str('name');
-      const passphrase = valid.str('passphrase');
       const broadcast = valid.bool('broadcast', true);
       const sign = valid.bool('sign', true);
 
@@ -1299,15 +1329,17 @@ class HTTP extends Server {
       enforce(name, 'Must pass name.');
 
       const options = TransactionOptions.fromValidator(valid);
-      const mtx = await req.wallet.createRenewal(name, options);
 
       if (broadcast) {
-        const tx = await req.wallet.sendMTX(mtx, passphrase);
+        // TODO: Add abort signal to close when request closes.
+        const tx = await req.wallet.sendRenewal(name, options);
         return res.json(200, tx.getJSON(this.network));
       }
 
+      const mtx = await req.wallet.createRenewal(name, options);
+
       if (sign)
-        await req.wallet.sign(mtx, passphrase);
+        await req.wallet.sign(mtx, options.passphrase);
 
       const json = mtx.getJSON(this.network);
 
@@ -1322,7 +1354,6 @@ class HTTP extends Server {
       const valid = Validator.fromRequest(req);
       const name = valid.str('name');
       const address = valid.str('address');
-      const passphrase = valid.str('passphrase');
       const broadcast = valid.bool('broadcast', true);
       const sign = valid.bool('sign', true);
 
@@ -1332,15 +1363,19 @@ class HTTP extends Server {
 
       const addr = Address.fromString(address, this.network);
       const options = TransactionOptions.fromValidator(valid);
-      const mtx = await req.wallet.createTransfer(name, addr, options);
 
       if (broadcast) {
-        const tx = await req.wallet.sendMTX(mtx, passphrase);
+        // TODO: Add abort signal to close when request closes.
+        const tx = await req.wallet.sendTransfer(name, addr, options);
         return res.json(200, tx.getJSON(this.network));
       }
 
+      // TODO: Add create TX with locks for used Coins and/or
+      // adds to the pending list.
+      const mtx = await req.wallet.createTransfer(name, addr, options);
+
       if (sign)
-        await req.wallet.sign(mtx, passphrase);
+        await req.wallet.sign(mtx, options.passphrase);
 
       const json = mtx.getJSON(this.network);
 
@@ -1354,7 +1389,6 @@ class HTTP extends Server {
     this.post('/wallet/:id/cancel', async (req, res) => {
       const valid = Validator.fromRequest(req);
       const name = valid.str('name');
-      const passphrase = valid.str('passphrase');
       const broadcast = valid.bool('broadcast', true);
       const sign = valid.bool('sign', true);
 
@@ -1362,15 +1396,19 @@ class HTTP extends Server {
       enforce(name, 'Must pass name.');
 
       const options = TransactionOptions.fromValidator(valid);
-      const mtx = await req.wallet.createCancel(name, options);
 
       if (broadcast) {
-        const tx = await req.wallet.sendMTX(mtx, passphrase);
+        // TODO: Add abort signal to close when request closes.
+        const tx = await req.wallet.sendCancel(name, options);
         return res.json(200, tx.getJSON(this.network));
       }
 
+      // TODO: Add create TX with locks for used Coins and/or
+      // adds to the pending list.
+      const mtx = await req.wallet.createCancel(name, options);
+
       if (sign)
-        await req.wallet.sign(mtx, passphrase);
+        await req.wallet.sign(mtx, options.passphrase);
 
       const json = mtx.getJSON(this.network);
 
@@ -1384,7 +1422,6 @@ class HTTP extends Server {
     this.post('/wallet/:id/finalize', async (req, res) => {
       const valid = Validator.fromRequest(req);
       const name = valid.str('name');
-      const passphrase = valid.str('passphrase');
       const broadcast = valid.bool('broadcast', true);
       const sign = valid.bool('sign', true);
 
@@ -1392,15 +1429,17 @@ class HTTP extends Server {
       enforce(name, 'Must pass name.');
 
       const options = TransactionOptions.fromValidator(valid);
-      const mtx = await req.wallet.createFinalize(name, options);
 
       if (broadcast) {
-        const tx = await req.wallet.sendMTX(mtx, passphrase);
+        // TODO: Add abort signal to close when request closes.
+        const tx = await req.wallet.sendFinalize(name, options);
         return res.json(200, tx.getJSON(this.network));
       }
 
+      const mtx = await req.wallet.createFinalize(name, options);
+
       if (sign)
-        await req.wallet.sign(mtx, passphrase);
+        await req.wallet.sign(mtx, options.passphrase);
 
       const json = mtx.getJSON(this.network);
 
@@ -1414,7 +1453,6 @@ class HTTP extends Server {
     this.post('/wallet/:id/revoke', async (req, res) => {
       const valid = Validator.fromRequest(req);
       const name = valid.str('name');
-      const passphrase = valid.str('passphrase');
       const broadcast = valid.bool('broadcast', true);
       const sign = valid.bool('sign', true);
 
@@ -1422,15 +1460,19 @@ class HTTP extends Server {
       enforce(name, 'Must pass name.');
 
       const options = TransactionOptions.fromValidator(valid);
-      const mtx = await req.wallet.createRevoke(name, options);
 
       if (broadcast) {
-        const tx = await req.wallet.sendMTX(mtx, passphrase);
+        // TODO: Add abort signal to close when request closes.
+        const tx = await req.wallet.sendRevoke(name, options);
         return res.json(200, tx.getJSON(this.network));
       }
 
+      // TODO: Add create TX with locks for used Coins and/or
+      // adds to the pending list.
+      const mtx = await req.wallet.createRevoke(name, options);
+
       if (sign)
-        await req.wallet.sign(mtx, passphrase);
+        await req.wallet.sign(mtx, options.passphrase);
 
       const json = mtx.getJSON(this.network);
 
@@ -1814,6 +1856,8 @@ class TransactionOptions {
     this.subtractIndex = valid.i32('subtractIndex');
     this.depth = valid.u32(['confirmations', 'depth']);
     this.paths = valid.bool('paths');
+    this.passphrase = valid.str('passphrase');
+    this.hardFee = valid.u64('hardFee'),
     this.outputs = [];
 
     if (valid.has('outputs')) {

--- a/lib/wallet/wallet.js
+++ b/lib/wallet/wallet.js
@@ -4028,10 +4028,10 @@ class Wallet extends EventEmitter {
    * @returns {Promise} - Returns {@link TX}.
    */
 
-  async send(options, passphrase) {
+  async send(options) {
     const unlock = await this.fundLock.lock();
     try {
-      return await this._send(options, passphrase);
+      return await this._send(options);
     } finally {
       unlock();
     }
@@ -4045,7 +4045,8 @@ class Wallet extends EventEmitter {
    * @returns {Promise} - Returns {@link TX}.
    */
 
-  async _send(options, passphrase) {
+  async _send(options) {
+    const passphrase = options ? options.passphrase : null;
     const mtx = await this._createTX(options);
     return this.sendMTX(mtx, passphrase);
   }

--- a/test/wallet-http-test.js
+++ b/test/wallet-http-test.js
@@ -1734,6 +1734,7 @@ describe('Wallet HTTP', function() {
       checkDoubleSpends(txs);
 
       // spend all money for now.
+      // Passphrase not necessary as the wallet is unlocked.
       await rcwallet1.send({
         subtractFee: true,
         outputs: [{
@@ -1806,7 +1807,7 @@ describe('Wallet HTTP', function() {
       assert.strictEqual(balance1.coin, 6);
       assert.strictEqual(balance1.confirmed, HARD_FEE * 3);
 
-      // 3 bids (nothing extra)
+      // 6 bids (nothing extra)
       assert.strictEqual(balance2.coin, 6);
       assert.strictEqual(balance2.confirmed, (HARD_FEE - 1) * 6);
     });
@@ -1860,11 +1861,13 @@ describe('Wallet HTTP', function() {
     it('should register 3 times', async () => {
       const promises = [];
 
+      // We don't have funds to fund anything.
+      // Add 3 coins to pay for the fees and cause
+      // double spend.
       await fundNcoins(rcwallet1, 3, HARD_FEE);
 
       const forMemTX = common.forEvent(node.mempool, 'tx', 3);
 
-      // We don't have funds to fund anything.
       for (let i = 0; i < 3; i++) {
         promises.push(rcwallet1.createUpdate({
           name: NAMES[i],


### PR DESCRIPTION
HTTP Endpoints that are responsible to directly sending transactions to the mempool (except send tx) - did not use fund lock to queue the requests to the wallet. What ends up happening if you are running automated scripts or send multiple requests at once - coins wont get marked as spent before another set of coins are selected. Resulting in conflicting transactions.

This makes sure every send* transaction:
  - `POST /wallet/:id/open`
  - `POST /wallet/:id/bid`
  - `POST /wallet/:id/reveal`
  - `POST /wallet/:id/redeem`
  - `POST /wallet/:id/update`
  - `POST /wallet/:id/renewal`
  - `POST /wallet/:id/transfer`
  - `POST /wallet/:id/cancel`
  - `POST /wallet/:id/finalize`
  - `POST /wallet/:id/revoke`

Uses fundlock until the coin is added to the txdb, before processing next HTTP request.

### Hard Fee
  Expose `hardFee` as an option to the HTTP. This can help users to specify the exact FEE they want to pay for transaction.

### NOTE About TODOs.
>  // TODO: Add create TX with locks for used Coins and/or
>  // adds to the pending list.

  When creating transaction (w/o sending), you run into the same issue. If you create 2 transactions at once, chances are they will use the same coins to fund them. There are two solution with existing tools for this:
  - If createTX is `SIGNED`, we can add those transactions to the txdb w/o sending to the mempool.
  - If createTX is `NOT SIGNED`, we can LOCK those coins, to ensure next createTX does not use the same coins to fund next one.
  This can be done by introducing new flags: `insert` - if signed but no broadcast - we can look at this flag and insert into `txdb`. And another flag: `lock` - if we are not signed (and of course that also means no broadcast), we lock the coins in non-permanently.

> // TODO: Add abort signal to close when request closes.

  Big wallets, with lots of coins, or big transactions that needs lots of coins can take a some time to craft transactions before broadcasting. We get compounding effect when we use fundLocks where multiple requests are also queued.
  So allowing new request parameter `abortOnClose` can work by making sure that transaction creation is done before request closes. If request closes and transaction already was being sent, it will do nothing.