### PR TITLE
ci: no longer update npm on build.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,7 +54,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        node: [14.x, 16.x, 18.x]
+        node: [14.x, 16.x, 18.x, 20.x]
 
     steps:
     - uses: actions/checkout@v3
@@ -63,9 +63,6 @@ jobs:
       uses: actions/setup-node@v3
       with:
         node-version: ${{ matrix.node }}
-
-    - name: Update npm
-      run: npm i -g npm
 
     - name: Install libunbound
       if: contains(matrix.os, 'ubuntu')


### PR DESCRIPTION
- npm broke compatibility with older nodejs versions. No longer update npm. 
- add nodejs v20 to the matrix.