### PR TITLE
txdb: fix conflict event bug.

### DIFF
--- a/lib/wallet/txdb.js
+++ b/lib/wallet/txdb.js
@@ -1283,7 +1283,7 @@ class TXDB {
    * database. Disconnect inputs.
    * @private
    * @param {TXRecord} wtx
-   * @returns {Promise}
+   * @returns {Promise<Details?>}
    */
 
   async erase(wtx, block) {
@@ -1420,7 +1420,7 @@ class TXDB {
    * remove all of its spenders.
    * @private
    * @param {TXRecord} wtx
-   * @returns {Promise}
+   * @returns {Promise<Details?>}
    */
 
   async removeRecursive(wtx) {
@@ -1632,7 +1632,7 @@ class TXDB {
    * @private
    * @param {Hash} hash
    * @param {TX} ref - Reference tx, the tx that double-spent.
-   * @returns {Promise} - Returns Boolean.
+   * @returns {Promise<Details?>} - Returns Boolean.
    */
 
   async removeConflict(wtx) {
@@ -1641,6 +1641,9 @@ class TXDB {
     this.logger.warning('Handling conflicting tx: %x.', tx.hash());
 
     const details = await this.removeRecursive(wtx);
+
+    if (!details)
+      return null;
 
     this.logger.warning('Removed conflict: %x.', tx.hash());
 


### PR DESCRIPTION
- Don't emit conflict event when transaction was not removed.

Port of https://github.com/bcoin-org/bcoin/pull/977