### PR TITLE
specify permanently hard-coded seed node locations

### DIFF
--- a/lib/net/seeds/main.js
+++ b/lib/net/seeds/main.js
@@ -1,25 +1,25 @@
 'use strict';
 
 module.exports = [
-  // pinheadmz
+  // Santa Clara, California, US (pinheadmz)
   'aonetsezqp4m52w4jpfq2gv3dggy2wqfwqtkfjyttgdidbvhgp5as@165.22.151.242',
-  // Falci
+  // Atlanta, Georgia, US (Falci)
   'ajpbuxkwtf7hkwbpw27siwg6dylsly4743rbhy2jssb3rxmircbrs@50.116.35.178',
-  // rithvikvibhu
+  // Ashburn, Virginia, US (rithvikvibhu)
   'aksygghkgmciomeldjf5sc6rs2sgn2m34zfdz4xr7z5vguqvjis4e@129.153.177.220',
-  // buffrr
+  // Chicago, Illinois, US (buffrr)
   'ai2wxnj4magzrhtlfvqnzuzg3vko25vryle5vd2bzi23jvcykbj5q@107.152.33.71',
-  // anon
+  // Mainz, Rheinland-Pfalz, DE (anon)
   'apt4rf2dfyelbivg63u47wykvdjtsl4kxzfdylkaae5s5ydldlnwu@159.69.46.23',
-  // chjj
+  // Fremont, California, US (chjj)
   'ajdzrpoxsusaw4ixq4ttibxxsuh5fkkduc5qszyboidif2z25i362@173.255.209.126',
-  // chjj
+  // Fremont, California, US (chjj)
   'akimcha5bck7s344dmge6k3agtxd2txi6x4qzg3mo26spvf5bjol2@74.207.247.120',
-  // chjj
+  // Morris Plains, New Jersey, US (chjj)
   'aoihqqagbhzz6wxg43itefqvmgda4uwtky362p22kbimcyg5fdp54@172.104.214.189',
-  // chjj
+  // Frankfurt am Main, Hesse, DE (chjj)
   'am2lsmbzzxncaptqjo22jay3mztfwl33bxhkp7icfx7kmi5rvjaic@139.162.183.168',
-  // chjj
+  // Morris Plains, New Jersey, US (chjj)
   'ap5vuwabzwyz6akhesanada4skhetd2jsvpkwuqxzuaoovn5ez4xg@45.79.134.225',
 
   // Same nodes as above, but clearnet


### PR DESCRIPTION
Could be confirmed with https://ipinfo.io, https://hnsnodes.htools.work/api/v1/snapshots/latest/reachable or https://shakenodes.

I decided to look into the permanent seed node locations during my work on https://github.com/opensystm/handshake-micro-grants/issues/5. 8 are in US and 2 are in DE.