### PR TITLE
Wallet: Add open/close and connect/disconnect events.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ you run it for the first time.**
 ### Wallet Changes:
 
 - Add migration that recalculates txdb balances to fix any inconsistencies.
+- WalletDB Now emits events for: `open`, `close`, `connect`, `disconnect`.
 - HTTP Changes:
   - All transaction creating endpoints now accept `hardFee` for specifying the
     exact fee.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,21 @@
 you run it for the first time.**
 
 ### Wallet Changes:
+#### Configuration
+  Wallet now has option `wallet-migrate-no-rescan`/`migrate-no-rescan` if you
+want to disable rescan when migration recommends it. It may result in the
+incorrect txdb state, but can be useful if you know the issue does not affect
+your wallet or is not critical.
+
+#### Wallet API
 
 - Add migration that recalculates txdb balances to fix any inconsistencies.
 - WalletDB Now emits events for: `open`, `close`, `connect`, `disconnect`.
+- WalletDB
+  - `open()` no longer calls `connect` and needs separate call `connect`.
+  - `open()` no longer calls scan, instead only rollbacks and waits for
+    sync to do the rescan.
+  - emits events for: `open`, `close`, `connect`, `disconnect`, `sync done`.
 - HTTP Changes:
   - All transaction creating endpoints now accept `hardFee` for specifying the
     exact fee.

--- a/lib/wallet/node.js
+++ b/lib/wallet/node.js
@@ -52,6 +52,7 @@ class WalletNode extends Node {
       wipeNoReally: this.config.bool('wipe-no-really'),
       spv: this.config.bool('spv'),
       walletMigrate: this.config.uint('migrate'),
+      migrateNoRescan: this.config.bool('migrate-no-rescan', false),
       icannlockup: this.config.bool('icannlockup', false)
     });
 
@@ -107,6 +108,7 @@ class WalletNode extends Node {
     await this.openPlugins();
 
     await this.http.open();
+    await this.wdb.connect();
     await this.handleOpen();
 
     this.logger.info('Wallet node is loaded.');
@@ -128,6 +130,7 @@ class WalletNode extends Node {
 
     this.rpc.wallet = null;
 
+    await this.wdb.disconnect();
     await this.wdb.close();
     await this.handleClose();
   }

--- a/lib/wallet/plugin.js
+++ b/lib/wallet/plugin.js
@@ -57,6 +57,7 @@ class Plugin extends EventEmitter {
       wipeNoReally: this.config.bool('wipe-no-really'),
       spv: node.spv,
       walletMigrate: this.config.uint('migrate'),
+      migrateNoRescan: this.config.bool('migrate-no-rescan', false),
       icannlockup: this.config.bool('icannlockup', false)
     });
 
@@ -90,11 +91,13 @@ class Plugin extends EventEmitter {
     await this.wdb.open();
     this.rpc.wallet = this.wdb.primary;
     await this.http.open();
+    await this.wdb.connect();
   }
 
   async close() {
     await this.http.close();
     this.rpc.wallet = null;
+    await this.wdb.disconnect();
     await this.wdb.close();
   }
 }

--- a/lib/wallet/walletdb.js
+++ b/lib/wallet/walletdb.js
@@ -64,12 +64,18 @@ class WalletDB extends EventEmitter {
     this.name = 'wallet';
     this.version = 2;
 
-    this.primary = null;
+    // chain state.
+    this.hasStateCache = false;
     this.state = new ChainState();
-    this.confirming = false;
     this.height = 0;
+
+    // wallets
+    this.primary = null;
     this.wallets = new Map();
     this.depth = 0;
+
+    // guards
+    this.confirming = false;
     this.rescanning = false;
     this.filterSent = false;
 
@@ -203,7 +209,7 @@ class WalletDB extends EventEmitter {
       await this.wipe();
 
     await this.watch();
-    await this.connect();
+    await this.loadState();
 
     this.logger.info(
       'WalletDB loaded (depth=%d, height=%d, start=%d).',
@@ -224,8 +230,13 @@ class WalletDB extends EventEmitter {
     this.primary = wallet;
 
     if (migrationResult.rescan) {
-      this.logger.info('Rescanning...');
-      await this.scan(0);
+      if (!this.options.migrateNoRescan) {
+        this.logger.info('Migration rollback...');
+        await this.rollback(0);
+      } else {
+        this.logger.warning(
+          'Migration rescan skipped, state may be incorrect.');
+      }
     }
 
     this.logger.info('WalletDB opened.');
@@ -275,7 +286,8 @@ class WalletDB extends EventEmitter {
    */
 
   async close() {
-    await this.disconnect();
+    if (this.client.opened)
+      await this.disconnect();
 
     for (const wallet of this.wallets.values()) {
       await wallet.destroy();
@@ -375,7 +387,7 @@ class WalletDB extends EventEmitter {
     const unlock = await this.txLock.lock();
     try {
       this.logger.info('Resyncing from server...');
-      await this.syncState();
+      await this.syncInitState();
       await this.syncFilter();
       await this.syncChain();
       await this.resend();
@@ -385,18 +397,31 @@ class WalletDB extends EventEmitter {
   }
 
   /**
+   * Recover state from the cache.
+   * @returns {Promise}
+   */
+
+  async loadState() {
+    const cache = await this.getState();
+
+    if (!cache)
+      return;
+
+    this.logger.info('Initialized chain state from the database.');
+    this.hasStateCache = true;
+    this.state = cache;
+    this.height = cache.height;
+  }
+
+  /**
    * Initialize and write initial sync state.
    * @returns {Promise}
    */
 
-  async syncState() {
-    const cache = await this.getState();
-
-    if (cache) {
-      this.state = cache;
-      this.height = cache.height;
-      return undefined;
-    }
+  async syncInitState() {
+    // We have recovered from the cache.
+    if (this.hasStateCache)
+      return;
 
     this.logger.info('Initializing database state from server.');
 
@@ -427,7 +452,7 @@ class WalletDB extends EventEmitter {
     this.state = state;
     this.height = state.height;
 
-    return undefined;
+    return;
   }
 
   /**
@@ -2192,6 +2217,7 @@ class WalletDB extends EventEmitter {
     await iter.each(async (key, value) => {
       const [height] = layout.b.decode(key);
       const block = MapRecord.decode(value);
+      this.logger.info('Reverting block: %d', height);
 
       for (const wid of block.wids) {
         const wallet = await this.get(wid);
@@ -2501,6 +2527,7 @@ class WalletOptions {
     this.spv = false;
     this.wipeNoReally = false;
     this.walletMigrate = -1;
+    this.migrateNoRescan = false;
     this.icannlockup = false;
 
     if (options)
@@ -2587,6 +2614,11 @@ class WalletOptions {
     if (options.icannlockup != null) {
       assert(typeof options.icannlockup === 'boolean');
       this.icannlockup = options.icannlockup;
+    }
+
+    if (options.migrateNoRescan != null) {
+      assert(typeof options.migrateNoRescan === 'boolean');
+      this.migrateNoRescan = options.migrateNoRescan;
     }
 
     return this;

--- a/lib/wallet/walletdb.js
+++ b/lib/wallet/walletdb.js
@@ -122,6 +122,7 @@ class WalletDB extends EventEmitter {
     });
 
     this.client.on('connect', async () => {
+      this.emit('connect');
       try {
         await this.syncNode();
         this.emit('sync done', this.state);
@@ -131,6 +132,7 @@ class WalletDB extends EventEmitter {
     });
 
     this.client.on('disconnect', async () => {
+      this.emit('disconnect');
       this.filterSent = false;
     });
 
@@ -225,6 +227,9 @@ class WalletDB extends EventEmitter {
       this.logger.info('Rescanning...');
       await this.scan(0);
     }
+
+    this.logger.info('WalletDB opened.');
+    this.emit('open');
   }
 
   /**
@@ -277,7 +282,9 @@ class WalletDB extends EventEmitter {
       this.unregister(wallet);
     }
 
-    return this.db.close();
+    await this.db.close();
+    this.logger.info('WalletDB Closed.');
+    this.emit('close');
   }
 
   /**

--- a/test/mempool-reorg-test.js
+++ b/test/mempool-reorg-test.js
@@ -8,6 +8,7 @@ const plugin = require('../lib/wallet/plugin');
 const Coin = require('../lib/primitives/coin');
 const Address = require('../lib/primitives/address');
 const MTX = require('../lib/primitives/mtx');
+const {forEvent} = require('./util/common');
 
 const network = Network.get('regtest');
 const {
@@ -25,8 +26,13 @@ describe('Mempool Covenant Reorg', function () {
   let wallet, name;
 
   before(async () => {
+    const wdb = node.require('walletdb').wdb;
+    const syncDone = forEvent(wdb, 'sync done');
     await node.open();
+
     wallet = node.get('walletdb').wdb.primary;
+
+    await syncDone;
   });
 
   after(async () => {

--- a/test/wallet-auction-test.js
+++ b/test/wallet-auction-test.js
@@ -64,6 +64,7 @@ describe('Wallet Auction', function() {
     await chain.open();
     await miner.open();
     await wdb.open();
+    await wdb.connect();
 
     // Set up wallet
     winner = await wdb.create();
@@ -81,6 +82,7 @@ describe('Wallet Auction', function() {
   });
 
   after(async () => {
+    await wdb.disconnect();
     await wdb.close();
     await miner.close();
     await chain.close();

--- a/test/wallet-migration-test.js
+++ b/test/wallet-migration-test.js
@@ -722,7 +722,7 @@ describe('Wallet Migrations', function() {
       assert.strictEqual(balance.clocked, expected.clocked);
     };
 
-    let walletDB, ldb, wdbOpenSync;
+    let walletDB, ldb;
     before(async () => {
       WalletMigrator.migrations = {};
       await fs.mkdirp(location);
@@ -736,7 +736,6 @@ describe('Wallet Migrations', function() {
     beforeEach(async () => {
       walletDB = new WalletDB(walletOptions);
       ldb = walletDB.db;
-      wdbOpenSync = wdbOpenSyncFn(walletDB);
     });
 
     afterEach(async () => {
@@ -746,7 +745,7 @@ describe('Wallet Migrations', function() {
 
     it('should write some coins w/o updating balance', async () => {
       // generate credits for the first 10 addresses stored on initialization.
-      await wdbOpenSync();
+      await walletDB.open();
 
       const wallet = walletDB.primary;
 
@@ -871,7 +870,7 @@ describe('Wallet Migrations', function() {
     });
 
     it('should have incorrect balance before migration', async () => {
-      await wdbOpenSync();
+      await walletDB.open();
 
       const wallet = walletDB.primary;
       const balance = await wallet.getBalance(-1);
@@ -903,7 +902,7 @@ describe('Wallet Migrations', function() {
     it('should migrate', async () => {
       walletDB.options.walletMigrate = 0;
 
-      await wdbOpenSync();
+      await walletDB.open();
 
       const wallet = walletDB.primary;
       const balance = await wallet.getBalance(-1);

--- a/test/wallet-test.js
+++ b/test/wallet-test.js
@@ -2158,6 +2158,7 @@ describe('Wallet', function() {
 
     before(async () => {
       await wdb.open();
+      await wdb.connect();
       wallet = await wdb.create();
       recip = await wdb.create();
       // rollout all names
@@ -2165,6 +2166,7 @@ describe('Wallet', function() {
     });
 
     after(async () => {
+      await wdb.disconnect();
       await wdb.close();
     });
 
@@ -2962,6 +2964,7 @@ describe('Wallet', function() {
 
     before(async () => {
       await wdb.open();
+      await wdb.connect();
       wallet = await wdb.create();
 
       for (let i = 0; i < 3; i++) {
@@ -2971,6 +2974,7 @@ describe('Wallet', function() {
     });
 
     after(async () => {
+      await wdb.disconnect();
       await wdb.close();
     });
 


### PR DESCRIPTION
WalletDB `open` does not guarantee that the connection will open, if it's in standalone mode it may fail. So having the connect method inside `open` w/o any guarantees leaves any logic depending on it break. So it's much better to totally remove the concept of connection from open.

This changes several things:
  - on open state cache needs to be recovered first (it was done on connect). If we don't have cache, then we initialize after on `connect` in the syncNode.
  - migration can no longer start a rescan (and it may have failed previously on standalone) - it will instead rollback. 
  - Added new flag `wallet-migration-no-rescan` - that tells to ignore rescan request from the migration.

Restructure the life-cycle methods for the walletdb.

 - open - no longer calls connect - now emits `open` event.
 - connect - needs to be called separately - now emits `connect` event.
 - disconnect - now emits `disconnect` event
 - close - will try to close client if it's open - now emits `close` event.
