### PR TITLE
lint: update to es2020. Use latest bslint

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,19 +1,9 @@
 {
   "env": {
-    "es6": true,
+    "es2020": true,
     "node": true
   },
   "extends": "eslint:recommended",
-  "globals": {
-    "Atomics": "readable",
-    "BigInt": "readable",
-    "BigInt64Array": "readable",
-    "BigUint64Array": "readable",
-    "queueMicrotask": "readable",
-    "SharedArrayBuffer": "readable",
-    "TextEncoder": "readable",
-    "TextDecoder": "readable"
-  },
   "overrides": [
     {
       "files": ["*.mjs"],
@@ -44,9 +34,8 @@
       }
     }
   ],
-  "parser": "babel-eslint",
   "parserOptions": {
-    "ecmaVersion": 10,
+    "ecmaVersion": 11,
     "ecmaFeatures": {
       "globalReturn": true
     },

--- a/lib/dns/resource.js
+++ b/lib/dns/resource.js
@@ -877,7 +877,7 @@ function typeToClass(type) {
 function stringToClass(type) {
   assert(typeof type === 'string');
 
-  if (!hsTypes.hasOwnProperty(type))
+  if (!Object.prototype.hasOwnProperty.call(hsTypes, type))
     return null;
 
   return typeToClass(hsTypes[type]);

--- a/lib/primitives/airdropkey.js
+++ b/lib/primitives/airdropkey.js
@@ -363,7 +363,7 @@ class AirdropKey extends bio.Struct {
   fromJSON(json) {
     assert(json && typeof json === 'object');
     assert(typeof json.type === 'string');
-    assert(keyTypes.hasOwnProperty(json.type));
+    assert(Object.prototype.hasOwnProperty.call(keyTypes, json.type));
 
     this.type = keyTypes[json.type];
 

--- a/lib/primitives/claim.js
+++ b/lib/primitives/claim.js
@@ -175,7 +175,7 @@ class Claim extends bio.Struct {
       Buffer.from(data.name, 'binary'),
       flags,
       data.commitHash,
-      data.commitHeight,
+      data.commitHeight
     );
 
     tx.inputs.push(input);

--- a/lib/wallet/wallet.js
+++ b/lib/wallet/wallet.js
@@ -3268,7 +3268,7 @@ class Wallet extends EventEmitter {
       flags,
       ns.claimed,
       ns.renewals,
-      await this.wdb.getRenewalBlock(),
+      await this.wdb.getRenewalBlock()
     );
 
     if (!mtx)

--- a/test/interactive-swap-test.js
+++ b/test/interactive-swap-test.js
@@ -170,7 +170,7 @@ describe('Interactive name swap', function() {
       0, // flags, may be required if name was CLAIMed
       ns.claimed,
       ns.renewals,
-      await wdb.getRenewalBlock(),
+      await wdb.getRenewalBlock()
     );
 
     const output1 = new Output();

--- a/test/util/memwallet.js
+++ b/test/util/memwallet.js
@@ -1538,7 +1538,7 @@ class MemWallet {
       flags,
       ns.claimed,
       ns.renewals,
-      this.getRenewalBlock(),
+      this.getRenewalBlock()
     );
 
     const mtx = new MTX();

--- a/test/wallet-test.js
+++ b/test/wallet-test.js
@@ -2723,7 +2723,7 @@ describe('Wallet', function() {
       output.covenant.setReveal(
         nameHash,
         start,
-        Buffer.alloc(32),
+        Buffer.alloc(32)
       );
 
       const mtx = new MTX();


### PR DESCRIPTION
Update to latest bslint: 8.54 in the CI.

Update to es2020, more or less covered by minimum node v14.
