### PR TITLE
Update wallet and node clients

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,6 +1,6 @@
 {
   "env": {
-    "es2022": true,
+    "es2024": true,
     "node": true
   },
   "extends": "eslint:recommended",
@@ -35,7 +35,7 @@
     }
   ],
   "parserOptions": {
-    "ecmaVersion": 13,
+    "ecmaVersion": "latest",
     "ecmaFeatures": {
       "globalReturn": true
     },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,9 @@ process and allows parallel rescans.
     - expects ws hook for `block rescan interactive` params `rawEntry, rawTXs`
       that returns scanAction object.
     - expects ws hook for `block rescan interactive abort` param `message`.
+  - Add `getMempoolRejectionFilter` and `checkMempoolRejectionFilter` NodeClient
+  aliases.
+  - Add `getFee`, an HTTP alternative to estimateFee socket call.
 
 ### Wallet Changes
 #### Configuration

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,11 +61,13 @@ process and allows parallel rescans.
   - `open()` no longer calls scan, instead only rollbacks and waits for
     sync to do the rescan.
   - emits events for: `open`, `close`, `connect`, `disconnect`, `sync done`.
-- HTTP Changes:
+
+### Wallet HTTP Client
   - All transaction creating endpoints now accept `hardFee` for specifying the
     exact fee.
   - All transaction sending endpoints now fundlock/queue tx creation. (no more
     conflicting transactions)
+  - Add options to `getNames` for passing `own`.
 
 ## v6.0.0
 

--- a/lib/client/node.js
+++ b/lib/client/node.js
@@ -58,6 +58,26 @@ class NodeClient extends Client {
   }
 
   /**
+   * Get a mempool rejection filter.
+   * @param {Object} options
+   * @returns {Promise}
+   */
+
+  getMempoolRejectionFilter(options) {
+    return this.get('/mempool/invalid', options);
+  }
+
+  /**
+   * Check against mempool rejection filter.
+   * @param {Hash} hash - transaction hash
+   * @returns {Promise}
+   */
+
+  checkMempoolRejectionFilter(hash) {
+    return this.get(`/mempool/invalid/${hash}`);
+  }
+
+  /**
    * Get some info about the server (network and version).
    * @returns {Promise}
    */
@@ -181,6 +201,17 @@ class NodeClient extends Client {
   broadcastClaim(claim) {
     assert(typeof claim === 'string');
     return this.post('/claim', { claim });
+  }
+
+  /**
+   * Estimate smart fee. Same as estimateFee, but
+   * an HTTP call instead of websocket call.
+   * @param {Number} blocks
+   * @returns {Promise}
+   */
+
+  getSmartFee(blocks) {
+    return this.get('/fee', { blocks });
   }
 
   /**

--- a/lib/client/wallet.js
+++ b/lib/client/wallet.js
@@ -118,6 +118,9 @@ class WalletClient extends Client {
 
   /**
    * Create a wallet object.
+   * @param {String} id
+   * @param {String} [token]
+   * @returns {Wallet}
    */
 
   wallet(id, token) {
@@ -339,11 +342,13 @@ class WalletClient extends Client {
    * that the wallet is managing.
    * {@see hsd.NameState}
    * @param {String} id
+   * @param {Object} options
+   * @param {Boolean} [optoins.own=false]
    * @returns {Promise}
    */
 
-  getNames(id) {
-    return this.get(`/wallet/${id}/name`);
+  getNames(id, options) {
+    return this.get(`/wallet/${id}/name`, options);
   }
 
   /**
@@ -893,6 +898,18 @@ class WalletClient extends Client {
  */
 
 class Wallet extends EventEmitter {
+  /** @type {WalletClient} */
+  client;
+
+  /** @type {WalletClient} */
+  parent;
+
+  /** @type {String} */
+  id;
+
+  /** @type {String} */
+  token;
+
   /**
    * Create a wallet client.
    * @param {Object?} options
@@ -1051,11 +1068,13 @@ class Wallet extends EventEmitter {
    * Get name state for all names
    * that the wallet is managing.
    * {@see hsd.NameState}
+   * @param {Object} options
+   * @param {Boolean} [optoins.own=false]
    * @returns {Promise}
    */
 
-  getNames() {
-    return this.client.getNames(this.id);
+  getNames(options) {
+    return this.client.getNames(this.id, options);
   }
 
   /**

--- a/test/node-http-test.js
+++ b/test/node-http-test.js
@@ -39,7 +39,9 @@ describe('Node HTTP', function() {
     });
 
     it('should get mempool rejection filter', async () => {
-      const filterInfo = await nclient.get('/mempool/invalid', { verbose: true });
+      const filterInfo = await nclient.getMempoolRejectionFilter({
+        verbose: true
+      });
 
       assert.ok('items' in filterInfo);
       assert.ok('filter' in filterInfo);
@@ -59,10 +61,10 @@ describe('Node HTTP', function() {
       const raw = mtx.toHex();
       const txid = await nclient.execute('sendrawtransaction', [raw]);
 
-      const json = await nclient.get(`/mempool/invalid/${txid}`);
+      const json = await nclient.checkMempoolRejectionFilter(txid);
       assert.equal(json.invalid, true);
 
-      const filterInfo = await nclient.get('/mempool/invalid');
+      const filterInfo = await nclient.getMempoolRejectionFilter();
       assert.equal(filterInfo.entries, 1);
     });
   });
@@ -90,7 +92,7 @@ describe('Node HTTP', function() {
 
       // fetch corresponding header and block
       const height = 7;
-      const header = await nclient.get(`/header/${height}`);
+      const header = await nclient.getBlockHeader(height);
       assert.equal(header.height, height);
 
       const properties = [
@@ -116,7 +118,7 @@ describe('Node HTTP', function() {
 
     it('should fetch null for block header that does not exist', async () => {
       // many blocks in the future
-      const header = await nclient.get(`/header/${40000}`);
+      const header = await nclient.getBlockHeader(40000);
       assert.equal(header, null);
     });
 
@@ -130,7 +132,7 @@ describe('Node HTTP', function() {
       let prevBlock = '0000000000000000000000000000000000000000000000000000000000000000';
 
       for (let i = 0; i < 10; i++) {
-        const header = await nclient.get(`/header/${i}`);
+        const header = await nclient.getBlockHeader(i);
 
         assert.equal(prevBlock, header.prevBlock);
         prevBlock = header.hash;
@@ -140,8 +142,8 @@ describe('Node HTTP', function() {
     it('should fetch block header by hash', async () => {
       const info = await nclient.getInfo();
 
-      const headerByHash = await nclient.get(`/header/${info.chain.tip}`);
-      const headerByHeight = await nclient.get(`/header/${info.chain.height}`);
+      const headerByHash = await nclient.getBlockHeader(info.chain.tip);
+      const headerByHeight = await nclient.getBlockHeader(info.chain.height);
 
       assert.deepEqual(headerByHash, headerByHeight);
     });

--- a/test/util/node-context.js
+++ b/test/util/node-context.js
@@ -11,6 +11,15 @@ const {NodeClient, WalletClient} = require('../../lib/client');
 const Logger = require('blgr');
 
 class NodeContext {
+  /** @type {FullNode|SPVNode} */
+  node;
+
+  /** @type {WalletClient} */
+  wclient;
+
+  /** @type {NodeClient} */
+  nclient;
+
   constructor(options = {}) {
     this.name = 'node-test';
     this.options = {};

--- a/test/wallet-http-test.js
+++ b/test/wallet-http-test.js
@@ -1787,9 +1787,7 @@ describe('Wallet HTTP', function() {
     });
 
     it('should only get wallet-owned names', async () => {
-      // TODO: convert to using hs-client method
-      // when wallet.getNames() allows `options`
-      const names = await wallet.client.get(`/wallet/${wallet.id}/name`, {own: true});
+      const names = await wallet.getNames({ own: true });
 
       assert.equal(names.length, ownedNames.length);
 


### PR DESCRIPTION
#### Node client
   - Add `getMempoolRejectionFilter` and `checkMempoolRejectionFilter` NodeClient
  aliases.
  - Add `getFee`, an HTTP alternative to estimateFee socket call.

#### Wallet client
   - Add options to `getNames` for passing `own`.