### PR TITLE
wallet: set icannlockup to true for wallets.

### DIFF
--- a/lib/wallet/node.js
+++ b/lib/wallet/node.js
@@ -52,7 +52,7 @@ class WalletNode extends Node {
       wipeNoReally: this.config.bool('wipe-no-really'),
       spv: this.config.bool('spv'),
       walletMigrate: this.config.uint('migrate'),
-      icannlockup: this.config.bool('icannlockup', false),
+      icannlockup: this.config.bool('icannlockup', true),
       migrateNoRescan: this.config.bool('migrate-no-rescan', false),
       preloadAll: this.config.bool('preload-all', false)
     });

--- a/lib/wallet/plugin.js
+++ b/lib/wallet/plugin.js
@@ -57,7 +57,7 @@ class Plugin extends EventEmitter {
       wipeNoReally: this.config.bool('wipe-no-really'),
       spv: node.spv,
       walletMigrate: this.config.uint('migrate'),
-      icannlockup: this.config.bool('icannlockup', false),
+      icannlockup: this.config.bool('icannlockup', true),
       migrateNoRescan: this.config.bool('migrate-no-rescan', false),
       preloadAll: this.config.bool('preload-all', false)
     });

--- a/lib/wallet/walletdb.js
+++ b/lib/wallet/walletdb.js
@@ -2578,7 +2578,7 @@ class WalletOptions {
     this.spv = false;
     this.wipeNoReally = false;
     this.walletMigrate = -1;
-    this.icannlockup = false;
+    this.icannlockup = true;
     this.migrateNoRescan = false;
     this.preloadAll = false;
 

--- a/test/chain-icann-lockup-test.js
+++ b/test/chain-icann-lockup-test.js
@@ -204,6 +204,8 @@ describe('BIP9 - ICANN lockup (integration)', function() {
       node = new FullNode({
         memory: true,
         network: network.type,
+        // We don't want wallet to check lockup names for this test.
+        walletIcannlockup: false,
         plugins: [require('../lib/wallet/plugin')]
       });
 
@@ -617,6 +619,8 @@ describe('BIP9 - ICANN lockup (integration)', function() {
       node = new FullNode({
         memory: true,
         network: network.type,
+        // We don't want wallet to check lockup names for this test.
+        walletIcannlockup: false,
         plugins: [require('../lib/wallet/plugin')]
       });
 


### PR DESCRIPTION
After the ICANNLOCKUP has been locked in, walletdb can safely enable this feature and make sure it does not accidentally try to OPEN locked up names.

Wallets using `v6` of the `hsd`, can now also enable `icannlockup` for the wallet.