### PR TITLE
hs-client: move all websocket calls under .ws namespace.

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,6 +1,6 @@
 {
   "env": {
-    "es2020": true,
+    "es2022": true,
     "node": true
   },
   "extends": "eslint:recommended",
@@ -35,7 +35,7 @@
     }
   ],
   "parserOptions": {
-    "ecmaVersion": 11,
+    "ecmaVersion": 13,
     "ecmaFeatures": {
       "globalReturn": true
     },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ process and allows parallel rescans.
     - expects ws hook for `block rescan interactive` params `rawEntry, rawTXs`
       that returns scanAction object.
     - expects ws hook for `block rescan interactive abort` param `message`.
+  - Move all `websocket` APIs under `.ws` namespace.
 
 ### Wallet Changes
 #### Configuration
@@ -63,6 +64,8 @@ process and allows parallel rescans.
     exact fee.
   - All transaction sending endpoints now fundlock/queue tx creation. (no more
     conflicting transactions)
+  - Move all `websocket` APIs under `.ws` namespace.
+
 
 ## v6.0.0
 

--- a/jsdoc.json
+++ b/jsdoc.json
@@ -8,7 +8,10 @@
     "includePattern": ".+\\.js(doc)?$",
     "excludePattern": "(^|\\/|\\\\)_"
   },
-  "plugins": ["plugins/markdown"],
+  "plugins": [
+    "plugins/markdown",
+    "plugins/rm-imports"
+  ],
   "templates": {
     "cleverLinks": false,
     "monospaceLinks": false

--- a/lib/client/node.js
+++ b/lib/client/node.js
@@ -11,6 +11,7 @@
 
 const assert = require('bsert');
 const {Client} = require('bcurl');
+const WSClient = require('./wsclient');
 
 /**
  * Node Client
@@ -26,6 +27,8 @@ class NodeClient extends Client {
 
   constructor(options) {
     super(options);
+
+    this.ws = new NodeWSClient(this);
   }
 
   /**
@@ -34,9 +37,9 @@ class NodeClient extends Client {
    */
 
   async auth() {
-    await this.call('auth', this.password);
-    await this.watchChain();
-    await this.watchMempool();
+    await this.ws.call('auth', this.password);
+    await this.ws.watchChain();
+    await this.ws.watchMempool();
   }
 
   /**
@@ -192,7 +195,15 @@ class NodeClient extends Client {
   reset(height) {
     return this.post('/reset', { height });
   }
+}
 
+/**
+ * Node WS Client
+ * @alias module:client.NodeWSClient
+ * @extends {WSClient}
+ */
+
+class NodeWSClient extends WSClient {
   /**
    * Watch the blockchain.
    * @private

--- a/lib/client/wallet.js
+++ b/lib/client/wallet.js
@@ -12,6 +12,7 @@
 const assert = require('bsert');
 const EventEmitter = require('events');
 const {Client} = require('bcurl');
+const WSClient = require('./wsclient');
 
 /**
  * Wallet Client
@@ -28,6 +29,7 @@ class WalletClient extends Client {
   constructor(options) {
     super(options);
     this.wallets = new Map();
+    this.ws = new WalletWSClient(this);
   }
 
   /**
@@ -37,31 +39,31 @@ class WalletClient extends Client {
    */
 
   init() {
-    this.bind('tx', (id, details) => {
+    this.ws.bind('tx', (id, details) => {
       this.dispatch(id, 'tx', details);
     });
 
-    this.bind('confirmed', (id, details) => {
+    this.ws.bind('confirmed', (id, details) => {
       this.dispatch(id, 'confirmed', details);
     });
 
-    this.bind('unconfirmed', (id, details) => {
+    this.ws.bind('unconfirmed', (id, details) => {
       this.dispatch(id, 'unconfirmed', details);
     });
 
-    this.bind('conflict', (id, details) => {
+    this.ws.bind('conflict', (id, details) => {
       this.dispatch(id, 'conflict', details);
     });
 
-    this.bind('updated', (id, details) => {
+    this.ws.bind('updated', (id, details) => {
       this.dispatch(id, 'updated', details);
     });
 
-    this.bind('address', (id, receive) => {
+    this.ws.bind('address', (id, receive) => {
       this.dispatch(id, 'address', receive);
     });
 
-    this.bind('balance', (id, balance) => {
+    this.ws.bind('balance', (id, balance) => {
       this.dispatch(id, 'balance', balance);
     });
   }
@@ -104,7 +106,7 @@ class WalletClient extends Client {
    */
 
   async auth() {
-    await this.call('auth', this.password);
+    await this.ws.call('auth', this.password);
   }
 
   /**
@@ -122,38 +124,6 @@ class WalletClient extends Client {
 
   wallet(id, token) {
     return new Wallet(this, id, token);
-  }
-
-  /**
-   * Join a wallet.
-   */
-
-  all(token) {
-    return this.call('join', '*', token);
-  }
-
-  /**
-   * Leave a wallet.
-   */
-
-  none() {
-    return this.call('leave', '*');
-  }
-
-  /**
-   * Join a wallet.
-   */
-
-  join(id, token) {
-    return this.call('join', id, token);
-  }
-
-  /**
-   * Leave a wallet.
-   */
-
-  leave(id) {
-    return this.call('leave', id);
   }
 
   /**
@@ -913,7 +883,7 @@ class Wallet extends EventEmitter {
    */
 
   async open() {
-    await this.parent.join(this.id, this.token);
+    await this.parent.ws.join(this.id, this.token);
     this.parent.wallets.set(this.id, this);
   }
 
@@ -923,7 +893,7 @@ class Wallet extends EventEmitter {
    */
 
   async close() {
-    await this.parent.leave(this.id);
+    await this.parent.ws.leave(this.id);
     this.parent.wallets.delete(this.id);
   }
 
@@ -1574,6 +1544,46 @@ class Wallet extends EventEmitter {
 
   resend() {
     return this.client.resendWallet(this.id);
+  }
+}
+
+/**
+ * Wallet WS Client
+ * @alias module:client.WalletClient
+ * @extends {WSClient}
+ */
+
+class WalletWSClient extends WSClient {
+  /**
+   * Join a wallet.
+   */
+
+  all(token) {
+    return this.call('join', '*', token);
+  }
+
+  /**
+   * Leave a wallet.
+   */
+
+  none() {
+    return this.call('leave', '*');
+  }
+
+  /**
+   * Join a wallet.
+   */
+
+  join(id, token) {
+    return this.call('join', id, token);
+  }
+
+  /**
+   * Leave a wallet.
+   */
+
+  leave(id) {
+    return this.call('leave', id);
   }
 }
 

--- a/lib/client/wsclient.js
+++ b/lib/client/wsclient.js
@@ -1,0 +1,124 @@
+/*!
+ * wsclient.js - WS Client for Node and Wallet.
+ * Copyright (c) 2024, Nodari Chkuaselidze (MIT License)
+ */
+
+'use strict';
+
+/** @typedef {import('bcurl').Client} Client */
+/** @typedef {import('bsock').Socket} Socket */
+
+/**
+ * Websocket Client
+ * @alias module:client.WSClient
+ */
+
+class WSClient {
+  /** @type {Client} */
+  client;
+
+  /** @type {Socket} */
+  socket;
+
+  /**
+   * @param {Client} client
+   */
+
+  constructor(client) {
+    this.client = client;
+    this.socket = client.socket;
+  }
+
+  /**
+   * @returns {Boolean}
+   */
+
+  get opened() {
+    return this.client.opened;
+  }
+
+  /**
+   * Open websocket.
+   * @returns {Promise}
+   */
+
+  async open() {
+    return this.client.open();
+  }
+
+  /**
+   * Close websocket.
+   * @returns {Promise}
+   */
+
+  async close() {
+    return this.client.close();
+  }
+
+  /**
+   * Alias for hook.
+   * @param {String} event
+   * @param {Function} handler
+   */
+
+  hook(event, handler) {
+    return this.client.hook(event, handler);
+  }
+
+  /**
+   * Alias for unhook.
+   * @param {String} event
+   * @param {Function} handler
+   */
+
+  unhook(event, handler) {
+    return this.client.unhook(event, handler);
+  }
+
+  /**
+   * Alias call.
+   * @param {String} event
+   * @param {...*} args
+   * @returns {Promise}
+   */
+
+  async call(event, ...args) {
+    return this.client.call(event, ...args);
+  }
+
+  /**
+   * Add an event listener.
+   * @param {String} event
+   * @param {Function} handler
+   */
+
+  bind(event, handler) {
+    return this.socket.bind(event, handler);
+  }
+
+  /**
+   * Remove an event listener.
+   * @param {String} event
+   * @param {Function} handler
+   */
+
+  unbind(event, handler) {
+    return this.socket.unbind(event, handler);
+  }
+
+  /**
+   * Fire an event.
+   * @param {String} event
+   * @param {...*} args
+   */
+
+  fire(event, ...args) {
+    return this.socket.fire(event, ...args);
+  }
+}
+
+/*
+ * Expose
+ */
+
+module.exports = WSClient;

--- a/lib/wallet/client.js
+++ b/lib/wallet/client.js
@@ -29,11 +29,11 @@ class WalletClient extends NodeClient {
     const parser = parsers[event];
 
     if (!parser) {
-      super.bind(event, handler);
+      super.ws.bind(event, handler);
       return;
     }
 
-    super.bind(event, (...args) => {
+    super.ws.bind(event, (...args) => {
       return handler(...parser(...args));
     });
   }
@@ -42,44 +42,44 @@ class WalletClient extends NodeClient {
     const parser = parsers[event];
 
     if (!parser) {
-      super.hook(event, handler);
+      super.ws.hook(event, handler);
       return;
     }
 
-    super.hook(event, (...args) => {
+    super.ws.hook(event, (...args) => {
       return handler(...parser(...args));
     });
   }
 
   async getTip() {
-    return parseEntry(await super.getTip());
+    return parseEntry(await super.ws.getTip());
   }
 
   async getEntry(block) {
     if (Buffer.isBuffer(block))
       block = block.toString('hex');
 
-    return parseEntry(await super.getEntry(block));
+    return parseEntry(await super.ws.getEntry(block));
   }
 
   async send(tx) {
-    return super.send(tx.encode());
+    return super.ws.send(tx.encode());
   }
 
   async sendClaim(claim) {
-    return super.sendClaim(claim.encode());
+    return super.ws.sendClaim(claim.encode());
   }
 
   async setFilter(filter) {
-    return super.setFilter(filter.encode());
+    return super.ws.setFilter(filter.encode());
   }
 
   async rescan(start) {
-    return super.rescan(start);
+    return super.ws.rescan(start);
   }
 
   async getNameStatus(nameHash) {
-    const json = await super.getNameStatus(nameHash);
+    const json = await super.ws.getNameStatus(nameHash);
     return NameState.fromJSON(json);
   }
 

--- a/test/node-rescan-test.js
+++ b/test/node-rescan-test.js
@@ -420,12 +420,12 @@ describe('Node Rescan Interactive API', function() {
     beforeEach(async () => {
       client = nodeCtx.nodeClient();
 
-      await client.open();
+      await client.ws.open();
     });
 
     afterEach(async () => {
-      if (client.opened)
-        await client.close();
+      if (client.ws.opened)
+        await client.ws.close();
     });
 
     for (const test of tests) {
@@ -433,7 +433,7 @@ describe('Node Rescan Interactive API', function() {
         const startHeight = nodeCtx.height - RESCAN_DEPTH + 1;
         let count = 0;
 
-        client.hook('block rescan interactive', (rawEntry, rawTXs) => {
+        client.ws.hook('block rescan interactive', (rawEntry, rawTXs) => {
           const [entry, txs] = parseBlock(rawEntry, rawTXs);
           assert.strictEqual(entry.height, startHeight + count);
           count++;
@@ -456,21 +456,21 @@ describe('Node Rescan Interactive API', function() {
         if (test.filter)
           filter = test.filter.encode();
 
-        await client.rescanInteractive(startHeight, filter);
+        await client.ws.rescanInteractive(startHeight, filter);
         assert.strictEqual(count, 10);
 
         count = 0;
         if (test.filter)
-          await client.setFilter(test.filter.encode());
+          await client.ws.setFilter(test.filter.encode());
 
-        await client.rescanInteractive(startHeight);
+        await client.ws.rescanInteractive(startHeight);
       });
 
       it(`should rescan only 5 blocks and stop with ${test.name} filter`, async () => {
         const startHeight = nodeCtx.height - RESCAN_DEPTH + 1;
         let count = 0;
 
-        client.hook('block rescan interactive', (rawEntry, rawTXs) => {
+        client.ws.hook('block rescan interactive', (rawEntry, rawTXs) => {
           const [entry, txs] = parseBlock(rawEntry, rawTXs);
           assert.strictEqual(entry.height, startHeight + count);
 
@@ -497,7 +497,7 @@ describe('Node Rescan Interactive API', function() {
 
         let aborted = false;
 
-        client.hook('block rescan interactive abort', (message) => {
+        client.ws.hook('block rescan interactive abort', (message) => {
           assert.strictEqual(message, 'scan request aborted.');
           aborted = true;
         });
@@ -507,7 +507,7 @@ describe('Node Rescan Interactive API', function() {
         if (test.filter)
           filter = test.filter.encode();
 
-        await client.rescanInteractive(startHeight, filter);
+        await client.ws.rescanInteractive(startHeight, filter);
         assert.strictEqual(count, 5);
         assert.strictEqual(aborted, true);
 
@@ -516,9 +516,9 @@ describe('Node Rescan Interactive API', function() {
         aborted = false;
 
         if (test.filter)
-          await client.setFilter(test.filter.encode());
+          await client.ws.setFilter(test.filter.encode());
 
-        await client.rescanInteractive(startHeight, null);
+        await client.ws.rescanInteractive(startHeight, null);
         assert.strictEqual(count, 5);
         assert.strictEqual(aborted, true);
       });
@@ -527,7 +527,7 @@ describe('Node Rescan Interactive API', function() {
         const startHeight = nodeCtx.height - RESCAN_DEPTH + 1;
 
         let count = 0;
-        client.hook('block rescan interactive', (rawEntry, rawTXs) => {
+        client.ws.hook('block rescan interactive', (rawEntry, rawTXs) => {
           const [entry, txs] = parseBlock(rawEntry, rawTXs);
 
           // we are repeating same block.
@@ -550,7 +550,7 @@ describe('Node Rescan Interactive API', function() {
 
         let aborted = false;
 
-        client.hook('block rescan interactive abort', (message) => {
+        client.ws.hook('block rescan interactive abort', (message) => {
           assert.strictEqual(message, 'scan request aborted.');
           aborted = true;
         });
@@ -560,7 +560,7 @@ describe('Node Rescan Interactive API', function() {
         if (test.filter)
           filter = test.filter.encode();
 
-        await client.rescanInteractive(startHeight, filter);
+        await client.ws.rescanInteractive(startHeight, filter);
         assert.strictEqual(count, 5);
         assert.strictEqual(aborted, true);
 
@@ -568,9 +568,9 @@ describe('Node Rescan Interactive API', function() {
         aborted = false;
 
         if (test.filter)
-          await client.setFilter(test.filter.encode());
+          await client.ws.setFilter(test.filter.encode());
 
-        await client.rescanInteractive(startHeight);
+        await client.ws.rescanInteractive(startHeight);
         assert.strictEqual(count, 5);
         assert.strictEqual(aborted, true);
       });
@@ -579,7 +579,7 @@ describe('Node Rescan Interactive API', function() {
         const startHeight = nodeCtx.height - RESCAN_DEPTH + 1;
 
         let count = 0;
-        client.hook('block rescan interactive', (rawEntry, rawTXs) => {
+        client.ws.hook('block rescan interactive', (rawEntry, rawTXs) => {
           const [entry, txs] = parseBlock(rawEntry, rawTXs);
 
           // we are repeating same block.
@@ -602,7 +602,7 @@ describe('Node Rescan Interactive API', function() {
 
         let aborted = false;
 
-        client.hook('block rescan interactive abort', (message) => {
+        client.ws.hook('block rescan interactive abort', (message) => {
           assert.strictEqual(message, 'scan request aborted.');
           aborted = true;
         });
@@ -612,7 +612,7 @@ describe('Node Rescan Interactive API', function() {
         if (test.filter)
           filter = test.filter.encode();
 
-        await client.rescanInteractive(startHeight, filter);
+        await client.ws.rescanInteractive(startHeight, filter);
         assert.strictEqual(count, 5);
         assert.strictEqual(aborted, true);
 
@@ -620,9 +620,9 @@ describe('Node Rescan Interactive API', function() {
         aborted = false;
 
         if (test.filter)
-          await client.setFilter(test.filter.encode());
+          await client.ws.setFilter(test.filter.encode());
 
-        await client.rescanInteractive(startHeight);
+        await client.ws.rescanInteractive(startHeight);
         assert.strictEqual(count, 5);
         assert.strictEqual(aborted, true);
       });
@@ -636,7 +636,7 @@ describe('Node Rescan Interactive API', function() {
 
       let count = 0;
 
-      client.hook('block rescan interactive', (rawEntry, rawTXs) => {
+      client.ws.hook('block rescan interactive', (rawEntry, rawTXs) => {
         count++;
 
         const [entry, txs] = parseBlock(rawEntry, rawTXs);
@@ -659,7 +659,7 @@ describe('Node Rescan Interactive API', function() {
       });
 
       let aborted = false;
-      client.hook('block rescan interactive abort', (message) => {
+      client.ws.hook('block rescan interactive abort', (message) => {
         assert.strictEqual(message, 'scan request aborted.');
         aborted = true;
       });
@@ -669,7 +669,7 @@ describe('Node Rescan Interactive API', function() {
       if (test.filter)
         filter = test.filter.encode();
 
-      await client.rescanInteractive(startHeight, filter);
+      await client.ws.rescanInteractive(startHeight, filter);
       assert.strictEqual(count, tests.length);
       assert.strictEqual(aborted, true);
     });
@@ -681,7 +681,7 @@ describe('Node Rescan Interactive API', function() {
       let filter = BloomFilter.fromRate(10000, 0.001);
       let expected = 0;
 
-      client.hook('block rescan interactive', (rawEntry, rawTXs) => {
+      client.ws.hook('block rescan interactive', (rawEntry, rawTXs) => {
         const [entry, txs] = parseBlock(rawEntry, rawTXs);
 
         // we are repeating same block.
@@ -707,12 +707,12 @@ describe('Node Rescan Interactive API', function() {
       });
 
       let aborted = false;
-      client.hook('block rescan interactive abort', (message) => {
+      client.ws.hook('block rescan interactive abort', (message) => {
         assert.strictEqual(message, 'scan request aborted.');
         aborted = true;
       });
 
-      await client.rescanInteractive(startHeight, filter.encode());
+      await client.ws.rescanInteractive(startHeight, filter.encode());
       assert.strictEqual(aborted, true);
 
       // Now try using client.filter
@@ -721,8 +721,8 @@ describe('Node Rescan Interactive API', function() {
       testTXs = allTXs[startHeight].slice();
       expected = 0;
 
-      await client.setFilter(filter.encode());
-      await client.rescanInteractive(startHeight);
+      await client.ws.setFilter(filter.encode());
+      await client.ws.rescanInteractive(startHeight);
       assert.strictEqual(aborted, true);
     });
 
@@ -750,12 +750,12 @@ describe('Node Rescan Interactive API', function() {
         };
       };
 
-      client.hook('block rescan interactive', getIter(counter1));
-      client2.hook('block rescan interactive', getIter(counter2));
+      client.ws.hook('block rescan interactive', getIter(counter1));
+      client2.ws.hook('block rescan interactive', getIter(counter2));
 
       await Promise.all([
-        client.rescanInteractive(startHeight),
-        client2.rescanInteractive(startHeight)
+        client.ws.rescanInteractive(startHeight),
+        client2.ws.rescanInteractive(startHeight)
       ]);
 
       assert.strictEqual(counter1.count, 10);
@@ -785,7 +785,7 @@ describe('Node Rescan Interactive API', function() {
       // We simulate this by acquiring chain lock before we
       // call rescan and then closing the client.
       const unlock = await nodeCtx.chain.locker.lock();
-      const rescan = client.rescanInteractive(0);
+      const rescan = client.ws.rescanInteractive(0);
       let err = null;
       rescan.catch(e => err = e);
 

--- a/test/util/node-context.js
+++ b/test/util/node-context.js
@@ -182,7 +182,7 @@ class NodeContext {
     if (this.wclient)
       await this.wclient.open();
 
-    await this.nclient.open();
+    await this.nclient.ws.open();
 
     this.opened = true;
   }


### PR DESCRIPTION
This makes it easier to reason about the calls. It becomes more explicit - what's going on, whether you need to call `.open` for a method call to work or not etc.

bindings and etc, other than methods themselves, could also work on the `client` as they were. But it's recommended to use `.ws`, makes it easier to read.