### PR TITLE
pkg: update lint and docs.

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,6 +1,6 @@
 {
   "env": {
-    "es2020": true,
+    "es2022": true,
     "node": true
   },
   "extends": "eslint:recommended",
@@ -35,7 +35,7 @@
     }
   ],
   "parserOptions": {
-    "ecmaVersion": 11,
+    "ecmaVersion": 13,
     "ecmaFeatures": {
       "globalReturn": true
     },

--- a/jsdoc.json
+++ b/jsdoc.json
@@ -8,7 +8,10 @@
     "includePattern": ".+\\.js(doc)?$",
     "excludePattern": "(^|\\/|\\\\)_"
   },
-  "plugins": ["plugins/markdown"],
+  "plugins": [
+    "plugins/markdown",
+    "plugins/rm-imports"
+  ],
   "templates": {
     "cleverLinks": false,
     "monospaceLinks": false


### PR DESCRIPTION
Update ecmascript version in the linter.

Add `rm-imports` to the jsdoc. It allows us to annotate typedefs with typescript specific `import`s, w/o breaking the jsdoc generation. https://github.com/pinheadmz/bsdoc/pull/1

It just removes imports, as if they did not exist.

There's better "import-aliases" plugin also implemented in the bsdoc. But It needs more testing how better generated docs get and if there are any issues in the output. So we can upgrade later, after more experimenting with it.