### PR TITLE
WalletDB Migration to v3

### DIFF
--- a/lib/wallet/migrations.js
+++ b/lib/wallet/migrations.js
@@ -74,7 +74,7 @@ class MigrateMigrations extends AbstractMigration {
 
 /**
  * Run change address migration.
- * Applies to WalletDB v0
+ * Applies to WalletDB v1
  */
 
 class MigrateChangeAddress extends AbstractMigration {
@@ -160,7 +160,7 @@ class MigrateChangeAddress extends AbstractMigration {
 
 /**
  * Migrate account for new lookahead entry.
- * Applies to WalletDB v1
+ * Applies to WalletDB v1 -> v2
  */
 
 class MigrateAccountLookahead extends AbstractMigration {
@@ -245,6 +245,11 @@ class MigrateAccountLookahead extends AbstractMigration {
   }
 }
 
+/**
+ * Recalculate TXDB balances.
+ * Applies to WalletDB v2
+ */
+
 class MigrateTXDBBalances extends AbstractMigration {
   /**
    * Create TXDB Balance migration object.
@@ -285,6 +290,65 @@ class MigrateTXDBBalances extends AbstractMigration {
     return {
       name: 'TXDB balance refresh',
       description: 'Refresh balances for TXDB after txdb updates'
+    };
+  }
+}
+
+/**
+ * Migrate WDB to v3. Drop TXDB and migrate to new WDB layout.
+ * Applies to WalletDB v2
+ */
+
+class MigrateWDBv3 extends AbstractMigration {
+  constructor(options) {
+    super(options);
+
+    this.options = options;
+    this.logger = options.logger.context('wdb-migrate-v3');
+    this.db = options.db;
+    this.ldb = options.ldb;
+  }
+
+  /**
+   * We always migrate.
+   * @returns {Promise}
+   */
+
+  async check() {
+    return types.MIGRATE;
+  }
+
+  /**
+   * Actual migration
+   * @param {Batch} b
+   * @param {WalletMigrationResult} pending
+   * @returns {Promise}
+   */
+
+  async migrate(b, pending) {
+    const removeRange = (opt) => {
+      return this.ldb.iterator(opt).each(key => b.del(key));
+    };
+
+    // Remove mappings and TXDB Entries.
+    await this.db.deepClean();
+
+    // Remove the sync progress.
+    await removeRange({
+      gte: layout.h.min(),
+      lte: layout.h.max()
+    });
+
+    await this.db.saveGenesis();
+
+    // Now rewrite genesis and version.
+    await this.db.writeVersion(b, 3);
+  }
+
+  static info() {
+    return {
+      name: 'Migrate WDB to v3',
+      description: 'Drop TXDB and migrate to new WDB layout'
     };
   }
 }
@@ -423,7 +487,8 @@ exports.migrations = {
   0: MigrateMigrations,
   1: MigrateChangeAddress,
   2: MigrateAccountLookahead,
-  3: MigrateTXDBBalances
+  3: MigrateTXDBBalances,
+  4: MigrateWDBv3
 };
 
 // Expose migrations
@@ -431,5 +496,6 @@ exports.MigrateChangeAddress = MigrateChangeAddress;
 exports.MigrateMigrations = MigrateMigrations;
 exports.MigrateAccountLookahead = MigrateAccountLookahead;
 exports.MigrateTXDBBalances = MigrateTXDBBalances;
+exports.MigrateWDBv3 = MigrateWDBv3;
 
 module.exports = exports;

--- a/lib/wallet/walletdb.js
+++ b/lib/wallet/walletdb.js
@@ -62,7 +62,7 @@ class WalletDB extends EventEmitter {
     this.feeRate = this.options.feeRate;
     this.db = bdb.create(this.options);
     this.name = 'wallet';
-    this.version = 2;
+    this.version = 3;
 
     // chain state.
     this.hasStateCache = false;

--- a/test/wallet-migration-test.js
+++ b/test/wallet-migration-test.js
@@ -1086,6 +1086,7 @@ describe('Wallet Migrations', function() {
     it('should migrate', async () => {
       walletDB.options.walletMigrate = 0;
 
+      walletDB.version = 3;
       await walletDB.open();
 
       // chain sync was reset.


### PR DESCRIPTION
  Migration to WalletDB v3 is different from previous migrations. It does not try to reindex the old data into new layout, instead it drops most of it - allowing us to do heavier modifications. This migration removes all txdb mappings (except for blinds) and cleans up block entries received from the chain. This should trigger rescan from the genesis block.

  Migration is separated from the actual txdb/walletdb changes in order to allow multiple PRs to modify the database and w/o it getting in the way. Migration needs to get merged last, before release of v7. This allows us to invalidate all commits between wdb v3 modifications and the migration. After migration there should no longer be any wdb modifications for wdb v3.

  This PR currently tracks modifications:
   - #888 