### PR TITLE
Fix typo in Docker example

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -113,7 +113,7 @@ $ docker run --name hsd \
     --publish 12037:12037 \
     --volume $HOME/.hsd:/root/.hsd \
     hsd:$VERSION-$COMMIT \
-    --http-host 0.0.0.0 \
+    --http-host=0.0.0.0 \
     --api-key=foo
 ```
 


### PR DESCRIPTION
This typo breaks the Docker command, as `hsd` is expecting an `=`.