### PR TITLE
test: disable dns-test until c-ares fix.

### DIFF
--- a/test/dns-test.js
+++ b/test/dns-test.js
@@ -13,7 +13,8 @@ const recursiveResolver = new Resolver({timeout: 1000});
 rootResolver.setServers([`127.0.0.1:${network.nsPort}`]);
 recursiveResolver.setServers([`127.0.0.1:${network.rsPort}`]);
 
-describe('Server Configuration', function() {
+// TODO: Enable once node.js supports ANY + SIG(0) queries (c-ares issue)
+describe.skip('Server Configuration', function() {
   describe('Full Node', function() {
     let node;
 


### PR DESCRIPTION
c-ares rewrote their DNS record parsing code and since c-ares 1.21 does not allow ANY records (https://github.com/c-ares/c-ares/pull/765). 

  - Node.js v18 since v18.20
  - Node.js v20 since v20.12
  - Node.js v22

All above node.js versions are all using newer version c-ares, which breaks this code. After this issue is resolved in c-ares and node.js has upgraded c-ares we can enable this test case again.