### PR TITLE
Add nowFn to wdb options and txdb.

### DIFF
--- a/lib/wallet/records.js
+++ b/lib/wallet/records.js
@@ -217,16 +217,20 @@ class TXRecord extends bio.Struct {
   /**
    * Create tx record.
    * @constructor
-   * @param {TX} tx
-   * @param {BlockMeta?} block
+   * @param {Number} mtime
+   * @param {TX} [tx]
+   * @param {BlockMeta} [block]
    */
 
-  constructor(tx, block) {
+  constructor(mtime, tx, block) {
     super();
+
+    if (mtime == null)
+      mtime = util.now();
 
     this.tx = null;
     this.hash = null;
-    this.mtime = util.now();
+    this.mtime = mtime;
     this.height = -1;
     this.block = null;
     this.index = -1;
@@ -240,7 +244,7 @@ class TXRecord extends bio.Struct {
    * Inject properties from tx and block.
    * @private
    * @param {TX} tx
-   * @param {Block?} block
+   * @param {Block} [block]
    * @returns {TXRecord}
    */
 
@@ -256,13 +260,14 @@ class TXRecord extends bio.Struct {
 
   /**
    * Instantiate tx record from tx and block.
-   * @param {TX} tx
-   * @param {Block?} block
+   * @param {TX} [tx]
+   * @param {Block} [block]
+   * @param {Number} [mtime]
    * @returns {TXRecord}
    */
 
-  static fromTX(tx, block) {
-    return new this().fromTX(tx, block);
+  static fromTX(tx, block, mtime) {
+    return new this(mtime).fromTX(tx, block);
   }
 
   /**

--- a/lib/wallet/txdb.js
+++ b/lib/wallet/txdb.js
@@ -46,6 +46,7 @@ class TXDB {
     this.wdb = wdb;
     this.db = wdb.db;
     this.logger = wdb.logger;
+    this.nowFn = wdb.options.nowFn || util.now;
 
     this.wid = wid || 0;
     this.bucket = null;
@@ -809,7 +810,8 @@ class TXDB {
       return this.confirm(existing, block);
     }
 
-    const wtx = TXRecord.fromTX(tx, block);
+    const now = this.nowFn();
+    const wtx = TXRecord.fromTX(tx, block, now);
 
     if (!block) {
       // Potentially remove double-spenders.
@@ -3252,7 +3254,7 @@ class TXDB {
   async zap(acct, age) {
     assert((age >>> 0) === age);
 
-    const now = util.now();
+    const now = this.nowFn();
 
     const txs = await this.getRange(acct, {
       start: 0,

--- a/lib/wallet/walletdb.js
+++ b/lib/wallet/walletdb.js
@@ -29,6 +29,7 @@ const WalletMigrator = require('./migrations');
 const layout = layouts.wdb;
 const tlayout = layouts.txdb;
 const {states} = require('../covenants/namestate');
+const util = require('../utils/util');
 
 const {
   ChainState,
@@ -2582,6 +2583,8 @@ class WalletOptions {
     this.migrateNoRescan = false;
     this.preloadAll = false;
 
+    this.nowFn = util.now;
+
     if (options)
       this.fromOptions(options);
   }
@@ -2676,6 +2679,11 @@ class WalletOptions {
     if (options.preloadAll != null) {
       assert(typeof options.preloadAll === 'boolean');
       this.preloadAll = options.preloadAll;
+    }
+
+    if (options.timeFn != null) {
+      assert(typeof options.timeFn === 'function');
+      this.nowFn = options.timeFn;
     }
 
     return this;

--- a/test/wallet-test.js
+++ b/test/wallet-test.js
@@ -1998,7 +1998,7 @@ describe('Wallet', function() {
   });
 
   it('should throw error with missing outputs', async () => {
-    const wallet = new Wallet({});
+    const wallet = new Wallet({ options: {} });
 
     let err = null;
 
@@ -2010,6 +2010,17 @@ describe('Wallet', function() {
 
     assert(err);
     assert.equal(err.message, 'At least one output is required.');
+  });
+
+  it('should pass nowFn to the txdb', async () => {
+    const nowFn = () => 1;
+    const wallet = new Wallet({
+      options: {
+        nowFn
+      }
+    });
+
+    assert.strictEqual(wallet.txdb.nowFn(), nowFn());
   });
 
   it('should cleanup', async () => {


### PR DESCRIPTION
Adds `mtime` option to the `TXRecord` and it no longer calls `util.now` directly, unless `mtime` is omitted. TXDB accepts option from WalletDB for nowFn.