### PR TITLE
Add checkpoint between 160k and 225k

### DIFF
--- a/lib/protocol/networks.js
+++ b/lib/protocol/networks.js
@@ -82,6 +82,8 @@ main.brontidePort = 44806;
 
 /**
  * Checkpoint block list.
+ * NOTE: The number of blocks between checkpoints needs to be lower than
+ * MAX_BLOCK_REQUEST (50k).
  * @const {Object}
  */
 
@@ -110,6 +112,8 @@ main.checkpointMap = {
     '0000000000000005ee5106df9e48bcd232a1917684ac344b35ddd9b9e4101096', 'hex'),
   160000: Buffer.from(
     '00000000000000021e723ce5aedc021ab4f85d46a6914e40148f01986baa46c9', 'hex'),
+  200000: Buffer.from(
+    '000000000000000181ebc18d6c34442ffef3eedca90c57ca8ecc29016a1cfe16', 'hex'),
   225000: Buffer.from(
     '00000000000000021f0be013ebad018a9ef97c8501766632f017a778781320d5', 'hex')
 };


### PR DESCRIPTION
The way headers are requested for checkpoints is slightly different than normal - it does header requests in bulk between two checkpoints. Because the difference between 220k and 160k is 65k - it becomes bigger than general limit to the number of headers that can be requested: 51k.

This should resolve issue, as the gaps between them will become lower than 51k now.

Temporary solution for those who don't want to upgrade is to disable checkpoints until node reaches 175k blocks. (After 160k) Or upgrade to the release version with this PR.

Closes: https://github.com/handshake-org/hsd/issues/913
Closes: https://github.com/handshake-org/hsd/issues/909 (Even though it was resolved, probably the node got those 15k blocks eventually and slowly?)