### PR TITLE
Update ci and add node v22

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,7 @@ jobs:
     - name: Setup
       uses: actions/setup-node@v4
       with:
-        node-version: 18.x
+        node-version: 20.x
 
     - name: Install dependencies
       run: sudo apt-get update && sudo apt-get install -y libunbound-dev |
@@ -54,7 +54,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        node: [14.x, 16.x, 18.x, 20.x]
+        node: [14.x, 16.x, 18.x, 20.x, 22.x]
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,10 +8,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Setup
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
         node-version: 18.x
 
@@ -29,10 +29,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Setup
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
         node-version: 18.x
 
@@ -57,10 +57,10 @@ jobs:
         node: [14.x, 16.x, 18.x, 20.x]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Setup Node.js
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
         node-version: ${{ matrix.node }}
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,6 +68,12 @@ jobs:
       if: contains(matrix.os, 'ubuntu')
       run: sudo apt-get update && sudo apt-get install -y libunbound-dev
 
+    # Pythong 3.10->3.11 broke node-gyp. This upgrades node-gyp for older nodejs.
+    # https://github.com/nodejs/node-gyp/issues/2219
+    - name: Update npm.
+      if: contains(matrix.node, '14.x')
+      run: npm i -g npm@9
+
     - name: Install dependencies
       run: npm install
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Docker meta
         id: meta

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -8,8 +8,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-node@v1
+    - uses: actions/checkout@v4
+    - uses: actions/setup-node@v4
       with:
           node-version: 16.x
     - run: |


### PR DESCRIPTION
- Update action versions
- Use v20 for coverage tests.
- Update npm for node v14 (to update node-gyp)
- Add 22.x to the matrix.