### PR TITLE
wallet: recalculate-balances endpoint.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
     indicating the number of transactions that were zapped.
   - `GET /wallet/:id/name/:name` now accepts an `own` parameter and only returns
     the namestate when the wallet owns the name.
+  - Introduce admin `POST /recalculate-balances`, useful if the post-migration
+    recalculation was not triggered and wallet balances are not correct.
 
 #### Wallet/WalletDB API
   - `Wallet.zap` now returns the number of transactions zapped instead of their hashes.

--- a/lib/wallet/http.js
+++ b/lib/wallet/http.js
@@ -31,6 +31,7 @@ const common = require('./common');
 /** @typedef {import('../types').NetworkType} NetworkType */
 /** @typedef {ReturnType<Validator['fromRequest']>} RequestValidator */
 /** @typedef {import('../covenants/namestate')} NameState */
+/** @typedef {import('./walletdb')} WalletDB */
 
 /**
  * HTTP
@@ -49,6 +50,7 @@ class HTTP extends Server {
 
     this.network = this.options.network;
     this.logger = this.options.logger.context('wallet-http');
+    /** @type {WalletDB} */
     this.wdb = this.options.node.wdb;
     this.rpc = this.options.node.rpc;
     this.maxTXs = this.wdb.options.maxHistoryTXs;
@@ -203,6 +205,18 @@ class HTTP extends Server {
       res.json(200, { success: true });
 
       await this.wdb.rescan(height);
+    });
+
+    // Recalculate balances
+    this.post('/recalculate-balances', async (req, res) => {
+      if (!req.admin) {
+        res.json(403);
+        return;
+      }
+
+      await this.wdb.recalculateBalances();
+
+      res.json(200, { success: true });
     });
 
     // Deep Clean

--- a/lib/wallet/walletdb.js
+++ b/lib/wallet/walletdb.js
@@ -796,6 +796,7 @@ class WalletDB extends EventEmitter {
     const wnames = await this.getWallets();
 
     for (const wname of wnames) {
+      this.logger.debug(`Recalculating balances for ${wname}.`);
       const wallet = await this.get(wname);
       await wallet.recalculateBalances();
     }


### PR DESCRIPTION
Introduces endpoint to recalculate wallet balances

This PR adds an admin-only endpoint to recalculate balances across all wallets. This functionality was developed to address a balance calculation bug in a previous hsd version, but serves as a valuable maintenance tool for ensuring balance accuracy going forward.

- Adds a new `POST /recalculate-balances` endpoint (admin-only)
- Can be used to fix wallet balances if an automatic post-migration recalculation was interrupted

This is intended as a maintenance tool and should not be necessary during normal wallet operation.