### PR TITLE
seeder: allow passing custom prefix dir

### DIFF
--- a/bin/_seeder
+++ b/bin/_seeder
@@ -13,8 +13,13 @@ config.load({
 });
 
 const network = config.str(['-n', '--network'], 'main');
-const prefix = path.join(os.homedir(), '.hsd',
-                         network === 'main' ? '' : network);
+
+const defaultPrefix = path.join(
+  os.homedir(),
+  '.hsd',
+  network === 'main' ? '' : network
+);
+const prefix = config.str('prefix', defaultPrefix);
 
 (async () => {
   const seeder = new Seeder({


### PR DESCRIPTION
Add a config option `--prefix` to hs-seeder that's similar to what can be used with hsd.