### PR TITLE
Release v8.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hsd",
-  "version": "8.0.0-rc.1",
+  "version": "8.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hsd",
-      "version": "8.0.0-rc.1",
+      "version": "8.0.0",
       "license": "MIT",
       "dependencies": {
         "@handshake-org/bfilter": "~2.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hsd",
-  "version": "8.0.0-rc.1",
+  "version": "8.0.0",
   "description": "Cryptocurrency bike-shed",
   "license": "MIT",
   "repository": "git://github.com/handshake-org/hsd.git",


### PR DESCRIPTION
[Release Notes](https://github.com/handshake-org/hsd/blob/75c99833228cf2ccd496b31b545165987537b7a6/docs/release-notes/release-notes-8.x.md)

Includes:
  - #933
  - #927
  - #928
  - #925
  - #930
  - #926
  - #922
  - #920
  - #916
  - #932
  - #929
  - #924
  - #923
  - #921
  - #919
  - #918
  - #917
