### PR TITLE
 Refactor batches

### DIFF
--- a/lib/wallet/rpc.js
+++ b/lib/wallet/rpc.js
@@ -2717,7 +2717,7 @@ class RPC extends RPCBase {
   async sendBatch(args, help) {
     const [actions, options] = this._validateBatch(args, help, 'sendbatch');
     const wallet = this.wallet;
-    const tx = await wallet.sendBatch(actions, options);
+    const {tx} = await wallet.sendBatch(actions, options);
 
     return tx.getJSON(this.network);
   }
@@ -2727,7 +2727,7 @@ class RPC extends RPCBase {
     options.paths = true;
 
     const wallet = this.wallet;
-    const mtx = await wallet.createBatch(actions, options);
+    const {mtx} = await wallet.createBatch(actions, options);
 
     return mtx.getJSON(this.network);
   }

--- a/lib/wallet/wallet.js
+++ b/lib/wallet/wallet.js
@@ -3863,18 +3863,44 @@ class Wallet extends EventEmitter {
 
   /**
    * @typedef {Object} BatchAction
-   * @property {String} type - Action type
-   * @property {Array} [args] - Arguments for the action
+   * @property {String} type - Action type.
+   * @property {String} [id] - Action ID.
+   * @property {Array} [args] - Arguments for the action.
+   */
+
+  /**
+   * @typedef {Object} BatchError
+   * @property {String} message - Error message.
+   * @property {String} type - Type of the action that caused the error.
+   * @property {Error} error - Original error object.
+   * @property {String} [id] - Optional ID for the action.
+   */
+
+  /**
+   * @typedef {Object} BatchResult
+   * @property {MTX} mtx - The resulting transaction
+   * @property {BatchError[]} errors - List of errors encountered during
+   *  processing.
+   */
+
+  /**
+   * @typedef {Object} BatchTXResult
+   * @property {TX} tx - The resulting transaction
+   * @property {BatchError[]} errors - List of errors encountered during
+   *  processing.
    */
 
   /**
    * Make a batch transaction with multiple actions.
    * @param {BatchAction[]} actions
    * @param {Object} options
-   * @returns {Promise<MTX>}
+   * @param {Number|String} [options.account=0] - Account index or name.
+   * @param {Boolean} [options.partialFailure=false] - Allow partial failure.
+   * @throws {Error} - general validations.
+   * @returns {Promise<BatchResult>}
    */
 
-  async makeBatch(actions, options) {
+  async makeBatch(actions, options = {}) {
     assert(Array.isArray(actions));
     assert(actions.length, 'Batches require at least one action.');
 
@@ -3916,17 +3942,15 @@ class Wallet extends EventEmitter {
     // We track that by bumping receiveIndex.
     const account = await this.getAccount(acct);
     let receiveIndex = account.receiveDepth - 1;
+    /** @type {BatchError[]} */
+    const errors = [];
 
-    // "actions" are arrays that start with a covenant type (or meta-type)
-    // followed by the arguments expected by the corresponding "make" function.
-    for (const action of actions) {
-      assert(action);
-      assert(typeof action.type === 'string');
+    /**
+     * @param {BatchAction} action
+     * @param {Array} args
+     */
 
-      const args =  action.args || [];
-
-      assert(Array.isArray(args), 'Action args must be an array.');
-
+    const handleAction = async (action, args) => {
       switch (action.type) {
         case 'NONE': {
           assert(args.length === 2);
@@ -3944,8 +3968,10 @@ class Wallet extends EventEmitter {
           break;
         }
         case 'BID': {
+          const bidIndex = receiveIndex++;
+
           assert(args.length === 3, 'Bad arguments for BID.');
-          const address = account.deriveReceive(receiveIndex++).getAddress();
+          const address = account.deriveReceive(bidIndex).getAddress();
           const name = args[0];
           const value = args[1];
           const lockup = args[2];
@@ -4025,6 +4051,34 @@ class Wallet extends EventEmitter {
         default:
           throw new Error(`Unknown action type: ${action.type}`);
       }
+    };
+
+    // "actions" are arrays that start with a covenant type (or meta-type)
+    // followed by the arguments expected by the corresponding "make" function.
+    for (const action of actions) {
+      assert(action);
+      assert(typeof action.type === 'string');
+
+      const args =  action.args || [];
+
+      assert(Array.isArray(args), 'Action args must be an array.');
+
+      try {
+        await handleAction(action, args);
+      } catch (err) {
+        if (!options.partialFailure)
+          throw err;
+
+        if (action.type === 'BID')
+          receiveIndex--;
+
+        errors.push({
+          message: err.message,
+          type: action.type,
+          error: err,
+          id: action.id || null
+        });
+      }
 
       if (rules.countOpens(mtx) > consensus.MAX_BLOCK_OPENS)
         throw new Error('Too many OPENs.');
@@ -4076,27 +4130,30 @@ class Wallet extends EventEmitter {
         throw new Error('Batch output addresses would exceed lookahead.');
     }
 
-    return mtx;
+    return {mtx, errors};
   }
 
   /**
    * Make a batch transaction with multiple actions.
    * @param {Array} actions
    * @param {Object} options
-   * @returns {Promise<MTX>}
+   * @returns {Promise<BatchResult>}
    */
 
   async _createBatch(actions, options) {
-    const mtx = await this.makeBatch(actions, options);
+    const {mtx, errors} = await this.makeBatch(actions, options);
     await this.fill(mtx, options);
-    return this.finalize(mtx, options);
+    return {
+      mtx: await this.finalize(mtx, options),
+      errors
+    };
   }
 
   /**
    * Make a batch transaction with multiple actions.
    * @param {Array} actions
    * @param {Object} options
-   * @returns {Promise<MTX>}
+   * @returns {Promise<BatchResult>}
    */
 
   async createBatch(actions, options) {
@@ -4112,20 +4169,23 @@ class Wallet extends EventEmitter {
    * Create and send a batch transaction with multiple actions.
    * @param {Array} actions
    * @param {Object} options
-   * @returns {Promise<TX>}
+   * @returns {Promise<BatchTXResult>}
    */
 
   async _sendBatch(actions, options) {
     const passphrase = options ? options.passphrase : null;
-    const mtx = await this._createBatch(actions, options);
-    return this.sendMTX(mtx, passphrase);
+    const {mtx, errors} = await this._createBatch(actions, options);
+    return {
+      tx: await this.sendMTX(mtx, passphrase),
+      errors
+    };
   }
 
   /**
    * Create and send a batch transaction with multiple actions.
    * @param {Array} actions
    * @param {Object} options
-   * @returns {Promise<TX>}
+   * @returns {Promise<BatchTXResult>}
    */
 
   async sendBatch(actions, options) {
@@ -5470,7 +5530,7 @@ class Wallet extends EventEmitter {
 
   /**
    * Get current change address.
-   * @param {Number} [acct=0]
+   * @param {Number|String} [acct=0]
    * @returns {Promise<Address>}
    */
 

--- a/test/wallet-balance-test.js
+++ b/test/wallet-balance-test.js
@@ -573,7 +573,7 @@ describe('Wallet Balance', function() {
     const txOpts = { hardFee: HARD_FEE };
 
     // all three bids are there.
-    const bidMTX = await wallet.createBatch([
+    const {mtx: bidMTX} = await wallet.createBatch([
       { type: 'BID', args: [name1, BID_AMOUNT_1, BLIND_AMOUNT_1] },
       { type: 'BID', args: [name2, BID_AMOUNT_2, BLIND_AMOUNT_2] }
     ], txOpts);
@@ -1018,7 +1018,7 @@ describe('Wallet Balance', function() {
       const {nextAddr} = getAheadAddr(account, ahead);
       const txOpts = { hardFee: HARD_FEE };
 
-      const bidMTX = await wallet.createBatch([
+      const {mtx: bidMTX} = await wallet.createBatch([
         { type: 'BID', args: [name, BID_AMOUNT_1, BLIND_AMOUNT_1] },
         { type: 'BID', args: [name, BID_AMOUNT_2, BLIND_AMOUNT_2] }
       ], txOpts);
@@ -1111,7 +1111,7 @@ describe('Wallet Balance', function() {
       const {nextAddr} = getAheadAddr(account, ahead);
       const txOpts = { hardFee: HARD_FEE };
 
-      const bidMTX = await primary.createBatch([
+      const {mtx: bidMTX} = await primary.createBatch([
         { type: 'BID', args: [name, BID_AMOUNT_1, BLIND_AMOUNT_1] },
         { type: 'BID', args: [name, BID_AMOUNT_2, BLIND_AMOUNT_2] }
       ], txOpts);
@@ -1208,7 +1208,7 @@ describe('Wallet Balance', function() {
       const addr1 = getAheadAddr(altAccount, -altAccount.lookahead);
       const addr2 = getAheadAddr(altAccount, ahead);
 
-      const bidMTX = await wallet.createBatch([
+      const {mtx: bidMTX} = await wallet.createBatch([
         { type: 'BID', args: [name, BID_AMOUNT_1, BLIND_AMOUNT_1] },
         { type: 'BID', args: [name, BID_AMOUNT_2, BLIND_AMOUNT_2] }
       ], txOpts);
@@ -1393,7 +1393,7 @@ describe('Wallet Balance', function() {
       await primary.sendOpen(name, false);
       await mineBlocks(openingPeriod);
 
-      const bidMTX = await clone.createBatch([
+      const {mtx: bidMTX} = await clone.createBatch([
         { type: 'BID', args: [name, BID_AMOUNT_1, BLIND_AMOUNT_1] },
         { type: 'BID', args: [name, BID_AMOUNT_2, BLIND_AMOUNT_2] }
       ], txOpts);
@@ -1852,7 +1852,7 @@ describe('Wallet Balance', function() {
       const txOpts = { hardFee: HARD_FEE };
 
       // all three bids are there.
-      const bidMTX = await clone.createBatch([
+      const {mtx: bidMTX} = await clone.createBatch([
         { type: 'BID', args: [name1, BID_AMOUNT_1, BLIND_AMOUNT_1] },
         { type: 'BID', args: [name2, BID_AMOUNT_2, BLIND_AMOUNT_2] }
       ], txOpts);

--- a/test/wallet-importnonce-test.js
+++ b/test/wallet-importnonce-test.js
@@ -79,7 +79,7 @@ describe('Wallet Import Nonce', function () {
       { type: 'BID', args: [NAME, BIDS[2].value, BIDS[2].lockup]}
     ];
 
-    const bidTx = await walletA.sendBatch(batch);
+    const {tx: bidTx} = await walletA.sendBatch(batch);
 
     // Save address for importnonce later
     for (const output of bidTx.outputs) {


### PR DESCRIPTION
Refactor batches in order to allow passing ids optionally and to better track errors on partial failures.

- [x] Pass objects instead of arrays
- [x] Accept and track ids in action object
- [x] Accept option 'allowPartialFailure` for new behaviour.
- [x] Refactor function a bit