### PR TITLE
wallet-http: TransactionOptions minor refactor

### DIFF
--- a/lib/wallet/http.js
+++ b/lib/wallet/http.js
@@ -1860,8 +1860,26 @@ class TransactionOptions {
    */
 
   constructor(valid, network) {
+    this.rate = null;
+    this.maxFee = null;
+    this.selection = null;
+    this.sweepdustMinValue = null;
+    this.smart = null;
+    this.account = null;
+    this.locktime = null;
+    this.sort = null;
+    this.subtractFee = null;
+    this.subtractIndex = null;
+    this.depth = null;
+    this.paths = null;
+    this.passphrase = null;
+    this.hardFee = null;
+    this.blocks = null;
+    this.network = network || Network.primary;
+    this.outputs = [];
+
     if (valid)
-      return this.fromValidator(valid, network);
+      this.fromValidator(valid, network);
   }
 
   /**
@@ -1875,22 +1893,53 @@ class TransactionOptions {
   fromValidator(valid, network) {
     assert(valid);
 
-    this.rate = valid.u64('rate');
-    this.maxFee = valid.u64('maxFee');
-    this.selection = valid.str('selection');
-    this.sweepdustMinValue = valid.u64('sweepdustMinValue');
-    this.smart = valid.bool('smart');
-    this.account = valid.str('account');
-    this.locktime = valid.u64('locktime');
-    this.sort = valid.bool('sort');
-    this.subtractFee = valid.bool('subtractFee');
-    this.subtractIndex = valid.i32('subtractIndex');
-    this.depth = valid.u32(['confirmations', 'depth']);
-    this.paths = valid.bool('paths');
-    this.passphrase = valid.str('passphrase');
-    this.hardFee = valid.u64('hardFee'),
-    this.blocks = valid.u32('blocks');
-    this.outputs = [];
+    if (network)
+      this.network = network;
+
+    if (valid.has('rate'))
+      this.rate = valid.u64('rate');
+
+    if (valid.has('maxFee'))
+      this.maxFee = valid.u64('maxFee');
+
+    if (valid.has('selection'))
+      this.selection = valid.str('selection');
+
+    if (valid.has('sweepdustMinValue'))
+      this.sweepdustMinValue = valid.u64('sweepdustMinValue');
+
+    if (valid.has('smart'))
+      this.smart = valid.bool('smart');
+
+    if (valid.has('account'))
+      this.account = valid.str('account');
+
+    if (valid.has('locktime'))
+      this.locktime = valid.u64('locktime');
+
+    if (valid.has('sort'))
+      this.sort = valid.bool('sort');
+
+    if (valid.has('subtractFee'))
+      this.subtractFee = valid.bool('subtractFee');
+
+    if (valid.has('subtractIndex'))
+      this.subtractIndex = valid.i32('subtractIndex');
+
+    if (valid.has('confirmations') || valid.has('depth'))
+      this.depth = valid.u32(['confirmations', 'depth']);
+
+    if (valid.has('paths'))
+      this.paths = valid.bool('paths');
+
+    if (valid.has('passphrase'))
+      this.passphrase = valid.str('passphrase');
+
+    if (valid.has('hardFee'))
+      this.hardFee = valid.u64('hardFee');
+
+    if (valid.has('blocks'))
+      this.blocks = valid.u32('blocks');
 
     if (valid.has('outputs')) {
       const outputs = valid.array('outputs');
@@ -1929,7 +1978,7 @@ class TransactionOptions {
    */
 
   static fromValidator(valid, network) {
-    return new this().fromValidator(valid, network);
+    return new this(valid, network);
   }
 }
 


### PR DESCRIPTION
This allows tx options to have different defaults.

e.g.
```
  const options = new TransactionOptions();
  options.blocks = 10;
  options.fromValidator(valid);
```

This will override options.blocks only when validator has it.