### PR TITLE
wallet: makeOpen will remove added output if output is doubleOpen.

### DIFF
--- a/lib/wallet/wallet.js
+++ b/lib/wallet/wallet.js
@@ -1770,8 +1770,10 @@ class Wallet extends EventEmitter {
 
     mtx.outputs.push(output);
 
-    if (await this.txdb.isDoubleOpen(mtx))
+    if (await this.txdb.isDoubleOpen(mtx)) {
+      mtx.outputs.pop();
       throw new Error(`Already sent an open for: ${name}.`);
+    }
 
     return mtx;
   }


### PR DESCRIPTION
If partial batching is used double open errors would still leave the outputs in mtx making OPEN txs invalid.

This ensures it is removed if check fails.