### PR TITLE
wallet: Pass worker pool to the wallet for signing.

### DIFF
--- a/lib/wallet/plugin.js
+++ b/lib/wallet/plugin.js
@@ -46,6 +46,7 @@ class Plugin extends EventEmitter {
 
     this.network = node.network;
     this.logger = node.logger;
+    this.workers = node.workers;
 
     this.client = new NodeClient(node);
 


### PR DESCRIPTION
When wallet is used as a plugin it does not properly initialize the workers pool.
This should use workers for signing transactions from now on.